### PR TITLE
Remove unnecessary completions from completion list when using lib_complete

### DIFF
--- a/plugin/completion/lib_complete.py
+++ b/plugin/completion/lib_complete.py
@@ -83,10 +83,9 @@ class Completer(BaseCompleter):
             log.debug(
                 " using bundled cindex: %s", cindex_module_name)
             cindex = importlib.import_module(cindex_module_name)
-
-            Completer.ignore_list.append(cindex.CursorKind.DESTRUCTOR)
-            Completer.ignore_list.append(cindex.CursorKind.CLASS_DECL)
-            Completer.ignore_list.append(cindex.CursorKind.ENUM_CONSTANT_DECL)
+            Completer.ignore_list = [cindex.CursorKind.DESTRUCTOR,
+                                     cindex.CursorKind.CLASS_DECL,
+                                     cindex.CursorKind.ENUM_CONSTANT_DECL]
 
             # load clang helper class
             clang_utils = importlib.import_module(clang_utils_module_name)

--- a/plugin/completion/lib_complete.py
+++ b/plugin/completion/lib_complete.py
@@ -343,9 +343,9 @@ class Completer(BaseCompleter):
         """
         completions = []
         if trigger != "::":
-            excluded = Completer.ignore_list[:-1]
-        else:
             excluded = Completer.ignore_list
+        else:
+            excluded = Completer.ignore_list[:-1]
 
         sorted_results = sorted(complete_results.results,
                                 key=lambda x: x.string.priority)

--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -128,8 +128,8 @@ class base_test_complete(object):
         self.assertTrue(completer.exists_for_view(self.view.buffer_id()))
 
         # Check the current cursor position is completable.
-        self.assertEqual(self.getRow(5), "  a.")
-        pos = self.view.text_point(5, 4)
+        self.assertEqual(self.getRow(8), "  a.")
+        pos = self.view.text_point(8, 4)
         current_word = self.view.substr(self.view.word(pos))
         self.assertEqual(current_word, ".\n")
 
@@ -144,6 +144,56 @@ class base_test_complete(object):
             self.assertIn(expected, completions)
         else:
             self.assertNotIn(expected, completions)
+
+    def test_excluded_private(self):
+        """Test autocompletion for user type."""
+        self.setUpView(path.join('test_files', 'test.cpp'))
+
+        completer = self.setUpCompleter()
+        self.assertTrue(completer.exists_for_view(self.view.buffer_id()))
+
+        # Check the current cursor position is completable.
+        self.assertEqual(self.getRow(8), "  a.")
+        pos = self.view.text_point(8, 4)
+        current_word = self.view.substr(self.view.word(pos))
+        self.assertEqual(current_word, ".\n")
+
+        # Load the completions.
+        request = CompletionRequest(self.view, pos)
+        (_, completions) = completer.complete(request)
+
+        # Verify that we got the expected completions back.
+        self.assertIsNotNone(completions)
+        expected = ['foo\tvoid foo(double a)', 'foo(${1:double a})']
+        unexpected = ['foo\tvoid foo(int a)', 'foo(${1:int a})']
+        if isinstance(completer, CompleterLib):
+            self.assertIn(expected, completions)
+            self.assertNotIn(unexpected, completions)
+
+    def test_excluded_destructor(self):
+        """Test autocompletion for user type."""
+        self.setUpView(path.join('test_files', 'test.cpp'))
+
+        completer = self.setUpCompleter()
+        self.assertTrue(completer.exists_for_view(self.view.buffer_id()))
+
+        # Check the current cursor position is completable.
+        self.assertEqual(self.getRow(8), "  a.")
+        pos = self.view.text_point(8, 4)
+        current_word = self.view.substr(self.view.word(pos))
+        self.assertEqual(current_word, ".\n")
+
+        # Load the completions.
+        request = CompletionRequest(self.view, pos)
+        (_, completions) = completer.complete(request)
+
+        # Verify that we got the expected completions back.
+        self.assertIsNotNone(completions)
+        destructor = ['~A\tvoid ~A()', '~A()']
+        if isinstance(completer, CompleterLib):
+            self.assertNotIn(destructor, completions)
+        else:
+            self.assertIn(destructor, completions)
 
     def test_complete_vector(self):
         """Test that we can complete vector members."""

--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -140,7 +140,10 @@ class base_test_complete(object):
         # Verify that we got the expected completions back.
         self.assertIsNotNone(completions)
         expected = ['a\tint a', 'a']
-        self.assertIn(expected, completions)
+        if type(completer) != CompleterLib:
+            self.assertIn(expected, completions)
+        else:
+            self.assertNotIn(expected, completions)
 
     def test_complete_vector(self):
         """Test that we can complete vector members."""

--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -140,7 +140,7 @@ class base_test_complete(object):
         # Verify that we got the expected completions back.
         self.assertIsNotNone(completions)
         expected = ['a\tint a', 'a']
-        if type(completer) != CompleterLib:
+        if isinstance(completer, CompleterBin):
             self.assertIn(expected, completions)
         else:
             self.assertNotIn(expected, completions)

--- a/tests/test_files/test.cpp
+++ b/tests/test_files/test.cpp
@@ -1,5 +1,8 @@
 class A {
   int a;
+  void foo(int a);
+public:
+  void foo(double a);
 };
 int main(int argc, char const *argv[]) {
   A a;


### PR DESCRIPTION
Not sure what to write :(
-Remove private members from completion list
-Remove enum values from completion list if triggered by '::'
-Remove destructor from completion list
-Sort completion list by priority
