### PR TITLE
Re-initialize plugin and completers on settings change

### DIFF
--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -59,6 +59,7 @@ class EasyClangComplete(sublime_plugin.EventListener):
     completer = None
 
     def __init__(self):
+        """Initializes the object."""
         super().__init__()
         global handle_plugin_loaded_function
         handle_plugin_loaded_function = lambda: self.on_plugin_loaded()
@@ -67,6 +68,7 @@ class EasyClangComplete(sublime_plugin.EventListener):
         logging.basicConfig(level=logging.DEBUG)
 
     def on_plugin_loaded(self):
+        """Called upon plugin load event."""
         self.settings = plugin_settings.Settings()
         self.on_settings_changed()
         self.settings.add_change_listener(lambda: self.on_settings_changed())
@@ -76,6 +78,7 @@ class EasyClangComplete(sublime_plugin.EventListener):
         self.on_activated_async(sublime.active_window().active_view())
 
     def on_settings_changed(self):
+        """Called when any of the settings changes."""
         # If verbose flag is set then respect default DEBUG level.
         # Otherwise disable level DEBUG and allow INFO and higher levels.
         off_level = logging.NOTSET if self.settings.verbose else logging.DEBUG

--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -62,7 +62,7 @@ class EasyClangComplete(sublime_plugin.EventListener):
         """Initializes the object."""
         super().__init__()
         global handle_plugin_loaded_function
-        handle_plugin_loaded_function = lambda: self.on_plugin_loaded()
+        handle_plugin_loaded_function = self.on_plugin_loaded
         # By default be verbose and limit on settings change if verbose flag is
         # not set.
         logging.basicConfig(level=logging.DEBUG)
@@ -71,7 +71,7 @@ class EasyClangComplete(sublime_plugin.EventListener):
         """Called upon plugin load event."""
         self.settings = plugin_settings.Settings()
         self.on_settings_changed()
-        self.settings.add_change_listener(lambda: self.on_settings_changed())
+        self.settings.add_change_listener(self.on_settings_changed)
         # As the plugin have just loaded, we might have missed an activation
         # event for the active view so completion will not work for it until
         # re-activated. Force active view initialization in that case.

--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -167,23 +167,30 @@ class EasyClangComplete(sublime_plugin.EventListener):
             sublime.Completions: completions with a flag
         """
         log.debug(" on_query_completions view id %s", view.buffer_id())
+        log.debug(" prefix: %s, locations: %s" % (prefix, locations))
 
         if not Tools.is_valid_view(view):
+            log.debug(" not a valid view")
             return Tools.SHOW_DEFAULT_COMPLETIONS
 
         if not completer:
+            log.debug(" no completer")
             return Tools.SHOW_DEFAULT_COMPLETIONS
 
         if completer.async_completions_ready:
             completer.async_completions_ready = False
+            log.debug(" returning existing completions")
             return completer.get_completions(settings.hide_default_completions)
 
         # Verify that character under the cursor is one allowed trigger
         pos_status = Tools.get_position_status(locations[0], view, settings)
         if pos_status == PosStatus.WRONG_TRIGGER:
             # we are at a wrong trigger, remove all completions from the list
+            log.debug(" wrong trigger")
+            log.debug(" hiding default completions")
             return Tools.HIDE_DEFAULT_COMPLETIONS
         if pos_status == PosStatus.COMPLETION_NOT_NEEDED:
+            log.debug(" completion not needed")
             # show default completions for now if allowed
             if settings.hide_default_completions:
                 log.debug(" hiding default completions")

--- a/plugin/completion/flags_manager.py
+++ b/plugin/completion/flags_manager.py
@@ -225,7 +225,7 @@ class FlagsManager:
             # can set them here from the settings.
             my_env = os.environ.copy()
             my_env['CMAKE_PREFIX_PATH'] = ":".join(prefix_paths)
-            log.info(' runnign command: %s', cmake_cmd)
+            log.info(' running command: %s', cmake_cmd)
             output = subprocess.check_output(cmake_cmd,
                                              stderr=subprocess.STDOUT,
                                              shell=True,
@@ -234,7 +234,7 @@ class FlagsManager:
             output_text = ''.join(map(chr, output))
         except subprocess.CalledProcessError as e:
             output_text = e.output.decode("utf-8")
-            log.info(" clang process finished with code: \n%s", e.returncode)
+            log.info(" cmake process finished with code: %s", e.returncode)
         log.info(" cmake produced output: \n%s", output_text)
 
         database_path = path.join(tempdir, FlagsManager.CMAKE_DB_FILE_NAME)

--- a/plugin/plugin_settings.py
+++ b/plugin/plugin_settings.py
@@ -64,6 +64,8 @@ class Settings:
 
     CMAKE_PRIORITIES = ["ask", "merge", "overwrite", "keep_old"]
 
+    __change_listeners = []
+
     def __init__(self):
         """Initialize the class.
         """
@@ -73,10 +75,17 @@ class Settings:
             log.critical(" NO AUTOCOMPLETE WILL BE AVAILABLE")
             return
 
+    def add_change_listener(self, listener):
+        if listener in self.__change_listeners:
+            log.error(' this settings listener was already added before')
+        self.__change_listeners.append(listener)
+
     def on_settings_changed(self):
         """When user changes settings, trigger this.
         """
         self.load_settings()
+        for listener in self.__change_listeners:
+            listener()
         log.info(" settings changed and reloaded")
 
     def load_settings(self):

--- a/plugin/plugin_settings.py
+++ b/plugin/plugin_settings.py
@@ -76,6 +76,11 @@ class Settings:
             return
 
     def add_change_listener(self, listener):
+        """Registers given listener to be notified whenever settings change.
+
+        Args:
+            listener (function): function to call on settings change
+        """
         if listener in self.__change_listeners:
             log.error(' this settings listener was already added before')
         self.__change_listeners.append(listener)

--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -228,12 +228,12 @@ class Tools:
     """just a bunch of helpful tools to unclutter main file
 
     Attributes:
-        HIDE_DEFAULT_COMPLETIONS: a valud to return from `on_query_completions`
+        HIDE_DEFAULT_COMPLETIONS: a value to return from `on_query_completions`
             Ensures nothing will be shown apart from the output of this plugin
         SHOW_DEFAULT_COMPLETIONS: `None` to return from `on_query_completions`.
             This guarantees that sublime text will show default completions.
         syntax_regex (regex): regex to parse syntax setting
-        valid_extensions (list): list of valid extentions for autocompletion
+        valid_extensions (list): list of valid extensions for auto-completion
         valid_syntax (list): list of valid syntaxes for this plugin
 
     """
@@ -285,7 +285,7 @@ class Tools:
         if syntax in Tools.valid_syntax:
             log.debug(" file has valid syntax: `%s`", syntax)
             return True
-        log.debug(" file has unsopported syntax: `%s`", syntax)
+        log.debug(" file has unsupported syntax: `%s`", syntax)
         return False
 
     @staticmethod


### PR DESCRIPTION
Previously changing settings required restart of Sublime which was
rather annoying when testing. Now changes are applied instantly.

Made settings and completer be members of the EasyClangComplete class
as that seems a bit cleaner to me (although one global is still
necessary) and also had to add settings listener which makes sense to
handle in the same class.

Changes Sublime listeners to not be @staticmethods as they need to
access class members settings and completer now. There is IMO no
point in them being static methods anyway as class is only
instantiated once.