### PR TITLE
Introduce class for compiler-specific options (issue #71, #73)

### DIFF
--- a/plugin/completion/base_complete.py
+++ b/plugin/completion/base_complete.py
@@ -29,6 +29,7 @@ class BaseCompleter:
         async_completions_ready (bool): is true after async completions ready
         completions (list): current list of completions
         error_vis (plugin.CompileErrors): object of compile errors class
+        compiler_variant (CompilerVariant): compiler specific options
         flags_manager (FlagsManager): An object that manages all the flags and
             how to load them from disk to memory.
         valid (bool): is completer valid
@@ -36,6 +37,7 @@ class BaseCompleter:
     """
     version_str = None
     error_vis = None
+    compiler_variant = None
 
     flags_manager = None
 
@@ -179,6 +181,17 @@ class BaseCompleter:
             NotImplementedError: Guarantees we do not call this abstract method
         """
         raise NotImplementedError("calling abstract method")
+
+    def show_errors(self, view, output):
+        """ Show current complie errors
+
+        Args:
+            view (sublime.View): Current view
+            output (object): opaque output to be parsed by compiler variant
+        """
+        errors = self.compiler_variant.errors_from_output(output)
+        self.error_vis.generate(view, errors)
+        self.error_vis.show_regions(view)
 
     def get_completions(self, hide_default_completions):
         """ Get completions. Manage hiding default ones.

--- a/plugin/completion/compiler_variant.py
+++ b/plugin/completion/compiler_variant.py
@@ -1,0 +1,114 @@
+"""Module contains options for various compiler variants
+
+Attributes:
+    log (logging.Logger): logger for this module
+"""
+import re
+import logging
+
+log = logging.getLogger(__name__)
+log.debug(" reloading module")
+
+
+class CompilerVariant(object):
+    """
+    Encapsulation of a compiler specific options
+    """
+
+    def errors_from_output(self, output):
+        """
+        Parse errors received from the compiler.
+
+        Args:
+            output (object): opaque output to be parsed by compiler variant
+
+        Raises:
+            NotImplementedError: Guarantees we do not call this abstract method
+        """
+        raise NotImplementedError("calling abstract method")
+
+
+class ClangCompilerVariant(CompilerVariant):
+    """
+    Encapsulation of clang/clang++ specific options
+
+    Attributes:
+        init_flags (list): flags that every command needs
+        error_regex (re): regex to find contents of an error
+    """
+    init_flags = ["-c", "-fsyntax-only", "-x c++"]
+    error_regex = re.compile("(?P<file>.*)" +
+                             ":(?P<row>\d+):(?P<col>\d+)" +
+                             ":\s*.*error: (?P<error>.*)")
+
+    def errors_from_output(self, output):
+        """
+        Parse errors received from clang binary output
+
+        Args:
+            view (sublime.View): current view
+            clang_output (string): list of unparsed errors
+
+        Returns:
+            list(dict): a list of parsed errors
+        """
+        errors = []
+        for line in output.splitlines():
+            error_search = self.error_regex.search(line)
+            if not error_search:
+                continue
+            error_dict = error_search.groupdict()
+            errors.append(error_dict)
+        return errors
+
+
+class ClangClCompilerVariant(ClangCompilerVariant):
+    """
+    Encapsulation of clang-cl specific options
+
+    Attributes:
+        init_flags (list): flags that every command needs
+        error_regex (re): regex to find contents of an error
+    """
+    init_flags = ["-c", "-fsyntax-only"]
+    error_regex = re.compile("(?P<file>.*)" +
+                             "\((?P<row>\d+),(?P<col>\d+)\)\s*" +
+                             ":\s*.*error: (?P<error>.*)")
+
+
+class LibClangCompilerVariant(CompilerVariant):
+    """
+    Encapsulation of libclang specific options
+
+    Attributes:
+        pos_regex (re): regex to find position of an error
+        msg_regex (re): regex to find error message
+    """
+    pos_regex = re.compile("'(?P<file>.+)'.*" +  # file
+                           "line\s(?P<row>\d+), " +  # row
+                           "column\s(?P<col>\d+)")  # col
+    msg_regex = re.compile("b\"(?P<error>.+)\"")
+
+    def errors_from_output(self, output):
+        """Parse errors received from diagnostics of a translation unit (used
+        with libclang)
+
+        Args:
+            output (diagnostics): diagnostics from a translation unit
+
+        Returns:
+            list(dict): a list of parsed errors
+        """
+        errors = []
+        for diag in output:
+            location = str(diag.location)
+            spelling = str(diag.spelling)
+            pos_search = self.pos_regex.search(location)
+            msg_search = self.msg_regex.search(spelling)
+            if not pos_search or not msg_search:
+                # not valid, continue
+                continue
+            error_dict = pos_search.groupdict()
+            error_dict.update(msg_search.groupdict())
+            errors.append(error_dict)
+        return errors


### PR DESCRIPTION
Added a small CompilerVariant class that provides compiler-specific
options (currently separate ones for clang, clang-cl, libclang).

This makes it easier to vary behavior for clang/clang-cl. Both produce
slightly different formatting for errors and have support for
different flags.