### PR TITLE
Gracefully handle unsaved views

### DIFF
--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -84,7 +84,7 @@ class EasyClangComplete(sublime_plugin.EventListener):
 
         """
         log.debug(" on_activated_async view id %s", view.id())
-        if Tools.has_valid_syntax(view):
+        if Tools.is_valid_view(view):
             if completer.exists_for_view(view.id()):
                 log.debug(" view %s, already has a completer", view.id())
                 return
@@ -106,7 +106,7 @@ class EasyClangComplete(sublime_plugin.EventListener):
         Args:
             view (sublime.View): current view
         """
-        if Tools.has_valid_syntax(view):
+        if Tools.is_valid_view(view):
             (row, _) = SublBridge.cursor_pos(view)
             completer.error_vis.show_popup_if_needed(view, row)
 
@@ -118,7 +118,7 @@ class EasyClangComplete(sublime_plugin.EventListener):
             view (sublime.View): current view
         """
         log.debug(" on_modified_async view id %s", view.id())
-        if Tools.has_valid_syntax(view):
+        if Tools.is_valid_view(view):
             completer.error_vis.clear(view)
 
     @staticmethod
@@ -130,7 +130,7 @@ class EasyClangComplete(sublime_plugin.EventListener):
 
         """
         log.debug(" saving view: %s", view.id())
-        if Tools.has_valid_syntax(view):
+        if Tools.is_valid_view(view):
             completer.error_vis.erase_regions(view)
             completer.update(view, settings.errors_on_save)
 
@@ -143,7 +143,7 @@ class EasyClangComplete(sublime_plugin.EventListener):
 
         """
         log.debug(" closing view %s", view.id())
-        if Tools.has_valid_syntax(view):
+        if Tools.is_valid_view(view):
             completer.remove(view.id())
 
     @staticmethod
@@ -162,7 +162,7 @@ class EasyClangComplete(sublime_plugin.EventListener):
         if view.is_scratch():
             return None
 
-        if not Tools.has_valid_syntax(view):
+        if not Tools.is_valid_view(view):
             return None
 
         if completer.async_completions_ready:

--- a/plugin/completion/bin_complete.py
+++ b/plugin/completion/bin_complete.py
@@ -16,6 +16,7 @@ import tempfile
 from os import path
 
 from .. import error_vis
+from ..tools import Tools
 from .base_complete import BaseCompleter
 
 log = logging.getLogger(__name__)
@@ -123,6 +124,11 @@ class Completer(BaseCompleter):
             settings (Settings): plugin settings
 
         """
+
+        # Return early if this is an invalid view.
+        if not Tools.is_valid_view(view):
+            return
+
         self.flags_dict[view.id()] = None
         file_name = view.file_name()
         file_folder = path.dirname(file_name)

--- a/plugin/completion/lib_complete.py
+++ b/plugin/completion/lib_complete.py
@@ -129,6 +129,11 @@ class Completer(BaseCompleter):
             settings (Settings): plugin settings
 
         """
+
+        # Return early if this is an invalid view.
+        if not Tools.is_valid_view(view):
+            return
+
         file_name = view.file_name()
         file_body = view.substr(sublime.Region(0, view.size()))
         file_folder = path.dirname(file_name)

--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -96,6 +96,20 @@ class Tools:
         return False
 
     @staticmethod
+    def is_valid_view(view):
+        """
+        Check whether the given view is one we can and want to handle.
+
+        Args:
+            view (sublime.View): view to check
+
+        Returns:
+            bool: True if we want to handle this view, False otherwise
+        """
+
+        return Tools.has_valid_syntax(view) and view.file_name()
+
+    @staticmethod
     def has_valid_extension(view):
         """Test if the current file has a valid extension
 

--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -9,7 +9,7 @@ from unittest import TestCase
 
 sys.path.append(path.dirname(path.dirname(__file__)))
 from plugin.plugin_settings import Settings
-from plugin.completion.bin_complete import Completer
+from plugin.completion.bin_complete import Completer as CompleterBin
 from plugin.completion.lib_complete import Completer as CompleterLib
 
 def has_libclang():
@@ -20,35 +20,76 @@ def has_libclang():
             return False
         return False
 
-class test_complete_command(TestCase):
-    """Test complete commands
+class base_test_complete(object):
+    """
+    Base class for all tests that are independent of the Completer implementation.
 
     Attributes:
         view (sublime.View): view
+        Completer (type): Completer class to use
     """
     def setUp(self):
-        """Set up the file to autocomplete
+        """ Setup method run before every test. """
 
-        """
-        file_name = path.join(path.dirname(__file__), 'test.cpp')
-        self.view = sublime.active_window().open_file(file_name)
-        while self.view.is_loading():
-            time.sleep(0.1)
-        # make sure we have a window to work with
+        # Ensure we have a window to work with.
         s = sublime.load_settings("Preferences.sublime-settings")
         s.set("close_windows_when_empty", False)
 
-    def tearDown(self):
-        """close the file. Finish test.
+        self.view = None
 
-        """
+    def tearDown(self):
+        """ Cleanup method run after every test. """
+
+        # If we have a view, close it.
         if self.view:
             self.view.set_scratch(True)
             self.view.window().focus_view(self.view)
             self.view.window().run_command("close_file")
+            self.view = None
+
+    def setUpView(self, filename):
+        """
+        Utility method to set up a view for a given file.
+
+        Args:
+            filename (str): The filename to open in a new view.
+        """
+
+        # Open the view.
+        file_path = path.join(path.dirname(__file__), filename)
+        self.view = sublime.active_window().open_file(file_path)
+
+        # Ensure it's loaded.
+        while self.view.is_loading():
+            time.sleep(0.1)
+
+    def setUpCompleter(self):
+        """
+        Utility method to set up a completer for the current view.
+
+        Returns:
+            BaseCompleter: completer for the current view.
+        """
+
+        settings = Settings()
+        current_folder = path.dirname(self.view.file_name())
+        parent_folder = path.dirname(current_folder)
+        include_dirs = settings.populate_include_dirs(
+            file_current_folder=current_folder,
+            file_parent_folder=parent_folder)
+
+        clang_binary = settings.clang_binary
+        completer = self.Completer(clang_binary)
+        completer.init(
+            view=self.view,
+            includes=include_dirs,
+            settings=settings)
+
+        return completer
 
     def getRow(self, row):
-        """Get text of a particular row
+        """
+        Get text of a particular row
 
         Args:
             row (int): number of row
@@ -58,10 +99,10 @@ class test_complete_command(TestCase):
         """
         return self.view.substr(self.view.line(self.view.text_point(row, 0)))
 
-    def test_setup(self):
-        """Test that the initial setup is valid
+    def test_setup_view(self):
+        """ Test that setup view correctly sets up the view. """
+        self.setUpView('test.cpp')
 
-        """
         file_name = path.join(path.dirname(__file__), 'test.cpp')
         self.assertEqual(self.view.file_name(), file_name)
         file = open(file_name, 'r')
@@ -74,200 +115,79 @@ class test_complete_command(TestCase):
         file.close()
 
     def test_init(self):
-        """Test that completer version is properly initialized
+        """ Test that the completer is properly initialized. """
+        self.setUpView('test.cpp')
+        completer = self.setUpCompleter()
 
-        """
-        completer = Completer("clang++")
-        self.assertIsNotNone(completer.version_str)
-        print("version is: {}".format(completer.version_str))
-
-    def test_init_lib(self):
-        """Test that completer version is properly initialized
-
-        """
-        if not has_libclang():
-            # we don't check libclang on platforms that lack its support
-            return
-        completer = CompleterLib("clang++")
-        self.assertIsNotNone(completer.version_str)
-        print("version is: {}".format(completer.version_str))
-
-    def test_init_completer(self):
-        """Test that completer is properly initialized
-
-        """
-        settings = Settings()
-        current_folder = path.dirname(self.view.file_name())
-        parent_folder = path.dirname(current_folder)
-        include_dirs = settings.populate_include_dirs(
-            file_current_folder=current_folder,
-            file_parent_folder=parent_folder)
-        completer = Completer("clang++")
-        completer.init(view=self.view,
-                       includes=include_dirs,
-                       settings=settings)
         self.assertTrue(completer.exists_for_view(self.view.id()))
-
-    def test_init_completer_lib(self):
-        """Test that completer is properly initialized
-
-        """
-        if not has_libclang():
-            return
-        settings = Settings()
-        current_folder = path.dirname(self.view.file_name())
-        parent_folder = path.dirname(current_folder)
-        include_dirs = settings.populate_include_dirs(
-            file_current_folder=current_folder,
-            file_parent_folder=parent_folder)
-        completer = CompleterLib("clang++")
-        completer.init(view=self.view,
-                       includes=include_dirs,
-                       settings=settings)
-        self.assertTrue(completer.exists_for_view(self.view.id()))
+        self.assertIsNotNone(completer.version_str)
 
     def test_complete(self):
-        """Test autocompletion for user type
+        """ Test autocompletion for user type. """
+        self.setUpView('test.cpp')
 
-        """
-        file_name = path.join(path.dirname(__file__), 'test.cpp')
-        self.view = sublime.active_window().open_file(file_name)
-        while self.view.is_loading():
-            time.sleep(0.1)
-        # now the file should be ready
-        settings = Settings()
-        current_folder = path.dirname(self.view.file_name())
-        parent_folder = path.dirname(current_folder)
-        include_dirs = settings.populate_include_dirs(
-            file_current_folder=current_folder,
-            file_parent_folder=parent_folder)
-        completer = Completer("clang++")
-        completer.init(view=self.view,
-                       includes=include_dirs,
-                       settings=settings)
+        completer = self.setUpCompleter()
         self.assertTrue(completer.exists_for_view(self.view.id()))
+
+        # Check the current cursor position is completable.
         self.assertEqual(self.getRow(5), "  a.")
         pos = self.view.text_point(5, 4)
         current_word = self.view.substr(self.view.word(pos))
         self.assertEqual(current_word, ".\n")
+
+        # Load the completions.
+        settings = Settings()
         completer.complete(self.view, pos, settings.errors_on_save)
+
+        # Wait 2 seconds for them to load.
         counter = 0
         while not completer.async_completions_ready:
             time.sleep(0.1)
             counter += 1
             if counter > 20:
-                break
+                self.fail("Async completions not ready after %d tries" % counter)
+
+        # Verify that we got the expected completions back.
         self.assertIsNotNone(completer.completions)
         expected = ['a\tint a', 'a']
-        self.assertTrue(expected in completer.completions)
-
-    def test_complete_lib(self):
-        """Test autocompletion for user type
-
-        """
-        if not has_libclang():
-            return
-        file_name = path.join(path.dirname(__file__), 'test.cpp')
-        self.view = sublime.active_window().open_file(file_name)
-        while self.view.is_loading():
-            time.sleep(0.1)
-        # now the file should be ready
-        settings = Settings()
-        current_folder = path.dirname(self.view.file_name())
-        parent_folder = path.dirname(current_folder)
-        include_dirs = settings.populate_include_dirs(
-            file_current_folder=current_folder,
-            file_parent_folder=parent_folder)
-        completer = CompleterLib("clang++")
-        completer.init(view=self.view,
-                       includes=include_dirs,
-                       settings=settings)
-        self.assertTrue(completer.exists_for_view(self.view.id()))
-        self.assertEqual(self.getRow(5), "  a.")
-        pos = self.view.text_point(5, 4)
-        current_word = self.view.substr(self.view.word(pos))
-        self.assertEqual(current_word, ".\n")
-        completer.complete(self.view, pos, settings.errors_on_save)
-        counter = 0
-        while not completer.async_completions_ready:
-            time.sleep(0.1)
-            counter += 1
-            if counter > 20:
-                break
-        self.assertIsNotNone(completer.completions)
-        expected = ['a\tint a', 'a']
-        self.assertTrue(expected in completer.completions)
+        self.assertIn(expected, completer.completions)
 
     def test_complete_vector(self):
-        """Test completion for std::vector
+        """ Test that we can complete vector members. """
+        self.setUpView('test_vector.cpp')
 
-        """
-        file_name = path.join(path.dirname(__file__), 'test_vector.cpp')
-        self.view = sublime.active_window().open_file(file_name)
-        while self.view.is_loading():
-            time.sleep(0.1)
-        # now the file should be ready
-        settings = Settings()
-        current_folder = path.dirname(self.view.file_name())
-        parent_folder = path.dirname(current_folder)
-        include_dirs = settings.populate_include_dirs(
-            file_current_folder=current_folder,
-            file_parent_folder=parent_folder)
-        completer = Completer("clang++")
-        completer.init(view=self.view,
-                       includes=include_dirs,
-                       settings=settings)
+        completer = self.setUpCompleter()
         self.assertTrue(completer.exists_for_view(self.view.id()))
+
+        # Check the current cursor position is completable.
         self.assertEqual(self.getRow(3), "  vec.")
         pos = self.view.text_point(3, 6)
         current_word = self.view.substr(self.view.word(pos))
         self.assertEqual(current_word, ".\n")
+
+        # Load the completions.
+        settings = Settings()
         completer.complete(self.view, pos, settings.errors_on_save)
+
+        # Wait 2 seconds for them to load.
         counter = 0
         while not completer.async_completions_ready:
             time.sleep(0.1)
             counter += 1
             if counter > 20:
-                break
-        print(completer.completions[:10])
+                self.fail("Async completions not ready after %d tries" % counter)
+
+        # Verify that we got the expected completions back.
         self.assertIsNotNone(completer.completions)
         expected = ['begin\titerator begin()', 'begin()']
-        self.assertTrue(expected in completer.completions)
+        self.assertIn(expected, completer.completions)
 
-    def test_complete_vector_lib(self):
-        """Test completion for std::vector
+# Define the actual test class implementations.
+class test_bin_complete(base_test_complete, TestCase):
+    """ Test class for the binary based completer. """
+    Completer = CompleterBin
 
-        """
-        if not has_libclang():
-            return
-        file_name = path.join(path.dirname(__file__), 'test_vector.cpp')
-        self.view = sublime.active_window().open_file(file_name)
-        while self.view.is_loading():
-            time.sleep(0.1)
-        # now the file should be ready
-        settings = Settings()
-        current_folder = path.dirname(self.view.file_name())
-        parent_folder = path.dirname(current_folder)
-        include_dirs = settings.populate_include_dirs(
-            file_current_folder=current_folder,
-            file_parent_folder=parent_folder)
-        completer = CompleterLib("clang++")
-        completer.init(view=self.view,
-                       includes=include_dirs,
-                       settings=settings)
-        self.assertTrue(completer.exists_for_view(self.view.id()))
-        self.assertEqual(self.getRow(3), "  vec.")
-        pos = self.view.text_point(3, 6)
-        current_word = self.view.substr(self.view.word(pos))
-        self.assertEqual(current_word, ".\n")
-        completer.complete(self.view, pos, settings.errors_on_save)
-        counter = 0
-        while not completer.async_completions_ready:
-            time.sleep(0.1)
-            counter += 1
-            if counter > 20:
-                break
-        print(completer.completions[:10])
-        self.assertIsNotNone(completer.completions)
-        expected = ['begin\titerator begin()', 'begin()']
-        self.assertTrue(expected in completer.completions)
+if has_libclang():
+    class test_lib_complete(base_test_complete, TestCase):
+        """ Test class for the library based completer. """
+        Completer = CompleterLib

--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -182,6 +182,24 @@ class base_test_complete(object):
         expected = ['begin\titerator begin()', 'begin()']
         self.assertIn(expected, completer.completions)
 
+    def test_unsaved_views(self):
+        """ Test that we gracefully handle unsaved views. """
+        # Construct an unsaved scratch view.
+        self.view = sublime.active_window().new_file()
+        self.view.set_scratch(True)
+
+        # Manually set up a completer.
+        settings = Settings()
+        clang_binary = settings.clang_binary
+        completer = self.Completer(clang_binary)
+        completer.init(
+            view=self.view,
+            includes=[],
+            settings=settings)
+
+        # Verify that the completer ignores the scratch view.
+        self.assertFalse(completer.exists_for_view(self.view.id()))
+
 # Define the actual test class implementations.
 class test_bin_complete(base_test_complete, TestCase):
     """ Test class for the binary based completer. """


### PR DESCRIPTION
Opening unsaved views that had their syntax set to C++ would create quite a few errors. This PR ensures unsaved views are handled gracefully.

The first commit (https://github.com/niosus/EasyClangComplete/commit/b8377e4de0a26926a17370942a8d008c0465427c) refactors `test_complete.py` a bit in order to avoid code duplication. The way I've done it is that there's one base class which all unit tests that are independent of the completion method (lib or bin) are defined on. Then there's two classes (bin and lib, if available) that inherit from that class and inject the specific completion method to test.

The second commit just ensures that the view has a filename before handling it.