### PR TITLE
error_vis: Fix popup getting newline after evey word

### DIFF
--- a/plugin/error_vis.py
+++ b/plugin/error_vis.py
@@ -141,7 +141,9 @@ class CompileErrors:
         errors_html = ""
         for entry in errors_dict:
             errors_html += "<p><tt>" + entry['error'] + "</tt></p>"
-        return errors_html
+        # Add non-breaking space to prevent popup from getting a newline
+        # after every word
+        return errors_html.replace(' ', '&nbsp;')
 
     @staticmethod
     def _as_region_list(err_regions_dict):


### PR DESCRIPTION
I'm on Archlinux x86-64 with nightly builds, not sure if this happens on other OSes/configs.

Without a non-breaking space, error popups wrap at every word making them unreadable. This PR replaces `' '` chars with `&nbsp;` to ensure that the whole error message remains on one line (unless a newline is inserted).