### PR TITLE
Fix macOS test issue and use the new version of UnitTesting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
         # Your package name
         - PACKAGE="EasyClangComplete"
     matrix:
-        - SUBLIME_TEXT_VERSION="3" UNITTESTING_TAG="0.8.0"
+        - SUBLIME_TEXT_VERSION="3"
 
 before_install:
     - curl -OL https://raw.githubusercontent.com/randy3k/UnitTesting/master/sbin/travis.sh

--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -112,6 +112,9 @@ class EasyClangComplete(sublime_plugin.EventListener):
             view (sublime.View): current view
 
         """
+        # disable on_activated_async when running tests
+        if view.settings().get("disable_easy_clang_complete"):
+            return
         log.debug(" on_activated_async view id %s", view.buffer_id())
         if Tools.is_valid_view(view):
             if not self.completer:

--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -65,6 +65,7 @@ class base_test_complete(object):
         # Open the view.
         file_path = path.join(path.dirname(__file__), filename)
         self.view = sublime.active_window().open_file(file_path)
+        self.view.settings().set("disable_easy_clang_complete", True)
 
         # Ensure it's loaded.
         while self.view.is_loading():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -25,6 +25,7 @@ class test_settings(TestCase):
         # Open the view.
         file_path = path.join(path.dirname(__file__), filename)
         self.view = sublime.active_window().open_file(file_path)
+        self.view.settings().set("disable_easy_clang_complete", True)
 
         # Ensure it's loaded.
         while self.view.is_loading():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -37,6 +37,7 @@ class test_tools_command(TestCase):
         # Open the view.
         file_path = path.join(path.dirname(__file__), filename)
         self.view = sublime.active_window().open_file(file_path)
+        self.view.settings().set("disable_easy_clang_complete", True)
 
         # Ensure it's loaded.
         while self.view.is_loading():


### PR DESCRIPTION
When the view is created, [on_activate_async][1] is triggered, and it runs `manager.settings_for_view()`. 




[1]: https://github.com/niosus/EasyClangComplete/blob/1d40ad4f3d1bc6cbf8c82b960e4ca5dae592fcde/EasyClangComplete.py#L108-L108 