### PR TITLE
fix #167

### DIFF
--- a/plugin/flags_sources/compilation_db.py
+++ b/plugin/flags_sources/compilation_db.py
@@ -54,6 +54,8 @@ class CompilationDb(FlagsSource):
         """
         # prepare search scope
         search_scope = self._update_search_scope(search_scope, file_path)
+        # make sure the file name conforms to standard
+        file_path = File.canonical_path(file_path)
         # remove extension from a file
         if file_path:
             # strip the file path from extension.
@@ -117,7 +119,9 @@ class CompilationDb(FlagsSource):
         parsed_db = {}
         unique_list_of_flags = UniqueList()
         for entry in data:
-            file_path = path.splitext(path.normpath(entry['file']))[0]
+            file_path = File.canonical_path(entry['file'],
+                                            database_file.folder())
+            file_path = path.splitext(file_path)[0]
             command_as_list = CompilationDb.line_as_list(entry['command'])
             flags = FlagsSource.parse_flags(database_file.folder(),
                                             command_as_list,

--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -225,6 +225,23 @@ class File:
         return True
 
     @staticmethod
+    def canonical_path(input_path, folder=''):
+        """Return a canonical path of the file.
+
+        Args:
+            input_path (str): path to convert.
+            folder (str, optional): parent folder.
+
+        Returns:
+            str: canonical path
+        """
+        if not input_path:
+            return None
+        if not path.isabs(input_path):
+            input_path = path.join(folder, input_path)
+        return path.normcase(path.normpath(input_path))
+
+    @staticmethod
     def update_mod_time(full_path):
         """Update modification time.
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -6,6 +6,7 @@ Attributes:
 """
 import sublime
 import time
+import platform
 from os import path
 from unittest import TestCase
 
@@ -198,3 +199,33 @@ class test_file(TestCase):
         expected = path.join(parent_folder, 'README.md')
         self.assertTrue(file.loaded())
         self.assertEqual(file.full_path(), expected)
+
+    def test_canonical_path(self):
+        """Test creating canonical path."""
+        if platform.system() == "Windows":
+            original_path = "../hello/world.txt"
+            folder = "D:\\folder"
+            res = File.canonical_path(original_path, folder)
+            self.assertEqual(res, "d:\\hello\\world.txt")
+        else:
+            original_path = "../hello/world.txt"
+            folder = "/folder"
+            res = File.canonical_path(original_path, folder)
+            self.assertEqual(res, "/hello/world.txt")
+
+    def test_canonical_path_absolute(self):
+        """Test creating canonical path."""
+        if platform.system() == "Windows":
+            original_path = "D:\\hello\\world.txt"
+            res = File.canonical_path(original_path)
+            self.assertEqual(res, "d:\\hello\\world.txt")
+        else:
+            original_path = "/hello/world.txt"
+            res = File.canonical_path(original_path)
+            self.assertEqual(res, "/hello/world.txt")
+
+    def test_canonical_path_empty(self):
+        """Test failing for canonical path."""
+        original_path = None
+        res = File.canonical_path(original_path)
+        self.assertIsNone(res)


### PR DESCRIPTION
Add a function to guarantee that the file is always conforming to standard case applying `path.normpath` and `path.normcase`