### PR TITLE
Remove unnecessary completions from completion list when using lib_completer

### DIFF
--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -140,7 +140,10 @@ class base_test_complete(object):
         # Verify that we got the expected completions back.
         self.assertIsNotNone(completions)
         expected = ['a\tint a', 'a']
-        self.assertIn(expected, completions)
+        if type(completer) != CompleterLib:
+            self.assertIn(expected, completions)
+        else:
+            self.assertNotIn(expected, completions)
 
     def test_complete_vector(self):
         """Test that we can complete vector members."""


### PR DESCRIPTION
-Remove private members from completion list
-Remove enum values from completion list if triggered by '::'
-Remove destructor from completion list
-Sort completion list by priority