### PR TITLE
Fix version checking to be compatible with clang-cl binary (issue #70)

### DIFF
--- a/plugin/completion/base_complete.py
+++ b/plugin/completion/base_complete.py
@@ -59,25 +59,28 @@ class BaseCompleter:
             raise RuntimeError("clang binary not defined")
 
         # run the cmd to get the proper version of the installed clang
-        check_version_cmd = clang_binary + " --version"
+        check_version_cmd = clang_binary + " -v"
         log.info(" Getting version from command: `%s`", check_version_cmd)
-        output = subprocess.check_output(check_version_cmd, shell=True)
-        output_text = ''.join(map(chr, output))
+        output_text = BaseCompleter.run_command(check_version_cmd, shell=True)
 
         # now we have the output, and can extract version from it
-        version_regex = re.compile("\d.\d")
-        found = version_regex.search(output_text)
-        self.version_str = found.group()
-        if self.version_str > "3.8" and platform.system() == "Darwin":
-            # info from this table: https://gist.github.com/yamaya/2924292
-            osx_version = self.version_str
-            self.version_str = tools.OSX_CLANG_VERSION_DICT[osx_version]
-            info = {"platform": platform.system()}
-            log.warning(
-                " OSX version %s reported. Reducing it to %s. Info: %s",
-                osx_version, self.version_str, info)
-        log.info(" Found clang version: %s", self.version_str)
-        # initialize error visuzlization
+        version_regex = re.compile("\d\.\d")
+        match = version_regex.search(output_text)
+        if match:
+            self.version_str = match.group()
+            if self.version_str > "3.8" and platform.system() == "Darwin":
+                # info from this table: https://gist.github.com/yamaya/2924292
+                osx_version = self.version_str
+                self.version_str = tools.OSX_CLANG_VERSION_DICT[osx_version]
+                info = {"platform": platform.system()}
+                log.warning(
+                    " OSX version %s reported. Reducing it to %s. Info: %s",
+                    osx_version, self.version_str, info)
+            log.info(" Found clang version: %s", self.version_str)
+        else:
+            raise RuntimeError(
+                " Couldn't find clang version in clang version output.")
+        # initialize error visualization
         self.error_vis = error_vis.CompileErrors()
 
     def needs_init(self, view):
@@ -210,7 +213,7 @@ class BaseCompleter:
             'next_competion_if_showing': True, })
 
     @staticmethod
-    def run_command(command):
+    def run_command(command, shell=True):
         """ Run a generic command in a subprocess
 
         Args:
@@ -222,10 +225,10 @@ class BaseCompleter:
         try:
             output = subprocess.check_output(command,
                                              stderr=subprocess.STDOUT,
-                                             shell=True)
+                                             shell=shell)
             output_text = ''.join(map(chr, output))
         except subprocess.CalledProcessError as e:
             output_text = e.output.decode("utf-8")
-            log.info(" clang process finished with code: \n%s", e.returncode)
+            log.info(" clang process finished with code: %s", e.returncode)
             log.info(" clang process output: \n%s", output_text)
         return output_text

--- a/plugin/completion/bin_complete.py
+++ b/plugin/completion/bin_complete.py
@@ -342,8 +342,8 @@ class Completer(BaseCompleter):
             pos_search = Completer.compl_regex.search(completion)
             if not pos_search:
                 log.debug(
-                    " completion %s did not match pattern %s",
-                    completion, Completer.compl_regex)
+                    " completion '%s' did not match pattern '%s'",
+                    completion, Completer.compl_regex.pattern)
                 continue
             comp_dict = pos_search.groupdict()
             # log.debug("completions parsed: %s", comp_dict)


### PR DESCRIPTION
Clang-cl doesn't support --version argument. It does support -v though and given
that normal clang supports both, we can always use -v.

Also:
 - Use BaseCompleter.run_command instead of duplicating check_output call.
   Another advantage is added logging on error.
 - Fix regexp which was incorrectly matching any character due to not escaped
   dot character.
 - Add better error handling to version output parsing - throw if version was
   not found.
 - Fix regexp printing on completion error. Was printing Python object which
   didn't say anything. Print the pattern itself.