### PR TITLE
paramters: str -> list(str)

### DIFF
--- a/.clang_complete
+++ b/.clang_complete
@@ -1,3 +1,4 @@
 -I/home/igor/.config/sublime-text-3/Packages/EasyClangComplete/src blah
 -I/home/igor/.config/sublime-text-3/Packages/EasyClangComplete
 -I/usr/include/opencv
+-std=c++11

--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -118,7 +118,7 @@ class EasyClangComplete(sublime_plugin.EventListener):
             if not self.completer.needs_init(view):
                 return
             log.debug("init completer for view id: %s", view.buffer_id())
-            self.completer.init(view, self.settings)
+            self.completer.init_for_view(view, self.settings)
 
     def on_selection_modified(self, view):
         """Called when selection is modified. Executed in gui thread.

--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -1,21 +1,20 @@
 {
-	// Where should clang search for headers
-	// These will be appended to build with `-I` flag each
-	// "$project_base_path" will be replaced with opened project path
-	// "$project_name" will be replaced with opened project name
-	// "$clang_version" will be replaced with numerical version str, e.g. 3.8.0
-	"include_dirs" : [
-		"/usr/include",
-		"$project_base_path/src",
-		"/workspace/$project_name/src",
-		"/usr/lib/clang/$clang_version/include" // example for Ubuntu 16.04
-		],
+	// TODO: add comments for these!
+	"common_flags" : [
+		// some example includes
+		"-I/usr/include",
+		"-I$project_base_path/src",
+		"-I/workspace/$project_name/src",
+		"-I/usr/lib/clang/$clang_version/include"
+	],
 
-	// set the default c standard library flag.
-	"std_flag_c" : "-std=c11",
+	"c_flags" : [
+		"-std=c11"
+	],
 
-	// set the default c++ standard library flag.
-	"std_flag_cpp" : "-std=c++11",
+	"cpp_flags" : [
+		"-std=c++11"
+	],
 
 	// search for .clang_complete file up the tree. Use includes from it if found
 	"search_clang_complete_file": true,

--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -1,22 +1,26 @@
 {
-	// TODO: add comments for these!
+	// Specify common flags that will be passed to clang for EVERY build.
+	// You can use wilcards:
+	// 	- $project_base_path -> will be replaced with the project path being built
+	// 	- $project_name -> replaced by name of the project being built
+	// 	- $clang_version -> replaced by the numeric version of clang in use
 	"common_flags" : [
 		// some example includes
-		"-I/usr/include",
+		"-isystem /usr/include",
 		"-I$project_base_path/src",
 		"-I/workspace/$project_name/src",
 		"-I/usr/lib/clang/$clang_version/include"
 	],
-
+	// C specific flags. Merged with common_flags for C files.
 	"c_flags" : [
 		"-std=c11"
 	],
-
+	// C++ specific flags. These are merged with common_flags for C++ files.
 	"cpp_flags" : [
 		"-std=c++11"
 	],
 
-	// search for .clang_complete file up the tree. Use includes from it if found
+	// search for .clang_complete file up the tree. Use flags from it if found
 	"search_clang_complete_file": true,
 
 	// search for CMakeLists.txt with a "project" command in it. Run cmake on this

--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ Sublime Text 3 plugin that offers clang-based auto-completion for C++
 [![Codacy Badge][img-codacy]][codacy]
 [![MIT licensed][img-mit]](./LICENSE)
 [![Gitter][img-gitter]][gitter]
+[![Flattr this git repo][img-flattr]][donate-flattr]
+[![Donate][img-paypal]][donate-paypal]
 
-This plugin aims to provide easy-to-use, minimal-setup autocompletions for C++
+This plugin for easy-to-use, minimal-setup autocompletions for C++
 for Sublime Text 3. [Support](#support-it) it if you like it.
 
 # Jump right in! #
@@ -32,7 +34,7 @@ Follow all the following steps to ensure the plugin works as expected!
 ## Install clang ##
 - **Ubuntu**: `sudo apt-get install clang`
 - **Windows**: install the latest release from `clang`
-  [website](http://llvm.org/releases/download.html)
+  [website](http://llvm.org/releases/download.html) (v >= 3.9)
 - **OSX**: ships `clang` by default. You are all set!
 - on other systems refer to their package managers or install from `clang`
   [website](http://llvm.org/releases/download.html)
@@ -40,15 +42,8 @@ Follow all the following steps to ensure the plugin works as expected!
 ## Configure your includes ##
 
 ### Are you using CMake? ###
-Then you're good to go! All the flags should be guessed automatically. The
-plugin will create a folder for your project in the temporary folder, will run
-`cmake -DCMAKE_EXPORT_COMPILE_COMMANDS <your_project_location>` to generate the
-compilation database and will parse it to get correct flags for your project.
-The flags will be saved to `.clang_complete` file near a `CMakeLists.txt` that
-contains a `project <name>` line.
-
-**WARNING**: this is in Beta state. Refer to issue [#19][cmake-issue] for
-discussions on the topic.
+Plugin automatically generates `.clang_complete` and uses it for building our
+code.
 
 ### Not using CMake? ###
 You will need a little bit of manual setup for now. `Clang` will automatically
@@ -81,17 +76,16 @@ The plugin has two modes:
 
 - one that uses `libclang` with its python bindings. This is the better method
   as it fully utilizes saving compilation database which makes your completions
-  blazingly fast. It is a default method for Linux and OSX. It is also unit
-  tested to complete STL functions on both platforms. Please help me to bring
-  it to Windows. Check out this [discussion][libclang-issue].
+  blazingly fast. It is a default method. It is also unit tested to complete
+  STL functions on Linux and OSX platforms. It will also work for Windows as
+  soon as clang 4.0 is released. See [issue][libclang-issue]
 - one that parses the output from `clang -Xclang -code-completion-at` run from
-  the command line. This is the default method for Windows. Tested on all
-  platforms (see [Testing](#tests) part). Slower than method with `libclang`.
-  Will be deprecated when we solve [issue #4][libclang-issue].
+  the command line. This is a fallback method if something is wrong with the
+  first one.
 
 This plugin is intended to be easy to use. It should autocomplete STL out of
-the box and you should just add the folders your project uses to `include_dirs`
-list in the settings to make it autocomplete code all your project. If you
+the box and you should just add the folders your project uses as includes to
+the flags in the settings to make it autocomplete code all your project. If you
 experience problems - create an issue. I will try to respond as soon as
 possible.
 
@@ -107,66 +101,11 @@ self explanatory. Open an issue if they are not.
 
 
 ## Settings highlights ##
-I will only cover most important settings here.
+
+Please see the default settings [file](EasyClangComplete.sublime-settings)
+shipped with the plugin for explanations and sane default values.
 
 **PLEASE RESTART SUBLIME TEXT AFTER EACH SETTINGS CHANGE**
-
-- `include_dirs`:
-    + stores the locations where `clang` should be looking for external
-      headers, e.g. `Boost`, `Ros`, `Eigen`, `OpenCV`, etc.
-    + you can use placeholders like `$project_base_name` or
-      `$project_base_path` to make includes more convenient.
-    + it is absolutely ok to include a folder that does not exist. `clang`
-      knows how to deal with it and it will neither break anything nor make
-      things slower.
-- `std_flag_cpp`:
-    + sets the standard flag that will be used for compilation of `C++` code.
-      Defaults to `std=c++11`.
-- `std_flag_c`:
-    + sets the standard flag that will be used for compilation of `C` code.
-      Defaults to `std=c11`.
-- `use_libclang`:
-    + if `true` use libclang as backend.
-    + if `false` or if first option failed, use output from `clang -Xclang
-      -completion-at` command and parse it with regular expressions.
-- `search_clang_complete_file`:
-    + seach for `.clang_complete` file up the tree. Project folder is the last
-      one to search for the file.
-    + If the file is found, its contents of style `-I<some_local_path>` and
-      `-I/<some_absolute_path>` (mind the `/` at the start of the line) are
-      appended to include flags.
-- `errors_on_save`:
-    + highlight errors on save. A tooltip with an error message will be shown
-      if the caret goes over a highlighted line.
-- `triggers`:
-    + defaults are `".", "::", "->"`. The autocompletion does not trigger on
-      `>` or `:`. It also ignores float numbers like `3.14`.
-    + For them to work, the Sublime Text completion triggers have to be
-      configured too. These are already set to match triggers by default. You
-      can also set these settings manually by copying the default ones defined
-      [here](Preferences.sublime-settings) to your User Preferences and
-      modifying them there.
-- Override any setting in your project file! Just define the same setting in
-  project specific settings with either one of two prefixes: `"ecc_"` or
-  `"easy_clang_complete"`. See the project file in this repo for example.
-  Minimal example for clarity (here, `include_dirs` and `verbose` are
-  overridden):
-
-      ```json
-      {
-        "settings":
-        {
-          "ecc_include_dirs":
-          ["-Isrc", "-I/usr/include"],
-          "easy_clang_complete_verbose": true,
-        }
-      }
-      ```
-
-Please see the default settings file in the repo for more settings
-descriptions. Every setting in settings
-[file](EasyClangComplete.sublime-settings) should have an understandable
-comment. Should they not be clear - create an issue.
 
 ## Credits ##
 The whole work seen here was originally a fork of another repository:
@@ -191,8 +130,8 @@ Some functionality is there only because of the help of the following users (in 
 ## Tests ##
 I have tried to cover most crucial functionality with unit tests using
 [UnitTesting](https://github.com/randy3k/UnitTesting) Sublime Text plugin.
-Currently tests cover autocompletion of user struct and stl vector using clang
-binary. To check out the current status click on relevant badge below:
+Currently tests cover autocompletion of user struct and stl vector. To check
+out the current status click on relevant badge below:
 
 |           Linux / OSX           |               Windows               |
 |:-------------------------------:|:-----------------------------------:|
@@ -205,7 +144,6 @@ binary. To check out the current status click on relevant badge below:
 Current sponsor of this project is my sleep.
 Please buy me a cup of tea if you appreciate the effort.
 
-
 [release]: https://github.com/niosus/EasyClangComplete/releases
 [downloads]: https://packagecontrol.io/packages/EasyClangComplete
 [travis]: https://travis-ci.org/niosus/EasyClangComplete
@@ -214,7 +152,7 @@ Please buy me a cup of tea if you appreciate the effort.
 [gitter]: https://gitter.im/niosus/EasyClangComplete?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
 [donate-paypal]: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=2QLY7J4Q944HS
 [donate-flattr]: https://flattr.com/submit/auto?user_id=niosus&url=https://github.com/niosus/EasyClangComplete&title=EasyClangComplete&language=Python&tags=github&category=software
-[libclang-issue]: https://github.com/niosus/EasyClangComplete/issues/4
+[libclang-issue]: https://github.com/niosus/EasyClangComplete/issues/88
 [cmake-issue]: https://github.com/niosus/EasyClangComplete/issues/19
 
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Sublime Text 3 plugin that offers clang-based auto-completion for C++
 [![Flattr this git repo][img-flattr]][donate-flattr]
 [![Donate][img-paypal]][donate-paypal]
 
-This plugin for easy-to-use, minimal-setup autocompletions for C++
-for Sublime Text 3. [Support](#support-it) it if you like it.
+Plugin for easy-to-use, minimal-setup autocompletions for C++ for Sublime Text
+3. [Support](#support-it) it if you like it.
 
 # Jump right in! #
 Follow all the following steps to ensure the plugin works as expected!

--- a/easy_clang_complete.sublime-project
+++ b/easy_clang_complete.sublime-project
@@ -16,7 +16,7 @@
 	],
 	"settings":
 	{
-			"ecc_use_libclang": true,
+			"ecc_use_libclang": false,
 			"easy_clang_complete_verbose": true
 	}
 }

--- a/easy_clang_complete.sublime-project
+++ b/easy_clang_complete.sublime-project
@@ -16,7 +16,7 @@
 	],
 	"settings":
 	{
-			"ecc_use_libclang": false,
+			"ecc_use_libclang": true,
 			"easy_clang_complete_verbose": true
 	}
 }

--- a/plugin/completion/base_complete.py
+++ b/plugin/completion/base_complete.py
@@ -128,8 +128,6 @@ class BaseCompleter:
             settings=settings,
             compiler_variant=self.compiler_variant,
             search_scope=search_scope)
-        if not self.flags_manager:
-            log.critical(" flags_manager NOT loaded. NO FLAGS AVAILABLE!")
         log.debug(" flags_manager loaded")
 
     def complete(self, view, cursor_pos, current_job_id):

--- a/plugin/completion/base_complete.py
+++ b/plugin/completion/base_complete.py
@@ -109,7 +109,7 @@ class BaseCompleter:
         """
         raise NotImplementedError("calling abstract method")
 
-    def init(self, view, settings):
+    def init_for_view(self, view, settings):
         """
         Initialize the completer for this view. For real implementation see
         children.

--- a/plugin/completion/base_complete.py
+++ b/plugin/completion/base_complete.py
@@ -119,9 +119,6 @@ class BaseCompleter:
             settings (Settings): plugin settings
 
         """
-        if not view:
-            log.critical(" no view to initialize completer!")
-            return
         current_dir = path.dirname(view.file_name())
         search_scope = SearchScope(
             from_folder=current_dir,

--- a/plugin/completion/base_complete.py
+++ b/plugin/completion/base_complete.py
@@ -120,16 +120,20 @@ class BaseCompleter:
 
         """
         if not view:
+            log.critical(" no view to initialize completer!")
             return
         current_dir = path.dirname(view.file_name())
         search_scope = SearchScope(
             from_folder=current_dir,
             to_folder=settings.project_base_folder)
         self.flags_manager = FlagsManager(
-            use_cmake=settings.generate_flags_with_cmake,
-            flags_update_strategy=settings.cmake_flags_priority,
-            cmake_prefix_paths=settings.cmake_prefix_paths,
+            view=view,
+            settings=settings,
+            compiler_variant=self.compiler_variant,
             search_scope=search_scope)
+        if not self.flags_manager:
+            log.critical(" flags_manager NOT loaded. NO FLAGS AVAILABLE!")
+        log.debug(" flags_manager loaded")
 
     def complete(self, view, cursor_pos, current_job_id):
         """Function to generate completions. See children for implementation.

--- a/plugin/completion/bin_complete.py
+++ b/plugin/completion/bin_complete.py
@@ -52,7 +52,6 @@ class Completer(BaseCompleter):
     clang_binary = None
 
     flags_dict = {}
-    std_flag = None
 
     PARAM_TAG = "param"
     TYPE_TAG = "type"
@@ -65,10 +64,7 @@ class Completer(BaseCompleter):
         type_tag=TYPE_TAG,
         type_chars=TYPE_CHARS)
 
-    compl_str_mask = "{complete_flag}={file}:{row}:{col} {file}"
-
-    completion_mask = "{binary} {init} {std} {complete_at} {flags}"
-    update_mask = "{binary} {init} {std} {file} {flags}"
+    compl_str_mask = "{complete_flag}={file}:{row}:{col}"
 
     compl_regex = re.compile("COMPLETION:\s(?P<name>.*)\s:\s(?P<content>.*)")
     compl_content_regex = re.compile(
@@ -136,33 +132,8 @@ class Completer(BaseCompleter):
         # init procedure from super class
         super(Completer, self).init(view, settings)
 
-        # init current flags empty
-        self.flags_dict[view.buffer_id()] = None
-        clang_flags = None
+        self.flags_dict[view.buffer_id()] = self.flags_manager.get_flags()
 
-        # set std_flag
-        current_lang = Tools.get_view_syntax(view)
-        if current_lang != 'C':
-            self.std_flag = settings.std_flag_cpp
-        else:
-            self.std_flag = settings.std_flag_c
-
-        clang_flags = []
-
-        # init includes to start with from settings
-        includes = settings.populate_include_dirs(view)
-
-        for include in includes:
-            clang_flags.append('-I "{}"'.format(include))
-
-        if settings.search_clang_complete_file and self.flags_manager:
-            log.debug(" flags_manager loaded")
-            custom_flags = self.flags_manager.get_flags(
-                separate_includes=True)
-            clang_flags += custom_flags
-
-        # let's print the flags just to be sure
-        self.flags_dict[view.buffer_id()] = clang_flags
         log.debug(" clang flags are: %s", self.flags_dict[view.buffer_id()])
 
     def complete(self, view, cursor_pos, current_job_id):
@@ -232,24 +203,15 @@ class Completer(BaseCompleter):
         flags = self.flags_dict[view.buffer_id()]
         if task_type == "update":
             # we construct command for update task
-            complete_cmd = Completer.update_mask.format(
-                binary=Completer.clang_binary,
-                init=" ".join(self.compiler_variant.init_flags),
-                std=self.std_flag,
-                file=temp_file_name,
-                flags=" ".join(flags))
+            complete_cmd = [Completer.clang_binary] + flags + [temp_file_name]
         elif task_type == "complete":
             # we construct command for complete task
             (row, col) = SublBridge.cursor_pos(view, cursor_pos)
             complete_at_str = Completer.compl_str_mask.format(
-                complete_flag="-Xclang -code-completion-at",
+                complete_flag="-code-completion-at",
                 file=temp_file_name, row=row, col=col)
-            complete_cmd = Completer.completion_mask.format(
-                binary=Completer.clang_binary,
-                init=" ".join(self.compiler_variant.init_flags),
-                std=self.std_flag,
-                complete_at=complete_at_str,
-                flags=" ".join(flags))
+            complete_cmd = [Completer.clang_binary] + flags + ["-Xclang"] \
+                + [complete_at_str] + [temp_file_name]
         else:
             log.critical(" unknown type of cmd command wanted.")
             return None

--- a/plugin/completion/bin_complete.py
+++ b/plugin/completion/bin_complete.py
@@ -116,7 +116,7 @@ class Completer(BaseCompleter):
             return True
         return False
 
-    def init(self, view, settings):
+    def init_for_view(self, view, settings):
         """Initialize the completer
 
         Args:
@@ -130,7 +130,7 @@ class Completer(BaseCompleter):
             return
 
         # init procedure from super class
-        super(Completer, self).init(view, settings)
+        super(Completer, self).init_for_view(view, settings)
 
         self.flags_dict[view.buffer_id()] = self.flags_manager.get_flags()
 

--- a/plugin/completion/compiler_variant.py
+++ b/plugin/completion/compiler_variant.py
@@ -37,7 +37,7 @@ class ClangCompilerVariant(CompilerVariant):
         error_regex (re): regex to find contents of an error
     """
     init_flags = ["-c", "-fsyntax-only", "-x", "c++"]
-    include_prefixes = ['-isystem ', '-I']
+    include_prefixes = ["-isystem ", "-I"]
     error_regex = re.compile("(?P<file>.*)" +
                              ":(?P<row>\d+):(?P<col>\d+)" +
                              ":\s*.*error: (?P<error>.*)")
@@ -72,7 +72,7 @@ class ClangClCompilerVariant(ClangCompilerVariant):
         error_regex (re): regex to find contents of an error
     """
     init_flags = ["-c", "-fsyntax-only"]
-    include_prefixes = ["-I", "-I ", "/I ", "-msvc ", "/imsvc "]
+    include_prefixes = ["-I", "/I", "-msvc", "/msvc"]
     error_regex = re.compile("(?P<file>.*)" +
                              "\((?P<row>\d+),(?P<col>\d+)\)\s*" +
                              ":\s*.*error: (?P<error>.*)")

--- a/plugin/completion/compiler_variant.py
+++ b/plugin/completion/compiler_variant.py
@@ -36,7 +36,7 @@ class ClangCompilerVariant(CompilerVariant):
         init_flags (list): flags that every command needs
         error_regex (re): regex to find contents of an error
     """
-    init_flags = ["-c", "-fsyntax-only", "-x c++"]
+    init_flags = ["-c", "-fsyntax-only", "-x", "c++"]
     error_regex = re.compile("(?P<file>.*)" +
                              ":(?P<row>\d+):(?P<col>\d+)" +
                              ":\s*.*error: (?P<error>.*)")
@@ -76,7 +76,7 @@ class ClangClCompilerVariant(ClangCompilerVariant):
                              ":\s*.*error: (?P<error>.*)")
 
 
-class LibClangCompilerVariant(CompilerVariant):
+class LibClangCompilerVariant(ClangCompilerVariant):
     """
     Encapsulation of libclang specific options
 

--- a/plugin/completion/compiler_variant.py
+++ b/plugin/completion/compiler_variant.py
@@ -72,7 +72,7 @@ class ClangClCompilerVariant(ClangCompilerVariant):
         error_regex (re): regex to find contents of an error
     """
     init_flags = ["-c", "-fsyntax-only"]
-    include_prefixes = ["-I ", "/I ", "-msvc ", "/imsvc "]
+    include_prefixes = ["-I", "-I ", "/I ", "-msvc ", "/imsvc "]
     error_regex = re.compile("(?P<file>.*)" +
                              "\((?P<row>\d+),(?P<col>\d+)\)\s*" +
                              ":\s*.*error: (?P<error>.*)")

--- a/plugin/completion/compiler_variant.py
+++ b/plugin/completion/compiler_variant.py
@@ -37,6 +37,7 @@ class ClangCompilerVariant(CompilerVariant):
         error_regex (re): regex to find contents of an error
     """
     init_flags = ["-c", "-fsyntax-only", "-x", "c++"]
+    include_prefixes = ['-isystem ', '-I']
     error_regex = re.compile("(?P<file>.*)" +
                              ":(?P<row>\d+):(?P<col>\d+)" +
                              ":\s*.*error: (?P<error>.*)")
@@ -71,6 +72,7 @@ class ClangClCompilerVariant(ClangCompilerVariant):
         error_regex (re): regex to find contents of an error
     """
     init_flags = ["-c", "-fsyntax-only"]
+    include_prefixes = ["-I ", "/I ", "-msvc ", "/imsvc "]
     error_regex = re.compile("(?P<file>.*)" +
                              "\((?P<row>\d+),(?P<col>\d+)\)\s*" +
                              ":\s*.*error: (?P<error>.*)")

--- a/plugin/completion/flags_manager.py
+++ b/plugin/completion/flags_manager.py
@@ -110,7 +110,7 @@ class FlagsManager:
         log.debug(" expanded CMAKE_PREFIX_PATHs: %s", self._cmake_prefix_paths)
 
         # initialize default flags
-        self._initial_flags = compiler_variant.init_flags
+        self._initial_flags = list(compiler_variant.init_flags)
         current_lang = Tools.get_view_syntax(view)
         if current_lang == 'C':
             self._initial_flags += settings.c_flags
@@ -204,11 +204,11 @@ class FlagsManager:
 
         if self._clang_complete_file.was_modified():
             log.debug(" .clang_complete modified. Load new flags.")
-            self._flags = FlagsManager.flags_from_clang_file(
-                self._clang_complete_file)
+            generated_flags = list(FlagsManager.flags_from_clang_file(
+                self._clang_complete_file))
 
         # the flags are now in final state, we can return them
-        return FlagsManager.merge_flags(self._initial_flags, list(self._flags))
+        return FlagsManager.merge_flags(self._initial_flags, generated_flags)
 
     @staticmethod
     def merge_flags(initial_flags, generated_flags):

--- a/plugin/completion/flags_manager.py
+++ b/plugin/completion/flags_manager.py
@@ -68,7 +68,7 @@ class FlagsManager:
     _flags_update_strategy = "ask"
     _cmake_prefix_paths = []
 
-    _include_prefixes = ['-isystem', '-I']
+    _include_prefixes = ['-isystem ', '-I']
 
     cmake_mask = 'cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON "{path}"'
 

--- a/plugin/completion/flags_manager.py
+++ b/plugin/completion/flags_manager.py
@@ -410,8 +410,6 @@ class FlagsManager:
         flags = set()
         for line in lines:
             line = line.strip()
-            if not line.startswith('-'):
-                line = '-' + line
             prefix, include_path = split_if_include(line,
                                                     self._include_prefixes)
             if include_path:

--- a/plugin/completion/flags_manager.py
+++ b/plugin/completion/flags_manager.py
@@ -376,6 +376,14 @@ class FlagsManager:
         """
 
         def split_if_include(flag):
+            """ Split flag if it is an include flag
+
+            Args:
+                flag (str): flag to test and split if needed
+
+            Returns:
+                (str, str): tuple of (prefix, path)
+            """
             for prefix in FlagsManager._include_prefixes:
                 if flag.startswith(prefix):
                     return (prefix, flag[len(prefix):])
@@ -392,6 +400,7 @@ class FlagsManager:
             if include_path:
                 if not path.isabs(include_path):
                     include_path = path.join(folder, include_path)
+                include_path = path.normpath(include_path)
                 line = prefix + include_path
             flags.add(line)
         return flags

--- a/plugin/completion/flags_manager.py
+++ b/plugin/completion/flags_manager.py
@@ -404,7 +404,7 @@ class FlagsManager:
             """
             for prefix in include_prefixes:
                 if flag.startswith(prefix):
-                    return (prefix, flag[len(prefix):])
+                    return (prefix, flag[len(prefix):].strip())
             return (None, None)
 
         flags = set()

--- a/plugin/completion/flags_manager.py
+++ b/plugin/completion/flags_manager.py
@@ -62,6 +62,7 @@ class FlagsManager:
     _cmake_file = File()
     _clang_complete_file = File()
     _flags = []
+    _initial_flags = []
     _search_scope = SearchScope()
     _use_cmake = False
     _flags_update_strategy = "ask"
@@ -77,9 +78,9 @@ class FlagsManager:
     CLANG_COMPLETE_FILE_NAME = ".clang_complete"
 
     def __init__(self,
-                 use_cmake,
-                 flags_update_strategy,
-                 cmake_prefix_paths=None,
+                 view,
+                 settings,
+                 compiler_variant,
                  search_scope=SearchScope()):
         """
         Initialize the flags manager
@@ -93,18 +94,33 @@ class FlagsManager:
                 search for CMakeLists.txt file and .clang_complete file.
         """
         if not search_scope.valid():
-            log.error(" search scope is wrong.")
+            log.critical(" search scope is wrong.")
             return
-        if not cmake_prefix_paths:
+        # intialize important variables
+        cmake_prefix_paths = settings.cmake_prefix_paths
+        if cmake_prefix_paths is None:
             cmake_prefix_paths = []
         self._search_scope = search_scope
-        self._use_cmake = use_cmake
-        self._flags_update_strategy = flags_update_strategy
+        self._use_cmake = settings.generate_flags_with_cmake
+        self._flags_update_strategy = settings.cmake_flags_priority
         self._cmake_prefix_paths = cmake_prefix_paths
+        self._use_clang_complete_file = settings.search_clang_complete_file
         # expand all entries containing "~"
         self._cmake_prefix_paths \
             = [path.expanduser(x) for x in self._cmake_prefix_paths]
         log.debug(" expanded CMAKE_PREFIX_PATHs: %s", self._cmake_prefix_paths)
+
+        # initialize default flags
+        self._initial_flags = compiler_variant.init_flags
+        current_lang = Tools.get_view_syntax(view)
+        if current_lang == 'C':
+            self._initial_flags += settings.c_flags
+        else:
+            self._initial_flags += settings.cpp_flags
+
+        home_folder = path.expanduser('~')
+        self._initial_flags += list(FlagsManager.parse_flags(
+            home_folder, settings.populate_common_flags(view)))
 
     def any_file_modified(self):
         """
@@ -119,7 +135,7 @@ class FlagsManager:
             return True
         return False
 
-    def get_flags(self, separate_includes):
+    def get_flags(self):
         """
         A function that handles getting all the flags. It will generate new
         flags in a lazy fashion. When any changes are detected and will update
@@ -127,12 +143,14 @@ class FlagsManager:
         been made to .clang_complete file or to CMakeLists.txt file it will
         just return already existing flags.
 
-        Args: separate_includes (bool): should we separate include path from
-            their identifier?
-
         Returns:
             str[]: flags
         """
+        if not self._use_clang_complete_file:
+            log.debug(" user doesn't want to look for .clang_complete file")
+            log.debug(" use flags from settings only")
+            return self._initial_flags
+
         if self._use_cmake and not self._cmake_file.loaded():
             # CMakeLists.txt was not loaded yet, so search for it
             log.debug(" cmake file not loaded yet. Searching for one...")
@@ -152,16 +170,14 @@ class FlagsManager:
                 prefix_paths=self._cmake_prefix_paths)
             if compilation_db:
                 new_flags = FlagsManager.flags_from_database(
-                    database_file=compilation_db,
-                    separate_includes=separate_includes)
+                    database_file=compilation_db)
                 new_clang_file_path = path.join(
                     self._cmake_file.folder(),
                     FlagsManager.CLANG_COMPLETE_FILE_NAME)
                 # there is no need to modify anything if the flags have not
                 # changed since we have last read them
                 curr_flags = FlagsManager.flags_from_clang_file(
-                    file=File(new_clang_file_path),
-                    separate_includes=separate_includes)
+                    file=File(new_clang_file_path))
                 if len(new_flags.symmetric_difference(curr_flags)) > 0:
                     log.debug("'%s' is not equal to '%s' by %s so update",
                               new_flags, curr_flags,
@@ -190,10 +206,10 @@ class FlagsManager:
         if self._clang_complete_file.was_modified():
             log.debug(" .clang_complete modified. Load new flags.")
             self._flags = FlagsManager.flags_from_clang_file(
-                self._clang_complete_file, separate_includes)
+                self._clang_complete_file)
 
         # the flags are now in final state, we can return them
-        return self._flags
+        return self._initial_flags + list(self._flags)
 
     @staticmethod
     def compile_cmake(cmake_file, prefix_paths):
@@ -263,7 +279,7 @@ class FlagsManager:
             if flag_strategy == "merge":
                 # union of two flags sets
                 curr_flags = set(FlagsManager.flags_from_clang_file(
-                    File(file_path), separate_includes=False))
+                    File(file_path)))
                 new_flags = new_flags.union(curr_flags)
             # unhandled is only "overwrite". "ask" is not possible here.
         f = open(file_path, 'w')
@@ -299,11 +315,9 @@ class FlagsManager:
             return strategy
 
     @staticmethod
-    def flags_from_database(database_file, separate_includes):
+    def flags_from_database(database_file):
         """Get flags from cmake compilation database
         Args: database_file (tools.File): compilation database file
-            separate_includes (bool): separate include specifier from the path
-            by a space
         Returns:
             set(str): flags
         """
@@ -318,23 +332,21 @@ class FlagsManager:
             command = entry['command']
             all_command_parts = command.split(' -')
             current_flags = FlagsManager.parse_flags(
-                database_file.folder(), all_command_parts, separate_includes)
+                database_file.folder(), all_command_parts)
             flags_set = flags_set.union(current_flags)
         log.debug(" flags set: %s", flags_set)
         return flags_set
 
     @staticmethod
-    def flags_from_clang_file(file, separate_includes):
+    def flags_from_clang_file(file):
         """
         Parse .clang_complete file
 
         Args:
-            separate_includes (bool):  Separation is needed for binary complete
-                if True: -I<include> turns to '-I "<include>"'.
-                if False: stays -I<include>
+            file(Tools.File): .clang_complete file handle
 
         Returns:
-            se(tstr): parsed list of includes from the file
+            set(str): parsed list of includes from the file
         """
         if not path.exists(file.full_path()):
             log.debug(" .clang_complete does not exist yet. No flags present.")
@@ -346,44 +358,40 @@ class FlagsManager:
         flags = set()
         with open(file.full_path()) as f:
             content = f.readlines()
-            flags = FlagsManager.parse_flags(file.folder(),
-                                             content,
-                                             separate_includes)
+            flags = FlagsManager.parse_flags(file.folder(), content)
         log.debug(" .clang_complete contains flags: %s", flags)
         return flags
 
     @staticmethod
-    def parse_flags(folder, lines, separate_includes):
+    def parse_flags(folder, lines):
         """
         Parse the flags in a given file
 
         Args:
             folder (str): current folder
             lines (str[]): lines to parse
-            separate_includes (bool): if True "-I/blah" turns to "-I '/blah'"
 
         Returns:
             str[]: flags
         """
+
+        def split_if_include(flag):
+            for prefix in FlagsManager._include_prefixes:
+                if flag.startswith(prefix):
+                    return (prefix, flag[len(prefix):])
+            return (None, None)
+
         mask = '{}{}'
-        separate_mask = '{} "{}"'
         flags = set()
         log.debug(" all lines: %s", lines)
         for line in lines:
-            for prefix in FlagsManager._possible_prefixes:
-                full_prefix = '-' + prefix
-                if not line.startswith('-'):
-                    line = '-' + line
-                if line.startswith(full_prefix):
-                    flag_content = line[len(full_prefix):].strip()
-                    flag_content = flag_content.strip('"')
-                    if prefix in FlagsManager._include_prefixes:
-                        if not path.isabs(flag_content):
-                            flag_content = path.join(folder, flag_content)
-                        if separate_includes:
-                            flags.add(separate_mask.format(full_prefix, flag_content))
-                        else:
-                            flags.add(mask.format(full_prefix, flag_content))
-                    else:
-                        flags.add(mask.format(full_prefix, flag_content))
+            line = line.strip()
+            if not line.startswith('-'):
+                line = '-' + line
+            prefix, include_path = split_if_include(line)
+            if include_path:
+                if not path.isabs(include_path):
+                    include_path = path.join(folder, include_path)
+                line = prefix + include_path
+            flags.add(line)
         return flags

--- a/plugin/completion/flags_manager.py
+++ b/plugin/completion/flags_manager.py
@@ -409,6 +409,8 @@ class FlagsManager:
 
         flags = set()
         for line in lines:
+            if line.startswith("#"):
+                continue
             line = line.strip()
             prefix, include_path = split_if_include(line,
                                                     self._include_prefixes)

--- a/plugin/completion/flags_manager.py
+++ b/plugin/completion/flags_manager.py
@@ -85,10 +85,10 @@ class FlagsManager:
         Initialize the flags manager
 
         Args:
-            use_cmake (bool): should we search for CMakeLists.txt?
-            flags_update_strategy (str): how to deal with flags conflicts?
-            cmake_prefix_paths (str[], optional): should we add any file paths
-                to the CMAKE_PREFIX_PATH before building a cmake project?
+            view (sublime.View): current view
+            settings (plugin.Settings): current settings
+            compiler_variant (completion.CompilerVariant): current compiler
+                variant picks correct initial flags based on compiler in use
             search_scope (tools.SearchScope, optional): search scope where to
                 search for CMakeLists.txt file and .clang_complete file.
         """

--- a/plugin/completion/flags_manager.py
+++ b/plugin/completion/flags_manager.py
@@ -351,6 +351,7 @@ class FlagsManager:
         for entry in data:
             command = entry['command']
             all_command_parts = command.split(' -')
+            all_command_parts = ['-' + part for part in all_command_parts]
             current_flags = self.parse_flags(database_file.folder(),
                                              all_command_parts)
             flags_set = flags_set.union(current_flags)

--- a/plugin/completion/flags_manager.py
+++ b/plugin/completion/flags_manager.py
@@ -389,7 +389,6 @@ class FlagsManager:
             return (None, None)
 
         flags = set()
-        log.debug(" all lines: %s", lines)
         for line in lines:
             line = line.strip()
             if not line.startswith('-'):

--- a/plugin/completion/flags_manager.py
+++ b/plugin/completion/flags_manager.py
@@ -68,8 +68,6 @@ class FlagsManager:
     _flags_update_strategy = "ask"
     _cmake_prefix_paths = []
 
-    _include_prefixes = ['-isystem ', '-I']
-
     cmake_mask = 'cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON "{path}"'
 
     CMAKE_FILE_NAME = "CMakeLists.txt"
@@ -104,6 +102,7 @@ class FlagsManager:
         self._flags_update_strategy = settings.cmake_flags_priority
         self._cmake_prefix_paths = cmake_prefix_paths
         self._use_clang_complete_file = settings.search_clang_complete_file
+        self._include_prefixes = compiler_variant.include_prefixes
         # expand all entries containing "~"
         self._cmake_prefix_paths \
             = [path.expanduser(x) for x in self._cmake_prefix_paths]

--- a/plugin/completion/flags_manager.py
+++ b/plugin/completion/flags_manager.py
@@ -212,6 +212,16 @@ class FlagsManager:
 
     @staticmethod
     def merge_flags(initial_flags, generated_flags):
+        """ Handle merging of initial and generated flags. Handles situations
+        where std flag has to be overridden.
+
+        Args:
+            initial_flags (list(str)): initial flags from settings
+            generated_flags (list(str)): flags from .clang_complete file
+
+        Returns:
+            list(str): merged flags
+        """
         initial_std_flag_idx = Tools.find_flag_idx(initial_flags, "-std")
         generated_std_flag_idx = Tools.find_flag_idx(generated_flags, "-std")
         if initial_std_flag_idx and generated_std_flag_idx:

--- a/plugin/completion/flags_manager.py
+++ b/plugin/completion/flags_manager.py
@@ -202,6 +202,7 @@ class FlagsManager:
                 from_folder=self._search_scope.from_folder,
                 to_folder=self._search_scope.to_folder)
 
+        generated_flags = []
         if self._clang_complete_file.was_modified():
             log.debug(" .clang_complete modified. Load new flags.")
             generated_flags = list(FlagsManager.flags_from_clang_file(

--- a/plugin/completion/flags_manager.py
+++ b/plugin/completion/flags_manager.py
@@ -68,8 +68,7 @@ class FlagsManager:
     _flags_update_strategy = "ask"
     _cmake_prefix_paths = []
 
-    _possible_prefixes = ['std', 'isystem', 'D', 'I']
-    _include_prefixes = ['isystem', 'I']
+    _include_prefixes = ['-isystem', '-I']
 
     cmake_mask = 'cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON "{path}"'
 
@@ -389,7 +388,6 @@ class FlagsManager:
                     return (prefix, flag[len(prefix):])
             return (None, None)
 
-        mask = '{}{}'
         flags = set()
         log.debug(" all lines: %s", lines)
         for line in lines:

--- a/plugin/completion/flags_manager.py
+++ b/plugin/completion/flags_manager.py
@@ -208,7 +208,20 @@ class FlagsManager:
                 self._clang_complete_file)
 
         # the flags are now in final state, we can return them
-        return self._initial_flags + list(self._flags)
+        return FlagsManager.merge_flags(self._initial_flags, list(self._flags))
+
+    @staticmethod
+    def merge_flags(initial_flags, generated_flags):
+        initial_std_flag_idx = Tools.find_flag_idx(initial_flags, "-std")
+        generated_std_flag_idx = Tools.find_flag_idx(generated_flags, "-std")
+        if initial_std_flag_idx and generated_std_flag_idx:
+            # we have std flags in both the initial flags and generated ones
+            log.debug(" overriding initial std flag with '%s'",
+                      generated_flags[generated_std_flag_idx])
+            initial_flags[initial_std_flag_idx] \
+                = generated_flags[generated_std_flag_idx]
+            generated_flags.pop(generated_std_flag_idx)
+        return initial_flags + generated_flags
 
     @staticmethod
     def compile_cmake(cmake_file, prefix_paths):

--- a/plugin/completion/lib_complete.py
+++ b/plugin/completion/lib_complete.py
@@ -155,37 +155,9 @@ class Completer(BaseCompleter):
         # initialize unsaved files
         files = [(file_name, file_body)]
 
-        # init needed variables from settings
-        clang_flags = []
+        # get flags from manager
+        clang_flags = self.flags_manager.get_flags()
 
-        # set std_flag
-        std_flag = None
-        current_lang = Tools.get_view_syntax(view)
-        if current_lang != 'C':
-            std_flag = settings.std_flag_cpp
-        else:
-            std_flag = settings.std_flag_c
-
-        # add std flag to all flags
-        clang_flags.append(std_flag)
-
-        # init includes to start with from settings
-        includes = settings.populate_include_dirs(view)
-
-        for include in includes:
-            clang_flags.append('-I' + include)
-
-        if settings.search_clang_complete_file and self.flags_manager:
-            log.debug(" flags_manager loaded")
-            custom_flags = self.flags_manager.get_flags(
-                separate_includes=False)
-            clang_flags += custom_flags
-
-        # now we have the flags and can continue initializing the TU
-        if Tools.get_view_syntax(view) != "C":
-            # treat this as c++ even if it is a header
-            log.debug(" This is a C++ file. Adding `-x c++` to flags")
-            clang_flags = ['-x'] + ['c++'] + clang_flags
         log.debug(" clang flags are: %s", clang_flags)
         v_id = view.buffer_id()
         with self.rlock:

--- a/plugin/completion/lib_complete.py
+++ b/plugin/completion/lib_complete.py
@@ -134,7 +134,7 @@ class Completer(BaseCompleter):
                 return True
             return False
 
-    def init(self, view, settings):
+    def init_for_view(self, view, settings):
         """Initialize the completer. Builds the view.
 
         Args:
@@ -147,7 +147,7 @@ class Completer(BaseCompleter):
             return
 
         # call initializer from the super class
-        super(Completer, self).init(view, settings)
+        super(Completer, self).init_for_view(view, settings)
 
         file_name = view.file_name()
         file_body = view.substr(sublime.Region(0, view.size()))

--- a/plugin/plugin_settings.py
+++ b/plugin/plugin_settings.py
@@ -179,7 +179,7 @@ class Settings:
             view (sublime.View): current view
 
         Returns:
-            str[]: directories where clang searches for header files
+            str[]: clang common flags with variables expanded
 
         """
         # init folders needed:
@@ -208,6 +208,4 @@ class Settings:
         if self.include_file_parent_folder:
             common_flags.add("-I" + file_parent_folder)
 
-        # print resulting include dirs
-        log.debug(" common_flags = %s", common_flags)
         return common_flags

--- a/plugin/plugin_settings.py
+++ b/plugin/plugin_settings.py
@@ -46,7 +46,6 @@ class Settings:
         "errors_on_save",
         "generate_flags_with_cmake",
         "hide_default_completions",
-        "include_dirs",
         "include_file_folder",
         "include_file_parent_folder",
         "max_tu_age",
@@ -173,7 +172,7 @@ class Settings:
         return True
 
     def populate_common_flags(self, view):
-        """ Populate the variables inside include dirs with real values
+        """ Populate the variables inside common_flags with real values
 
         Args:
             view (sublime.View): current view

--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -496,3 +496,10 @@ class Tools:
     def get_position_identifier(view, position_in_file):
         """ Generate unique tuple for file and position in the file """
         return (view.buffer_id(), position_in_file)
+
+    @staticmethod
+    def find_flag_idx(flags, prefix):
+        for idx, flag in enumerate(flags):
+            if flag.startswith("-std"):
+                return idx
+        return None

--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -499,6 +499,9 @@ class Tools:
 
     @staticmethod
     def find_flag_idx(flags, prefix):
+        """ Find index of flag with given prefix in list.
+        Returns: index of found flag or None if not found
+        """
         for idx, flag in enumerate(flags):
             if flag.startswith("-std"):
                 return idx

--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -431,7 +431,8 @@ class Tools:
         try:
             startupinfo = None
             if isinstance(command, list):
-                log.debug(" command: \n%s", subprocess.list2cmdline(command))
+                command = subprocess.list2cmdline(command)
+                log.debug(" command: \n%s", command)
             if platform.system() == "Windows":
                 # Don't let console window pop-up briefly.
                 startupinfo = subprocess.STARTUPINFO()

--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -430,6 +430,8 @@ class Tools:
         """
         try:
             startupinfo = None
+            if isinstance(command, list):
+                log.debug(" command: \n%s", subprocess.list2cmdline(command))
             if platform.system() == "Windows":
                 # Don't let console window pop-up briefly.
                 startupinfo = subprocess.STARTUPINFO()

--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -87,7 +87,7 @@ class base_test_complete(object):
 
         clang_binary = settings.clang_binary
         completer = self.Completer(clang_binary)
-        completer.init(
+        completer.init_for_view(
             view=self.view,
             settings=settings)
 
@@ -185,7 +185,7 @@ class base_test_complete(object):
         settings = Settings()
         clang_binary = settings.clang_binary
         completer = self.Completer(clang_binary)
-        completer.init(
+        completer.init_for_view(
             view=self.view,
             settings=settings)
 

--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -246,6 +246,7 @@ class base_test_complete(object):
             if line.startswith('-I'):
                 if real_line.endswith('lib') or real_line.endswith('lib"'):
                     found = True
+                    break
             line = file.readline()
         file.close()
         self.assertTrue(found)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -57,10 +57,8 @@ class test_settings(TestCase):
         self.assertIsNotNone(settings.include_file_folder)
         self.assertIsNotNone(settings.include_file_parent_folder)
         self.assertIsNotNone(settings.triggers)
-        self.assertIsNotNone(settings.include_dirs)
+        self.assertIsNotNone(settings.common_flags)
         self.assertIsNotNone(settings.clang_binary)
-        self.assertIsNotNone(settings.std_flag_c)
-        self.assertIsNotNone(settings.std_flag_cpp)
         self.assertIsNotNone(settings.search_clang_complete_file)
         self.assertIsNotNone(settings.errors_on_save)
 
@@ -71,7 +69,7 @@ class test_settings(TestCase):
         settings = Settings()
         self.assertTrue(settings.is_valid())
 
-    def test_populate_includes(self):
+    def test_populate_flags(self):
         """Testing include population
         """
         # open any existing file
@@ -82,17 +80,17 @@ class test_settings(TestCase):
         self.assertTrue(settings.is_valid())
         settings.include_file_folder = True
         settings.include_file_parent_folder = True
-        settings.include_dirs = [
-            path.realpath("/$project_name/src"),
-            path.realpath("/test/test")
+        settings.common_flags = [
+            "-I" + path.realpath("/$project_name/src"),
+            "-I" + path.realpath("/test/test")
         ]
-        initial_dirs = list(settings.include_dirs)
-        dirs = settings.populate_include_dirs(self.view)
+        initial_flags = list(settings.common_flags)
+        dirs = settings.populate_common_flags(self.view)
 
         current_folder = path.dirname(self.view.file_name())
         parent_folder = path.dirname(current_folder)
-        self.assertLess(len(initial_dirs), len(dirs))
-        self.assertFalse(initial_dirs[0] in dirs)
-        self.assertTrue(initial_dirs[1] in dirs)
-        self.assertTrue(current_folder in dirs)
-        self.assertTrue(parent_folder in dirs)
+        self.assertLess(len(initial_flags), len(dirs))
+        self.assertFalse(initial_flags[0] in dirs)
+        self.assertTrue(initial_flags[1] in dirs)
+        self.assertTrue(("-I" + current_folder) in dirs)
+        self.assertTrue(("-I" + parent_folder) in dirs)


### PR DESCRIPTION
- deprecating include dirs as discussed in #113
- use flags manager to manage flags in all cases
- actually use compiler variant for flags initialization