### PR TITLE
shiny new async completions

### DIFF
--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -207,8 +207,8 @@ class EasyClangComplete(sublime_plugin.EventListener):
         log.debug(" on_query_completions view id %s", view.buffer_id())
         log.debug(" prefix: %s, locations: %s" % (prefix, locations))
         trigger_pos = locations[0] - len(prefix)
-        current_pos_id = Tools.get_position_hash(view, trigger_pos)
-        log.debug(" this position has hash: '%s'", current_pos_id)
+        current_pos_id = Tools.get_position_identifier(view, trigger_pos)
+        log.debug(" this position has identifier: '%s'", current_pos_id)
 
         if not self.completer:
             log.debug(" no completer")

--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -183,8 +183,11 @@ class EasyClangComplete(sublime_plugin.EventListener):
             (job_id, completions) = future.result()
             if job_id == self.current_job_id:
                 self.current_completions = completions
-                SublBridge.show_auto_complete(
-                    sublime.active_window().active_view())
+                if self.current_completions:
+                    # we only want to trigger the autocompletion popup if there
+                    # are new completions to show there. Otherwise let it be.
+                    SublBridge.show_auto_complete(
+                        sublime.active_window().active_view())
 
     def on_query_completions(self, view, prefix, locations):
         """ Function that is called when user queries completions in the code

--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -132,7 +132,7 @@ class EasyClangComplete(sublime_plugin.EventListener):
             self.completer.error_vis.show_popup_if_needed(view, row)
 
     def on_modified_async(self, view):
-        """Called in a worker thread when view is modified
+        """ Called in a worker thread when view is modified
 
         Args:
             view (sublime.View): current view
@@ -144,7 +144,7 @@ class EasyClangComplete(sublime_plugin.EventListener):
             self.completer.error_vis.clear(view)
 
     def on_post_save_async(self, view):
-        """On save. Executed in a worker thread.
+        """ On save. Executed in a worker thread.
 
         Args:
             view (sublime.View): current view
@@ -171,6 +171,13 @@ class EasyClangComplete(sublime_plugin.EventListener):
             self.completer.remove(view.buffer_id())
 
     def completion_finished(self, future):
+        """ Callback called when completion async function has returned. Checks
+        if job id equals the one that is expected now and updates the
+        completion list that is going to be used in on_query_completions
+
+        Args:
+            future (concurrent.Future): future holding completion result
+        """
         if future.done():
             (job_id, completions) = future.result()
             if job_id == self.current_job_id:
@@ -178,15 +185,8 @@ class EasyClangComplete(sublime_plugin.EventListener):
                 EasyClangComplete.show_auto_complete(
                     sublime.active_window().active_view())
 
-    def show_auto_complete(view):
-        view.run_command('hide_auto_complete')
-        view.run_command('auto_complete', {
-            'disable_auto_insert': True,
-            'api_completions_only': False,
-            'next_competion_if_showing': False})
-
     def on_query_completions(self, view, prefix, locations):
-        """Function that is called when user queries completions in the code
+        """ Function that is called when user queries completions in the code
 
         Args:
             view (sublime.View): current view

--- a/plugin/completion/base_complete.py
+++ b/plugin/completion/base_complete.py
@@ -25,7 +25,6 @@ class BaseCompleter:
     """A base class for clang based completions
 
     Attributes:
-        async_completions_ready (bool): is true after async completions ready
         completions (list): current list of completions
         error_vis (plugin.CompileErrors): object of compile errors class
         compiler_variant (CompilerVariant): compiler specific options
@@ -40,9 +39,6 @@ class BaseCompleter:
 
     flags_manager = None
 
-    completions = []
-
-    async_completions_ready = False
     valid = False
 
     def __init__(self, clang_binary):
@@ -141,7 +137,7 @@ class BaseCompleter:
         Args:
             view (sublime.View): current view
             cursor_pos (int): sublime provided poistion of the cursor
-            show_errors (bool): true if we want to visualize errors
+            current_job_id (str): identifier for this completion job
 
         Raises:
             NotImplementedError: Guarantees we do not call this abstract method

--- a/plugin/completion/base_complete.py
+++ b/plugin/completion/base_complete.py
@@ -135,7 +135,7 @@ class BaseCompleter:
             cmake_prefix_paths=settings.cmake_prefix_paths,
             search_scope=search_scope)
 
-    def complete(self, view, cursor_pos, show_errors):
+    def complete(self, view, cursor_pos, current_job_id):
         """Function to generate completions. See children for implementation.
 
         Args:

--- a/plugin/completion/base_complete.py
+++ b/plugin/completion/base_complete.py
@@ -171,35 +171,3 @@ class BaseCompleter:
         errors = self.compiler_variant.errors_from_output(output)
         self.error_vis.generate(view, errors)
         self.error_vis.show_regions(view)
-
-    def get_completions(self, hide_default_completions):
-        """ Get completions. Manage hiding default ones.
-
-        Args:
-            hide_default_completions (bool): True if we hide default ones
-
-        Returns:
-            tupple: (completions, flags)
-        """
-        if hide_default_completions:
-            log.debug(" hiding default completions")
-            return (self.completions, tools.SublBridge.NO_DEFAULT_COMPLETIONS)
-        else:
-            log.debug(" adding clang completions to default ones")
-            return self.completions
-
-    @staticmethod
-    def _reload_completions(view):
-        """Ask sublime to reload the completions. Needed to update the active
-        completion list when async autocompletion task has finished.
-
-        Args:
-            view (sublime.View): current_view
-
-        """
-        log.debug(" reload completion tooltip")
-        view.run_command('hide_auto_complete')
-        view.run_command('auto_complete', {
-            'disable_auto_insert': True,
-            'api_completions_only': True,
-            'next_competion_if_showing': True, })

--- a/plugin/completion/bin_complete.py
+++ b/plugin/completion/bin_complete.py
@@ -35,9 +35,6 @@ class Completer(BaseCompleter):
         std_flag (TYPE): std flag, e.g. "std=c++11"
 
         completions (list): current completions
-        async_completions_ready (bool): turns true if there are completions
-                                    that have become ready from an async call
-
         compl_regex (regex): regex to parse raw completion for name and content
         compl_content_regex (regex): regex to parse the content of the
         completion opts_regex (regex): regex to detect optional parameters
@@ -171,14 +168,7 @@ class Completer(BaseCompleter):
     def complete(self, view, cursor_pos, current_job_id):
         """ This function is called asynchronously to create a list of
         autocompletions. It builds up a clang command that is then executed
-        as a subprocess. The output is parsed for completions and/or errors
-
-        Args:
-            view (sublime.View): current view
-            cursor_pos (int): sublime provided poistion of the cursor
-            show_errors (bool): true if we want to visualize errors
-
-        """
+        as a subprocess. The output is parsed for completions """
         if not view.buffer_id() in self.flags_dict:
             log.error(" cannot complete view: %s", view.buffer_id())
             return None
@@ -189,9 +179,9 @@ class Completer(BaseCompleter):
         end = time.time()
         log.debug(" code complete done in %s seconds", end - start)
 
-        self.completions = Completer._parse_completions(raw_complete)
-        log.debug(' completions: %s' % self.completions)
-        return (current_job_id, self.completions)
+        completions = Completer._parse_completions(raw_complete)
+        log.debug(' completions: %s' % completions)
+        return (current_job_id, completions)
 
     def update(self, view, show_errors):
         """update build for current view

--- a/plugin/completion/bin_complete.py
+++ b/plugin/completion/bin_complete.py
@@ -168,7 +168,7 @@ class Completer(BaseCompleter):
         self.flags_dict[view.buffer_id()] = clang_flags
         log.debug(" clang flags are: %s", self.flags_dict[view.buffer_id()])
 
-    def complete(self, view, cursor_pos, show_errors):
+    def complete(self, view, cursor_pos, current_job_id):
         """ This function is called asynchronously to create a list of
         autocompletions. It builds up a clang command that is then executed
         as a subprocess. The output is parsed for completions and/or errors
@@ -191,14 +191,7 @@ class Completer(BaseCompleter):
 
         self.completions = Completer._parse_completions(raw_complete)
         log.debug(' completions: %s' % self.completions)
-        self.async_completions_ready = True
-        if len(self.completions) > 0:
-            Completer._reload_completions(view)
-        else:
-            log.debug(" no completions")
-
-        if show_errors:
-            self.show_errors(view, output_text)
+        return (current_job_id, self.completions)
 
     def update(self, view, show_errors):
         """update build for current view

--- a/plugin/completion/flags_manager.py
+++ b/plugin/completion/flags_manager.py
@@ -213,8 +213,7 @@ class FlagsManager:
         import shutil
         import hashlib
         cmake_cmd = FlagsManager.cmake_mask.format(path=cmake_file.folder())
-        unique_proj_str = hashlib.md5(
-            cmake_file.full_path().encode('utf-8')).hexdigest()
+        unique_proj_str = Tools.get_unique_str(cmake_file.full_path())
         tempdir = path.join(
             Tools.get_temp_dir(), 'cmake_builds', unique_proj_str)
         # ensure a clean build

--- a/plugin/completion/lib_complete.py
+++ b/plugin/completion/lib_complete.py
@@ -216,13 +216,9 @@ class Completer(BaseCompleter):
     def complete(self, view, cursor_pos, current_job_id):
         """ This function is called asynchronously to create a list of
         autocompletions. Using the current translation unit it queries libclang
-        for the possible completions. It also shows compile errors if needed.
+        for the possible completions.
 
-        Args:
-            view (sublime.View): current view
-            cursor_pos (int): sublime provided poistion of the cursor
         """
-        print(" in complete function")
         file_body = view.substr(sublime.Region(0, view.size()))
         (row, col) = SublBridge.cursor_pos(view, cursor_pos)
 
@@ -247,11 +243,11 @@ class Completer(BaseCompleter):
             log.debug(" code complete done in %s seconds", end - start)
 
         if complete_obj is None or len(complete_obj.results) == 0:
-            self.completions = []
+            completions = []
         else:
-            self.completions = Completer._parse_completions(complete_obj)
-        log.debug(' completions: %s' % self.completions)
-        return (current_job_id, self.completions)
+            completions = Completer._parse_completions(complete_obj)
+        log.debug(' completions: %s' % completions)
+        return (current_job_id, completions)
 
     def update(self, view, show_errors):
         """Reparse the translation unit. This speeds up completions

--- a/plugin/plugin_settings.py
+++ b/plugin/plugin_settings.py
@@ -114,27 +114,30 @@ class Settings:
         log.debug(" Overriding settings by project ones if needed:")
         log.debug(" Valid prefixes: %s", Settings.PREFIXES)
         settings_handle = sublime.active_window().active_view().settings()
-        self.__load_vars_from_settings(settings_handle, Settings.PREFIXES)
+        self.__load_vars_from_settings(settings_handle, project_specific=True)
         log.debug(" All overrides applied.")
 
-    def __load_vars_from_settings(self, settings_handle, prefixes=None):
+    def __load_vars_from_settings(self, settings, project_specific=False):
         """
         Load all settings and add them as attributes of self
 
         Args:
-            settings_handle (dict): settings from sublime
+            settings (dict): settings from sublime
             prefixes (list, optional): package-specific prefixes to
                 disambiguate settings when loading them from project settings
 
         """
         log.debug(" Reading settings...")
-        if not prefixes:
+        # project settings are all prefixed to disambiguate them from others
+        if project_specific:
+            prefixes = Settings.PREFIXES
+        else:
             prefixes = [""]
         for setting_name in Settings.NAMES_ENUM:
             if setting_name.startswith('__') or callable(setting_name):
                 continue
             for prefix in prefixes:
-                val = settings_handle.get(prefix + setting_name)
+                val = settings.get(prefix + setting_name)
                 if val is not None:
                     # we don't want to override existing setting
                     break

--- a/plugin/plugin_settings.py
+++ b/plugin/plugin_settings.py
@@ -117,7 +117,7 @@ class Settings:
         self.__load_vars_from_settings(settings_handle, Settings.PREFIXES)
         log.debug(" All overrides applied.")
 
-    def __load_vars_from_settings(self, settings_handle, prefixes=[""]):
+    def __load_vars_from_settings(self, settings_handle, prefixes=None):
         """
         Load all settings and add them as attributes of self
 
@@ -128,6 +128,8 @@ class Settings:
 
         """
         log.debug(" Reading settings...")
+        if not prefixes:
+            prefixes = [""]
         for setting_name in Settings.NAMES_ENUM:
             if setting_name.startswith('__') or callable(setting_name):
                 continue

--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -490,8 +490,6 @@ class Tools:
         return hashlib.md5(init_string.encode('utf-8')).hexdigest()
 
     @staticmethod
-    def get_position_hash(view, position_in_file):
-        """ Generate md5 unique sting hash from position in the file """
-        unique_id = Tools.get_unique_str(
-            view.file_name() + str(position_in_file))
-        return unique_id
+    def get_position_identifier(view, position_in_file):
+        """ Generate unique tuple for file and position in the file """
+        return (view.buffer_id(), position_in_file)

--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -94,6 +94,23 @@ class SublBridge:
         line = view.line(point_on_next_line)
         return view.substr(line)
 
+    @staticmethod
+    def format_completions(completions, hide_default_completions):
+        """ Get completions. Manage hiding default ones.
+
+        Args:
+            hide_default_completions (bool): True if we hide default ones
+
+        Returns:
+            tupple: (completions, flags)
+        """
+        if hide_default_completions:
+            log.debug(" hiding default completions")
+            return (completions, SublBridge.NO_DEFAULT_COMPLETIONS)
+        else:
+            log.debug(" adding clang completions to default ones")
+            return completions
+
 
 class PosStatus:
 
@@ -342,7 +359,7 @@ class Tools:
         return int(h) * 3600 + int(m) * 60 + int(s)
 
     @staticmethod
-    def get_position_status(point, view, settings):
+    def get_pos_status(point, view, settings):
         """Check if the cursor focuses a valid trigger
 
         Args:
@@ -452,3 +469,14 @@ class Tools:
         else:
             raise RuntimeError(
                 " Couldn't find clang version in clang version output.")
+
+    @staticmethod
+    def get_unique_str(init_string):
+        import hashlib
+        return hashlib.md5(init_string.encode('utf-8')).hexdigest()
+
+    @staticmethod
+    def get_position_hash(view, position_in_file):
+        unique_id = Tools.get_unique_str(
+            view.file_name() + str(position_in_file))
+        return unique_id

--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -111,10 +111,23 @@ class SublBridge:
             log.debug(" adding clang completions to default ones")
             return completions
 
+    @staticmethod
+    def show_auto_complete(view):
+        """ Calling this function reopens completion popup,
+        subsequently calling EasyClangComplete.on_query_completions(...)
+        Args:
+            view (sublime.View): view to open completion window in
+        """
+        log.debug(" reload completion tooltip")
+        view.run_command('hide_auto_complete')
+        view.run_command('auto_complete', {
+            'disable_auto_insert': True,
+            'api_completions_only': False,
+            'next_competion_if_showing': False})
+
 
 class PosStatus:
-
-    """Enum class for position status
+    """ Enum class for position status
 
     Attributes:
         COMPLETION_NEEDED (int): completion needed
@@ -472,11 +485,13 @@ class Tools:
 
     @staticmethod
     def get_unique_str(init_string):
+        """ Generate md5 unique sting hash given init_string """
         import hashlib
         return hashlib.md5(init_string.encode('utf-8')).hexdigest()
 
     @staticmethod
     def get_position_hash(view, position_in_file):
+        """ Generate md5 unique sting hash from position in the file """
         unique_id = Tools.get_unique_str(
             view.file_name() + str(position_in_file))
         return unique_id

--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -143,20 +143,12 @@ class base_test_complete(object):
 
         # Load the completions.
         settings = Settings()
-        completer.complete(self.view, pos, settings.errors_on_save)
-
-        # Wait 2 seconds for them to load.
-        counter = 0
-        while not completer.async_completions_ready:
-            time.sleep(0.1)
-            counter += 1
-            if counter > 20:
-                self.fail("Completions not ready after %d tries" % counter)
+        (_, completions) = completer.complete(self.view, pos, "¯\_(ツ)_/¯")
 
         # Verify that we got the expected completions back.
-        self.assertIsNotNone(completer.completions)
+        self.assertIsNotNone(completions)
         expected = ['a\tint a', 'a']
-        self.assertIn(expected, completer.completions)
+        self.assertIn(expected, completions)
 
     def test_complete_vector(self):
         """ Test that we can complete vector members. """
@@ -173,18 +165,10 @@ class base_test_complete(object):
 
         # Load the completions.
         settings = Settings()
-        completer.complete(self.view, pos, settings.errors_on_save)
-
-        # Wait 2 seconds for them to load.
-        counter = 0
-        while not completer.async_completions_ready:
-            time.sleep(0.1)
-            counter += 1
-            if counter > 20:
-                self.fail("Completions not ready after %d tries" % counter)
+        (_, completions) = completer.complete(self.view, pos, "¯\_(ツ)_/¯")
 
         # Verify that we got the expected completions back.
-        self.assertIsNotNone(completer.completions)
+        self.assertIsNotNone(completions)
         if platform.system() == "Windows":
             # disable the windows tests for now until AppVeyor fixes things
             return
@@ -226,72 +210,6 @@ class base_test_complete(object):
         # Trigger default completions popup.
         self.view.run_command('auto_complete')
         self.assertTrue(self.view.is_auto_complete_visible())
-
-        # Load the completions.
-        settings = Settings()
-        completer.complete(self.view, pos, settings.errors_on_save)
-
-        # Wait 2 seconds for them to load.
-        counter = 0
-        while not completer.async_completions_ready:
-            time.sleep(0.1)
-            counter += 1
-            if counter > 20:
-                self.fail("Completions not ready after %d tries" % counter)
-
-        # Verify that we got the expected completions back.
-        self.assertEqual([], completer.completions)
-        # And that popup with default completions is still open.
-        self.assertTrue(self.view.is_auto_complete_visible())
-
-    def test_no_completions_with_error_markers(self):
-        """ Test that empty completions still produce error marks. """
-        self.setUpView("test_errors.cpp")
-
-        completer = self.setUpCompleter()
-        self.assertTrue(completer.exists_for_view(self.view.buffer_id()))
-
-        # Undefined foo object has no completions.
-        self.assertEqual(self.getRow(1), "  foo.")
-        pos = self.view.text_point(1, 6)
-        current_word = self.view.substr(self.view.word(pos))
-        self.assertEqual(current_word, ".\n")
-
-        # Load the completions.
-        settings = Settings()
-        completer.complete(self.view, pos, settings.errors_on_save)
-
-        # Wait 2 seconds for them to load.
-        counter = 0
-        while not completer.async_completions_ready:
-            time.sleep(0.1)
-            counter += 1
-            if counter > 20:
-                self.fail("Completions not ready after %d tries" % counter)
-
-        # Verify that we got the expected completions back.
-        self.assertEqual([], completer.completions)
-
-        # Verify that error regions were added.
-        error_vis = completer.error_vis
-        self.assertIsNotNone(error_vis)
-        regions_dict = error_vis.err_regions[self.view.buffer_id()]
-        self.assertIsNotNone(regions_dict)
-        # Verify the number of rows with error regions.
-        self.assertTrue(len(regions_dict.keys()) > 0)
-        # Verify the region row.
-        expected_row = 2
-        self.assertIn(expected_row, regions_dict)
-        # Verify that correct amount of regions were created.
-        expected_regions_count = 1
-        self.assertEqual(expected_regions_count,
-                         len(regions_dict[expected_row]))
-        # Verify the column, row and region extent.
-        error_region = regions_dict[expected_row][0]
-        self.assertEqual('3', error_region['col'])
-        self.assertEqual('2', error_region['row'])
-        self.assertEqual(43, error_region['region'].a)
-        self.assertEqual(46, error_region['region'].b)
 
     def test_cmake_generate(self):
         """

--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -173,7 +173,7 @@ class base_test_complete(object):
             # disable the windows tests for now until AppVeyor fixes things
             return
         expected = ['begin\titerator begin()', 'begin()']
-        self.assertIn(expected, completer.completions)
+        self.assertIn(expected, completions)
 
     def test_unsaved_views(self):
         """ Test that we gracefully handle unsaved views. """

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -137,7 +137,7 @@ class test_tools_command(TestCase):
         current_word = self.view.substr(self.view.word(pos))
         self.assertEqual(current_word, "> ")
 
-        status = Tools.get_position_status(pos, self.view, settings)
+        status = Tools.get_pos_status(pos, self.view, settings)
 
         # Verify that we got the expected completions back.
         self.assertEqual(status, PosStatus.WRONG_TRIGGER)
@@ -147,7 +147,7 @@ class test_tools_command(TestCase):
         current_word = self.view.substr(self.view.word(pos))
         self.assertEqual(current_word, " >")
 
-        status = Tools.get_position_status(pos, self.view, settings)
+        status = Tools.get_pos_status(pos, self.view, settings)
 
         # Verify that we got the expected completions back.
         self.assertEqual(status, PosStatus.COMPLETION_NOT_NEEDED)
@@ -157,7 +157,7 @@ class test_tools_command(TestCase):
         current_word = self.view.substr(self.view.word(pos))
         self.assertEqual(current_word, ".\n")
 
-        status = Tools.get_position_status(pos, self.view, settings)
+        status = Tools.get_pos_status(pos, self.view, settings)
 
         # Verify that we got the expected completions back.
         self.assertEqual(status, PosStatus.WRONG_TRIGGER)


### PR DESCRIPTION
- no thread, using concurrent.futures instead
- completions can be queried in multiple threads as the access is read-only
- each completion relevance is decided based on the job_id hash. This hash is produced by hashlib.md5 of current view file name + position of trigger that started completion
- [regression] dropped showing errors on autocompletion. They will only be shown on save for now.
- some minor refactorings

I will open a pull request, that I will update with more commits if necessary. I want to finish this this weekend. Feel free to give it a try and comment.
Should fix issues: #62 #81 #99 #105  