### PR TITLE
Fix flags separation

### DIFF
--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -13,10 +13,12 @@
 	],
 	// C specific flags. Merged with common_flags for C files.
 	"c_flags" : [
+		"-x", "c",
 		"-std=c11"
 	],
 	// C++ specific flags. These are merged with common_flags for C++ files.
 	"cpp_flags" : [
+		"-x", "c++",
 		"-std=c++11"
 	],
 

--- a/plugin/completion/base_complete.py
+++ b/plugin/completion/base_complete.py
@@ -124,10 +124,9 @@ class BaseCompleter:
 
         include_prefixes = self.compiler_variant.include_prefixes
         home_folder = path.expanduser('~')
-        initial_flags += Flag.tokenize_list(
-            FlagsSource.parse_flags(home_folder,
-                                    settings.common_flags,
-                                    include_prefixes))
+        initial_flags += FlagsSource.parse_flags(home_folder,
+                                                 settings.common_flags,
+                                                 include_prefixes)
         # get other flags from some flag source
         current_flags = BaseCompleter.get_flags_from_source(
             view, settings, include_prefixes)

--- a/plugin/completion/base_complete.py
+++ b/plugin/completion/base_complete.py
@@ -8,20 +8,22 @@ import logging
 
 from os import path
 
+from .compiler_variant import CompilerVariant
+
 from .. import error_vis
-from .. import tools
 
 from ..tools import SearchScope
+from ..tools import Tools
 
 from ..flags_sources.cmake_file import CMakeFile
 from ..flags_sources.compilation_db import CompilationDb
 from ..flags_sources.flags_file import FlagsFile
 from ..flags_sources.flags_source import FlagsSource
+from ..utils.unique_list import UniqueList
+from ..utils.flag import Flag
 
 
 log = logging.getLogger(__name__)
-
-Tools = tools.Tools
 
 
 class BaseCompleter:
@@ -111,21 +113,28 @@ class BaseCompleter:
 
         """
         # initialize default flags (init_flags list needs to be copied).
-        initial_flags = list(self.compiler_variant.init_flags)
+        initial_flags = UniqueList(CompilerVariant.init_flags)
         current_lang = Tools.get_view_syntax(view)
         if current_lang == 'C' or current_lang == 'C99':
-            initial_flags += settings.c_flags
+            lang_flags = settings.c_flags
         else:
-            initial_flags += settings.cpp_flags
+            lang_flags = settings.cpp_flags
+
+        initial_flags += Flag.tokenize_list(lang_flags)
 
         include_prefixes = self.compiler_variant.include_prefixes
         home_folder = path.expanduser('~')
-        initial_flags += FlagsSource.parse_flags(
-            home_folder, settings.common_flags, include_prefixes)
+        initial_flags += Flag.tokenize_list(
+            FlagsSource.parse_flags(home_folder,
+                                    settings.common_flags,
+                                    include_prefixes))
         # get other flags from some flag source
         current_flags = BaseCompleter.get_flags_from_source(
             view, settings, include_prefixes)
-        self.clang_flags = initial_flags + current_flags
+        all_flags = initial_flags + current_flags
+        self.clang_flags = []
+        for flag in all_flags:
+            self.clang_flags += flag.as_list()
 
     @staticmethod
     def get_flags_from_source(view, settings, include_prefixes):

--- a/plugin/completion/compiler_variant.py
+++ b/plugin/completion/compiler_variant.py
@@ -1,4 +1,4 @@
-"""Module contains options for various compiler variants
+"""Module contains options for various compiler variants.
 
 Attributes:
     log (logging.Logger): logger for this module
@@ -6,14 +6,19 @@ Attributes:
 import re
 import logging
 
+from ..utils.flag import Flag
+
 log = logging.getLogger(__name__)
 log.debug(" reloading module")
 
 
 class CompilerVariant(object):
+    """Encapsulation of a compiler specific options.
+
+    Attributes:
+        init_flags (list): flags that every command needs.
     """
-    Encapsulation of a compiler specific options
-    """
+    init_flags = [Flag("-c"), Flag("-fsyntax-only")]
 
     def errors_from_output(self, output):
         """
@@ -29,22 +34,18 @@ class CompilerVariant(object):
 
 
 class ClangCompilerVariant(CompilerVariant):
-    """
-    Encapsulation of clang/clang++ specific options
+    """Encapsulation of clang/clang++ specific options.
 
     Attributes:
-        init_flags (list): flags that every command needs
         error_regex (re): regex to find contents of an error
     """
-    init_flags = ["-c", "-fsyntax-only", "-x", "c++"]
     include_prefixes = ["-isystem", "-I", "-isysroot"]
     error_regex = re.compile("(?P<file>.*)" +
                              ":(?P<row>\d+):(?P<col>\d+)" +
                              ":\s*.*error: (?P<error>.*)")
 
     def errors_from_output(self, output):
-        """
-        Parse errors received from clang binary output
+        """Parse errors received from clang binary output.
 
         Args:
             view (sublime.View): current view
@@ -64,14 +65,11 @@ class ClangCompilerVariant(CompilerVariant):
 
 
 class ClangClCompilerVariant(ClangCompilerVariant):
-    """
-    Encapsulation of clang-cl specific options
+    """Encapsulation of clang-cl specific options.
 
     Attributes:
-        init_flags (list): flags that every command needs
         error_regex (re): regex to find contents of an error
     """
-    init_flags = ["-c", "-fsyntax-only"]
     include_prefixes = ["-I", "/I", "-msvc", "/msvc"]
     error_regex = re.compile("(?P<file>.*)" +
                              "\((?P<row>\d+),(?P<col>\d+)\)\s*" +
@@ -79,8 +77,7 @@ class ClangClCompilerVariant(ClangCompilerVariant):
 
 
 class LibClangCompilerVariant(ClangCompilerVariant):
-    """
-    Encapsulation of libclang specific options
+    """Encapsulation of libclang specific options.
 
     Attributes:
         pos_regex (re): regex to find position of an error
@@ -92,8 +89,9 @@ class LibClangCompilerVariant(ClangCompilerVariant):
     msg_regex = re.compile('[b\"|\"]*(?P<error>[^"]+)\"*')
 
     def errors_from_output(self, output):
-        """Parse errors received from diagnostics of a translation unit (used
-        with libclang)
+        """Parse errors received from diagnostics of a translation unit.
+
+        This is used with libclang.
 
         Args:
             output (diagnostics): diagnostics from a translation unit

--- a/plugin/flags_sources/compilation_db.py
+++ b/plugin/flags_sources/compilation_db.py
@@ -8,6 +8,7 @@ from ..tools import File
 from ..tools import SearchScope
 from ..tools import singleton
 from ..utils.unique_list import UniqueList
+from ..utils.flag import Flag
 
 from os import path
 
@@ -107,6 +108,7 @@ class CompilationDb(FlagsSource):
         """
         import json
         data = None
+
         with open(database_file.full_path()) as data_file:
             data = json.load(data_file)
         if not data:
@@ -117,9 +119,10 @@ class CompilationDb(FlagsSource):
         for entry in data:
             file_path = path.splitext(path.normpath(entry['file']))[0]
             command_as_list = CompilationDb.line_as_list(entry['command'])
-            flags = FlagsSource.parse_flags(database_file.folder(),
-                                            command_as_list,
-                                            self._include_prefixes)
+            flags_str_list = FlagsSource.parse_flags(database_file.folder(),
+                                                     command_as_list,
+                                                     self._include_prefixes)
+            flags = Flag.tokenize_list(flags_str_list)
             # set these flags for current file
             parsed_db[file_path] = flags
             # also maintain merged flags

--- a/plugin/flags_sources/compilation_db.py
+++ b/plugin/flags_sources/compilation_db.py
@@ -8,7 +8,6 @@ from ..tools import File
 from ..tools import SearchScope
 from ..tools import singleton
 from ..utils.unique_list import UniqueList
-from ..utils.flag import Flag
 
 from os import path
 
@@ -119,10 +118,9 @@ class CompilationDb(FlagsSource):
         for entry in data:
             file_path = path.splitext(path.normpath(entry['file']))[0]
             command_as_list = CompilationDb.line_as_list(entry['command'])
-            flags_str_list = FlagsSource.parse_flags(database_file.folder(),
-                                                     command_as_list,
-                                                     self._include_prefixes)
-            flags = Flag.tokenize_list(flags_str_list)
+            flags = FlagsSource.parse_flags(database_file.folder(),
+                                            command_as_list,
+                                            self._include_prefixes)
             # set these flags for current file
             parsed_db[file_path] = flags
             # also maintain merged flags

--- a/plugin/flags_sources/flags_file.py
+++ b/plugin/flags_sources/flags_file.py
@@ -7,7 +7,6 @@ from .flags_source import FlagsSource
 from ..tools import File
 from ..tools import SearchScope
 from ..tools import singleton
-from ..utils.flag import Flag
 
 from os import path
 
@@ -69,7 +68,6 @@ class FlagsFile(FlagsSource):
         flags_file_same = File.is_unchanged(cached_flags_path)
         if flags_file_path_same and flags_file_same:
             log.debug(" [clang_complete_file]:[unchanged]: load cached")
-            log.debug(" [clang_complete_file]: cache: %s", self._cache)
             return self._cache[cached_flags_path]
         log.debug(" [clang_complete_file]:[changed]: load new")
         if cached_flags_path and cached_flags_path in self._cache:
@@ -103,5 +101,4 @@ class FlagsFile(FlagsSource):
             content = f.readlines()
             flags = FlagsSource.parse_flags(
                 file.folder(), content, self._include_prefixes)
-            flags = Flag.tokenize_list(flags)
         return flags

--- a/plugin/flags_sources/flags_file.py
+++ b/plugin/flags_sources/flags_file.py
@@ -7,6 +7,7 @@ from .flags_source import FlagsSource
 from ..tools import File
 from ..tools import SearchScope
 from ..tools import singleton
+from ..utils.flag import Flag
 
 from os import path
 
@@ -102,5 +103,5 @@ class FlagsFile(FlagsSource):
             content = f.readlines()
             flags = FlagsSource.parse_flags(
                 file.folder(), content, self._include_prefixes)
-        log.debug(" .clang_complete contains flags: %s", flags)
+            flags = Flag.tokenize_list(flags)
         return flags

--- a/plugin/utils/__init__.py
+++ b/plugin/utils/__init__.py
@@ -1,7 +1,8 @@
 """Useful utils.
 
-  stamped_tu: A translation unit with time of creation.
-  unique_list: A list that guarantees element uniqueness, but saves order.
+stamped_tu: A translation unit with time of creation.
+unique_list: A list that guarantees element uniqueness, but saves order.
+flag: A class that encapsulates a flag that can contain two parts.
 
 """
-__all__ = ["stamped_tu", "unique_list"]
+__all__ = ["stamped_tu", "unique_list", "flag"]

--- a/plugin/utils/flag.py
+++ b/plugin/utils/flag.py
@@ -12,11 +12,11 @@ class Flag:
             part_2 (str, optional): Second part if present.
         """
         if part_2:
-            self.__prefix = part_1
-            self.__body = part_2
+            self.__prefix = part_1.strip()
+            self.__body = part_2.strip()
         else:
             self.__prefix = ""
-            self.__body = part_1
+            self.__body = part_1.strip()
 
     def prefix(self):
         """Prefix of the flag. Empty if not separable."""
@@ -57,7 +57,7 @@ class Flag:
 
         Returns (Flag[]): A list of flags containing two parts if needed.
         """
-        # FIXME(igor): probably need to get it from -help of clang
+        # FIXME(igor): probably need to get it from `clang -help`
         separable_prefixes = ["-I", "/I", "-isystem",
                               "-cxx-isystem", "-F",
                               "-isysroot", "-iprefix", "-x"]
@@ -65,6 +65,8 @@ class Flag:
         flags = []
         skip = False
         for i, entry in enumerate(all_split_line):
+            if entry.startswith("#"):
+                continue
             if skip:
                 skip = False
                 continue

--- a/plugin/utils/flag.py
+++ b/plugin/utils/flag.py
@@ -49,16 +49,19 @@ class Flag:
         return self.__prefix == other.prefix() and self.__body == other.body()
 
     @staticmethod
-    def tokenize_list(all_split_line, separable_prefixes):
+    def tokenize_list(all_split_line):
         """Find flags, that need to be separated and separate them.
 
         Args:
             all_split_line (str[]): A list of all flags split.
-            separable_prefixes (str[]): A list of all prefixes that require
-                separation from the body.
 
         Returns (Flag[]): A list of flags containing two parts if needed.
         """
+        # FIXME(igor): probably need to get it from -help of clang
+        separable_prefixes = ["-I", "/I", "-isystem",
+                              "-cxx-isystem", "-F",
+                              "-isysroot", "-iprefix", "-x"]
+
         flags = []
         skip = False
         for i in range(len(all_split_line)):

--- a/plugin/utils/flag.py
+++ b/plugin/utils/flag.py
@@ -38,6 +38,12 @@ class Flag:
             return self.__prefix + " " + self.__body
         return self.__body
 
+    def __repr__(self):
+        """Return flag as a printable string."""
+        if self.__prefix:
+            return '({}, {})'.format(self.__prefix, self.__body)
+        return '({})'.format(self.__body)
+
     def __hash__(self):
         """Compute a hash of a flag."""
         if self.__prefix:

--- a/plugin/utils/flag.py
+++ b/plugin/utils/flag.py
@@ -64,14 +64,14 @@ class Flag:
 
         flags = []
         skip = False
-        for i in range(len(all_split_line)):
+        for i, entry in enumerate(all_split_line):
             if skip:
                 skip = False
                 continue
-            if all_split_line[i] in separable_prefixes:
-                # add both parts to a flag
+            if entry in separable_prefixes:
+                # add both this and next part to a flag
                 flags.append(Flag(all_split_line[i], all_split_line[i + 1]))
                 skip = True
                 continue
-            flags.append(Flag(all_split_line[i]))
+            flags.append(Flag(entry))
         return flags

--- a/plugin/utils/flag.py
+++ b/plugin/utils/flag.py
@@ -1,0 +1,74 @@
+"""Wraps a flag class."""
+
+
+class Flag:
+    """Utility class for storing possibly separated flag."""
+
+    def __init__(self, part_1, part_2=None):
+        """Initialize a flag with two parts.
+
+        Args:
+            part_1 (str): First (or only) part of the flag.
+            part_2 (str, optional): Second part if present.
+        """
+        if part_2:
+            self.__prefix = part_1
+            self.__body = part_2
+        else:
+            self.__prefix = ""
+            self.__body = part_1
+
+    def prefix(self):
+        """Prefix of the flag. Empty if not separable."""
+        return self.__prefix
+
+    def body(self):
+        """Body of the flag. Full flag if not separable."""
+        return self.__body
+
+    def as_list(self):
+        """Return flag as list of its parts."""
+        if self.__prefix:
+            return [self.__prefix] + [self.__body]
+        return [self.__body]
+
+    def __str__(self):
+        """Return flag as a string."""
+        if self.__prefix:
+            return self.__prefix + " " + self.__body
+        return self.__body
+
+    def __hash__(self):
+        """Compute a hash of a flag."""
+        if self.__prefix:
+            return hash(self.__prefix + self.__body)
+        return hash(self.__body)
+
+    def __eq__(self, other):
+        """Check if it is equal to another flag."""
+        return self.__prefix == other.prefix() and self.__body == other.body()
+
+    @staticmethod
+    def tokenize_list(all_split_line, separable_prefixes):
+        """Find flags, that need to be separated and separate them.
+
+        Args:
+            all_split_line (str[]): A list of all flags split.
+            separable_prefixes (str[]): A list of all prefixes that require
+                separation from the body.
+
+        Returns (Flag[]): A list of flags containing two parts if needed.
+        """
+        flags = []
+        skip = False
+        for i in range(len(all_split_line)):
+            if skip:
+                skip = False
+                continue
+            if all_split_line[i] in separable_prefixes:
+                # add both parts to a flag
+                flags.append(Flag(all_split_line[i], all_split_line[i + 1]))
+                skip = True
+                continue
+            flags.append(Flag(all_split_line[i]))
+        return flags

--- a/tests/test_clang_complete_file.py
+++ b/tests/test_clang_complete_file.py
@@ -8,15 +8,19 @@ from os import path
 from unittest import TestCase
 
 from EasyClangComplete.plugin.flags_sources import flags_file
+from EasyClangComplete.plugin.utils import flag
 from EasyClangComplete.plugin import tools
 
 imp.reload(flags_file)
 imp.reload(tools)
+imp.reload(flag)
 
 SearchScope = tools.SearchScope
 PKG_NAME = tools.PKG_NAME
 
 FlagsFile = flags_file.FlagsFile
+
+Flag = flag.Flag
 
 
 class TestFlagsFile(TestCase):
@@ -37,7 +41,7 @@ class TestFlagsFile(TestCase):
 
         flags_file = FlagsFile(['-I', '-isystem'])
         flags = flags_file.get_flags(test_file_path)
-        self.assertIn('-std=c++11', flags)
+        self.assertIn(Flag('-std=c++11'), flags)
 
     def test_fail_to_find(self):
         """Test failing to find a .clang_complete file."""

--- a/tests/test_cmake_file.py
+++ b/tests/test_cmake_file.py
@@ -6,17 +6,21 @@ from unittest import TestCase
 
 from EasyClangComplete.plugin.flags_sources import cmake_file
 from EasyClangComplete.plugin.flags_sources import compilation_db
+from EasyClangComplete.plugin.utils import flag
 from EasyClangComplete.plugin import tools
 
 imp.reload(cmake_file)
 imp.reload(compilation_db)
 imp.reload(tools)
+imp.reload(flag)
 
 CMakeFile = cmake_file.CMakeFile
 CompilationDb = compilation_db.CompilationDb
 
 SearchScope = tools.SearchScope
 PKG_NAME = tools.PKG_NAME
+
+Flag = flag.Flag
 
 
 class TestCmakeFile(object):
@@ -36,7 +40,7 @@ class TestCmakeFile(object):
         expected_lib = path.join(path_to_cmake_proj, 'lib')
         flags = cmake_file.get_flags(test_file_path)
         self.assertEqual(len(flags), 1)
-        self.assertEqual(flags[0], '-I' + expected_lib)
+        self.assertEqual(flags[0], Flag('-I' + expected_lib))
         self.assertIn(test_file_path, cmake_file._cache)
         expected_cmake_file = path.join(
             path_to_cmake_proj, CMakeFile._FILE_NAME)
@@ -49,13 +53,13 @@ class TestCmakeFile(object):
             path.dirname(__file__), 'cmake_tests', 'lib', 'a.h')
 
         path_to_file_folder = path.dirname(test_file_path)
-        expected_lib_include = '-I' + path_to_file_folder
+        expected_lib_include = Flag('-I' + path_to_file_folder)
         cmake_file = CMakeFile(['-I', '-isystem'], [])
         flags = cmake_file.get_flags(test_file_path)
         db = CompilationDb(['-I', '-isystem'])
         self.assertEqual(len(flags), 2)
-        self.assertEqual(flags[0], '-Dliba_EXPORTS')
-        self.assertEqual(flags[1], '-fPIC')
+        self.assertEqual(flags[0], Flag('-Dliba_EXPORTS'))
+        self.assertEqual(flags[1], Flag('-fPIC'))
         self.assertIn(test_file_path, cmake_file._cache)
         expected_cmake_file = path.join(
             path.dirname(path_to_file_folder), CMakeFile._FILE_NAME)

--- a/tests/test_compilation_db.py
+++ b/tests/test_compilation_db.py
@@ -5,12 +5,15 @@ from unittest import TestCase
 
 from EasyClangComplete.plugin.flags_sources import compilation_db
 from EasyClangComplete.plugin import tools
+from EasyClangComplete.plugin.utils import flag
 
 imp.reload(compilation_db)
 imp.reload(tools)
+imp.reload(flag)
 
 CompilationDb = compilation_db.CompilationDb
 SearchScope = tools.SearchScope
+Flag = flag.Flag
 
 
 class TestCompilationDb(TestCase):
@@ -21,9 +24,9 @@ class TestCompilationDb(TestCase):
         include_prefixes = ['-I']
         db = CompilationDb(include_prefixes)
 
-        expected = ['-I' + path.normpath('/lib_include_dir'),
-                    '-Dlib_EXPORTS',
-                    '-fPIC']
+        expected = [Flag('-I' + path.normpath('/lib_include_dir')),
+                    Flag('-Dlib_EXPORTS'),
+                    Flag('-fPIC')]
         path_to_db = path.join(path.dirname(__file__),
                                'compilation_db_files',
                                'linux')
@@ -35,8 +38,8 @@ class TestCompilationDb(TestCase):
         include_prefixes = ['-I']
         db = CompilationDb(include_prefixes)
 
-        expected_lib = ['-Dlib_EXPORTS', '-fPIC']
-        expected_main = ['-I' + path.normpath('/lib_include_dir')]
+        expected_lib = [Flag('-Dlib_EXPORTS'), Flag('-fPIC')]
+        expected_main = [Flag('-I' + path.normpath('/lib_include_dir'))]
         lib_file_path = path.normpath('/home/user/dummy_lib.cpp')
         main_file_path = path.normpath('/home/user/dummy_main.cpp')
         # also try to test a header
@@ -78,8 +81,8 @@ class TestCompilationDb(TestCase):
         include_prefixes = ['-I']
         db = CompilationDb(include_prefixes)
 
-        expected_lib = ['-Dlib_EXPORTS', '-fPIC']
-        expected_main = ['-I' + path.normpath('/lib_include_dir')]
+        expected_lib = [Flag('-Dlib_EXPORTS'), Flag('-fPIC')]
+        expected_main = [Flag('-I' + path.normpath('/lib_include_dir'))]
         lib_file_path = path.normpath('/home/user/dummy_lib.cpp')
         main_file_path = path.normpath('/home/user/dummy_main.cpp')
         path_to_db = path.join(path.dirname(__file__),

--- a/tests/test_flag.py
+++ b/tests/test_flag.py
@@ -1,0 +1,59 @@
+"""Tests for flag class."""
+import imp
+from unittest import TestCase
+
+from EasyClangComplete.plugin.utils import flag
+
+imp.reload(flag)
+
+Flag = flag.Flag
+
+
+class TestFlag(TestCase):
+    """Test getting flags from CMakeLists.txt."""
+
+    def test_init(self):
+        """Initialization test."""
+        flag = Flag("hello")
+        self.assertEqual(flag.as_list(), ["hello"])
+        self.assertEqual(flag.prefix(), "")
+        self.assertEqual(flag.body(), "hello")
+        self.assertEqual(str(flag), "hello")
+        flag = Flag("hello", "world")
+        self.assertEqual(flag.as_list(), ["hello", "world"])
+        self.assertEqual(flag.prefix(), "hello")
+        self.assertEqual(flag.body(), "world")
+        self.assertEqual(str(flag), "hello world")
+
+    def test_hash(self):
+        """Test that hash is always the same when needed."""
+        flag1 = Flag("hello", "world")
+        flag2 = Flag("hello", "world")
+        flag3 = Flag("world", "hello")
+        self.assertEqual(hash(flag1), hash(flag2))
+        self.assertNotEqual(hash(flag1), hash(flag3))
+
+    def test_put_into_container(self):
+        """Test adding to hashed container."""
+        flags_set = set()
+        flag1 = Flag("hello")
+        flag2 = Flag("world")
+        flag3 = Flag("hello", "world")
+        flag4 = Flag("world", "hello")
+        flags_set.add(flag1)
+        flags_set.add(flag2)
+        flags_set.add(flag3)
+        self.assertIn(flag1, flags_set)
+        self.assertIn(flag2, flags_set)
+        self.assertIn(flag3, flags_set)
+        self.assertNotIn(flag4, flags_set)
+
+    def test_tokenize(self):
+        """Test tokenizing a list of all split flags."""
+        split_str = ["-I", "hello", "-Iblah", "-isystem", "world"]
+        prefixes = ["-I", "-isystem"]
+        list_of_flags = Flag.tokenize_list(split_str, prefixes)
+        self.assertTrue(len(list_of_flags), 3)
+        self.assertIn(Flag("-I", "hello"), list_of_flags)
+        self.assertIn(Flag("-Iblah"), list_of_flags)
+        self.assertIn(Flag("-isystem", "world"), list_of_flags)

--- a/tests/test_flag.py
+++ b/tests/test_flag.py
@@ -51,8 +51,7 @@ class TestFlag(TestCase):
     def test_tokenize(self):
         """Test tokenizing a list of all split flags."""
         split_str = ["-I", "hello", "-Iblah", "-isystem", "world"]
-        prefixes = ["-I", "-isystem"]
-        list_of_flags = Flag.tokenize_list(split_str, prefixes)
+        list_of_flags = Flag.tokenize_list(split_str)
         self.assertTrue(len(list_of_flags), 3)
         self.assertIn(Flag("-I", "hello"), list_of_flags)
         self.assertIn(Flag("-Iblah"), list_of_flags)

--- a/tests/test_flags_source.py
+++ b/tests/test_flags_source.py
@@ -3,7 +3,6 @@ import imp
 from os import path
 from unittest import TestCase
 
-from EasyClangComplete.plugin.flags_sources import cmake_file
 from EasyClangComplete.plugin.flags_sources import flags_source
 from EasyClangComplete.plugin.utils import flag
 

--- a/tests/test_flags_source.py
+++ b/tests/test_flags_source.py
@@ -1,0 +1,47 @@
+"""Tests for cmake database generation."""
+import imp
+from os import path
+from unittest import TestCase
+
+from EasyClangComplete.plugin.flags_sources import cmake_file
+from EasyClangComplete.plugin.flags_sources import flags_source
+from EasyClangComplete.plugin.utils import flag
+
+imp.reload(flags_source)
+imp.reload(flag)
+
+FlagsSource = flags_source.FlagsSource
+Flag = flag.Flag
+
+
+class TestFlagsSource(TestCase):
+    """Test getting flags from a list of chunks."""
+
+    def test_init(self):
+        """Initialization test."""
+        include_prefixes = ["-I", "-isystem"]
+        flags_source = FlagsSource(include_prefixes)
+        self.assertEqual(flags_source._include_prefixes, include_prefixes)
+
+    def test_parse_flags(self):
+        """Initialization test."""
+        include_prefixes = ["-I", "-isystem"]
+        current_folder = path.dirname(__file__)
+        initial_str_flags = ["-I", current_folder, "-I" + current_folder,
+                             "-isystem", current_folder, "-std=c++11",
+                             "#simulate a comment",
+                             "-Iblah\n", "-I", "blah"]
+        flags = FlagsSource.parse_flags(
+            current_folder, initial_str_flags, include_prefixes)
+        expected_blah_path = path.join(current_folder, "blah")
+        self.assertEqual(len(flags), 6)
+        self.assertIn(Flag("-I", current_folder), flags)
+        self.assertIn(Flag("-I" + current_folder), flags)
+        self.assertIn(Flag("-isystem", current_folder), flags)
+        self.assertIn(Flag("-I", expected_blah_path), flags)
+        self.assertIn(Flag("-I" + expected_blah_path), flags)
+        self.assertIn(Flag("-std=c++11"), flags)
+
+        self.assertNotIn(Flag("-Iblah"), flags)
+        self.assertNotIn(Flag("-I", "blah"), flags)
+        self.assertNotIn(Flag("-isystem" + current_folder), flags)


### PR DESCRIPTION
- added Flag class
- moving settings for c++ and c to preferences as opposed to hardcoding them in compiler variant class
- use Flag wrapper class to disambiguate flag prefixes

Still need to do some cleanups and cleanup the mess in base_compeleter. Every method that does something with flags should return Flag instances from now on instead. This way we won't need to do all the processing in the base completer.