### PR TITLE
Use proper async thread pool

### DIFF
--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -192,7 +192,11 @@ class EasyClangComplete(sublime_plugin.EventListener):
         if Tools.is_valid_view(view):
             log.debug(" saving view: %s", view.buffer_id())
             settings = self.settings_manager.settings_for_view(view)
-            self.view_config_manager.load_for_view(view, settings)
+            job = ThreadJob(name=EasyClangComplete.UPDATE_JOB_TAG,
+                            callback=EasyClangComplete.config_updated,
+                            function=self.view_config_manager.load_for_view,
+                            args=[view, settings])
+            EasyClangComplete.thread_pool.new_job(job)
 
     def on_close(self, view):
         """Called on closing the view.

--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -13,12 +13,12 @@ import shutil
 import imp
 
 from os import path
-from concurrent import futures
 
 from .plugin import tools
 from .plugin import error_vis
 from .plugin import view_config
 from .plugin import flags_sources
+from .plugin.utils import thread_pool
 from .plugin.settings import settings_manager
 from .plugin.completion import lib_complete
 from .plugin.completion import bin_complete
@@ -30,6 +30,7 @@ imp.reload(error_vis)
 imp.reload(lib_complete)
 imp.reload(bin_complete)
 imp.reload(view_config)
+imp.reload(thread_pool)
 imp.reload(flags_sources)
 
 # some aliases
@@ -40,6 +41,8 @@ Tools = tools.Tools
 PosStatus = tools.PosStatus
 CMakeFile = flags_sources.cmake_file.CMakeFile
 CMakeFileCache = flags_sources.cmake_file.CMakeFileCache
+ThreadPool = thread_pool.ThreadPool
+ThreadJob = thread_pool.ThreadJob
 
 log = logging.getLogger(__name__)
 
@@ -86,10 +89,15 @@ class EasyClangComplete(sublime_plugin.EventListener):
 
     Most of the functionality is delegated.
     """
-    thread_pool = futures.ThreadPoolExecutor(max_workers=4)
+    thread_pool = ThreadPool(max_workers=4)
 
     current_job_id = None
     current_completions = []
+
+    CLEAR_JOB_TAG = "clear"
+    COMPLETE_JOB_TAG = "complete"
+    UPDATE_JOB_TAG = "update"
+    INFO_JOB_TAG = "info"
 
     def __init__(self):
         """Initialize the object."""
@@ -135,7 +143,11 @@ class EasyClangComplete(sublime_plugin.EventListener):
             log.debug(" on_activated_async view id %s", view.buffer_id())
             settings = self.settings_manager.settings_for_view(view)
             # All is taken care of. The view is built if needed.
-            self.view_config_manager.load_for_view(view, settings)
+            job = ThreadJob(name=EasyClangComplete.UPDATE_JOB_TAG,
+                            callback=EasyClangComplete.config_updated,
+                            function=self.view_config_manager.load_for_view,
+                            args=[view, settings])
+            EasyClangComplete.thread_pool.new_job(job)
 
     def on_selection_modified(self, view):
         """Called when selection is modified. Executed in gui thread.
@@ -193,9 +205,11 @@ class EasyClangComplete(sublime_plugin.EventListener):
             log.debug(" closing view %s", view.buffer_id())
             self.settings_manager.clear_for_view(view)
             file_path = view.buffer_id()
-            future = EasyClangComplete.thread_pool.submit(
-                self.view_config_manager.clear_for_view, file_path)
-            future.add_done_callback(EasyClangComplete.config_removed)
+            job = ThreadJob(name=EasyClangComplete.CLEAR_JOB_TAG,
+                            callback=EasyClangComplete.config_removed,
+                            function=self.view_config_manager.clear_for_view,
+                            args=[file_path])
+            EasyClangComplete.thread_pool.new_job(job)
 
     @staticmethod
     def config_removed(future):
@@ -210,6 +224,18 @@ class EasyClangComplete(sublime_plugin.EventListener):
             log.debug(" removed config for id: %s", future.result())
         elif future.cancelled():
             log.debug(" could not remove config -> cancelled")
+
+    @staticmethod
+    def config_updated(future):
+        """Callback called when config has been updated for a view.
+
+        Args:
+            future (concurrent.Future): future holding config of updated view
+        """
+        if future.done():
+            log.debug(" updated config: %s", future.result())
+        elif future.cancelled():
+            log.debug(" could not update config -> cancelled")
 
     @staticmethod
     def on_open_declaration(location):
@@ -289,9 +315,12 @@ class EasyClangComplete(sublime_plugin.EventListener):
         if not view_config:
             return
         self.current_job_id = tooltip_request.get_identifier()
-        future = EasyClangComplete.thread_pool.submit(
-            view_config.completer.info, tooltip_request)
-        future.add_done_callback(self.info_finished)
+
+        job = ThreadJob(name=EasyClangComplete.INFO_JOB_TAG,
+                        callback=self.info_finished,
+                        function=view_config.completer.info,
+                        args=[tooltip_request])
+        EasyClangComplete.thread_pool.new_job(job)
 
     def on_query_completions(self, view, prefix, locations):
         """Function that is called when user queries completions in the code.
@@ -348,9 +377,13 @@ class EasyClangComplete(sublime_plugin.EventListener):
         self.current_job_id = current_pos_id
         log.debug(" starting async auto_complete with id: %s",
                   self.current_job_id)
-        future = EasyClangComplete.thread_pool.submit(
-            view_config.completer.complete, completion_request)
-        future.add_done_callback(self.completion_finished)
+
+        # submit async completion job
+        job = ThreadJob(name=EasyClangComplete.COMPLETE_JOB_TAG,
+                        callback=self.completion_finished,
+                        function=view_config.completer.complete,
+                        args=[completion_request])
+        EasyClangComplete.thread_pool.new_job(job)
 
         # show default completions for now if allowed
         if settings.hide_default_completions:

--- a/plugin/utils/__init__.py
+++ b/plugin/utils/__init__.py
@@ -1,8 +1,8 @@
 """Useful utils.
 
-stamped_tu: A translation unit with time of creation.
 unique_list: A list that guarantees element uniqueness, but saves order.
 flag: A class that encapsulates a flag that can contain two parts.
+thread_pool: A class that encapsulates a thread pool to allow delayed run.
 
 """
-__all__ = ["unique_list", "flag"]
+__all__ = ["unique_list", "flag", "thread_pool"]

--- a/plugin/utils/thread_pool.py
+++ b/plugin/utils/thread_pool.py
@@ -78,6 +78,7 @@ class ThreadPool:
                 log.debug("submitting job: %s", job)
                 future = self.__thread_pool.submit(job.function, *job.args)
                 future.add_done_callback(job.callback)
+            ThreadPool.__jobs_to_run.clear()
 
     def new_job(self, job):
         """Add a new job to be submitted.

--- a/plugin/utils/thread_pool.py
+++ b/plugin/utils/thread_pool.py
@@ -1,6 +1,9 @@
+import logging
 from concurrent import futures
 from threading import Timer
 from threading import RLock
+
+log = logging.getLogger(__name__)
 
 
 class ThreadJob:
@@ -38,7 +41,8 @@ class ThreadPool:
     def submit_jobs(self):
         with ThreadPool.__lock:
             for job in ThreadPool.__jobs_to_run.values():
-                future = self.__thread_pool.submit(job.function, job.args)
+                log.debug("submitting job: %s", job)
+                future = self.__thread_pool.submit(job.function, *job.args)
                 future.add_done_callback(job.callback)
 
     def new_job(self, job):

--- a/plugin/utils/thread_pool.py
+++ b/plugin/utils/thread_pool.py
@@ -1,3 +1,8 @@
+"""This file defines a class for managing a thread pool with delayed execution.
+
+Attributes:
+    log (logging.Logger): Logger for current module.
+"""
 import logging
 from concurrent import futures
 from threading import Timer
@@ -7,38 +12,67 @@ log = logging.getLogger(__name__)
 
 
 class ThreadJob:
-    """docstring for ThreadJob"""
+    """A class for a job that can be submitted to ThreadPool.
+
+    Attributes:
+        name (str): Name of this job.
+        callback (func): Function to use as callback.
+        function (func): Function to run asyncronously.
+        args (object[]): Sequence of additional arguments for `function`.
+    """
 
     def __init__(self, name, callback, function, args):
+        """Initialize a job.
+
+        Args:
+            name (str): Name of this job.
+            callback (func): Function to use as callback.
+            function (func): Function to run asyncronously.
+            args (object[]): Sequence of additional arguments for `function`.
+        """
         self.name = name
         self.callback = callback
         self.function = function
         self.args = args
 
     def __repr__(self):
+        """Representation."""
         return "job: '{name}', args: ({args})".format(
             name=self.name, args=self.args)
 
 
 class ThreadPool:
-    """docstring for ThreadPool"""
+    """Thread pool that makes sure we don't get recurring jobs.
+
+    Whenever a job is submitted to this pool, the pool waits for a specified
+    amount of time before actually submitting the job to an async pool of
+    threads. Therefore we avoid running similar jobs over and over again.
+    """
 
     __lock = RLock()
     __jobs_to_run = {}
 
     def __init__(self, max_workers, run_delay=0.05):
+        """Create a thread pool.
+
+        Args:
+            max_workers (int): Maximum number of parallel workers.
+            run_delay (float, optional): Time of delay in seconds.
+        """
         self.__timer = None
         self.__delay = run_delay
         self.__thread_pool = futures.ThreadPoolExecutor(
             max_workers=max_workers)
 
     def restart_timer(self):
+        """Restart timer because there was a change in jobs."""
         if self.__timer:
             self.__timer.cancel()
         self.__timer = Timer(self.__delay, self.submit_jobs)
         self.__timer.start()
 
     def submit_jobs(self):
+        """Submit jobs that survived the delay."""
         with ThreadPool.__lock:
             for job in ThreadPool.__jobs_to_run.values():
                 log.debug("submitting job: %s", job)
@@ -46,6 +80,11 @@ class ThreadPool:
                 future.add_done_callback(job.callback)
 
     def new_job(self, job):
+        """Add a new job to be submitted.
+
+        Args:
+            job (ThreadJob): A job to be run asyncronously.
+        """
         with ThreadPool.__lock:
             ThreadPool.__jobs_to_run[job.name] = job
             self.restart_timer()

--- a/plugin/utils/thread_pool.py
+++ b/plugin/utils/thread_pool.py
@@ -1,0 +1,47 @@
+from concurrent import futures
+from threading import Timer
+from threading import RLock
+
+
+class ThreadJob:
+    """docstring for ThreadJob"""
+
+    def __init__(self, name, callback, function, args):
+        self.name = name
+        self.callback = callback
+        self.function = function
+        self.args = args
+
+    def __repr__(self):
+        return "job: '{name}', args: ({args})".format(
+            name=self.name, args=self.args)
+
+
+class ThreadPool:
+    """docstring for ThreadPool"""
+
+    __lock = RLock()
+    __jobs_to_run = {}
+
+    def __init__(self, max_workers, run_delay=0.05):
+        self.__timer = None
+        self.__delay = run_delay
+        self.__thread_pool = futures.ThreadPoolExecutor(
+            max_workers=max_workers)
+
+    def restart_timer(self):
+        if self.__timer:
+            self.__timer.cancel()
+        self.__timer = Timer(self.__delay, self.submit_jobs)
+        self.__timer.start()
+
+    def submit_jobs(self):
+        with ThreadPool.__lock:
+            for job in ThreadPool.__jobs_to_run.values():
+                future = self.__thread_pool.submit(job.function, job.args)
+                future.add_done_callback(job.callback)
+
+    def new_job(self, job):
+        with ThreadPool.__lock:
+            ThreadPool.__jobs_to_run[job.name] = job
+            self.restart_timer()

--- a/plugin/view_config.py
+++ b/plugin/view_config.py
@@ -102,10 +102,13 @@ class ViewConfig(object):
             bool: True if update is needed, False otherwise.
         """
         if not self.completer:
+            log.debug("no completer. Need to update.")
             return True
         if completer.name != self.completer.name:
+            log.debug("different completer class. Need to update.")
             return True
         if flags != self.completer.clang_flags:
+            log.debug("different completer flags. Need to update.")
             return True
         log.debug(" view config needs no update.")
         return False

--- a/tests/test_thread_pool.py
+++ b/tests/test_thread_pool.py
@@ -1,7 +1,6 @@
-"""Test compilation database flags generation."""
+"""Test delayed thread pool."""
 import imp
 import time
-from os import path
 from unittest import TestCase
 
 import EasyClangComplete.plugin.utils.thread_pool
@@ -13,6 +12,7 @@ ThreadJob = EasyClangComplete.plugin.utils.thread_pool.ThreadJob
 
 
 def run_me(succeed):
+    """A simple function to run asyncronously."""
     return succeed
 
 
@@ -20,9 +20,11 @@ class test_thread_pool(TestCase):
     """Test thread pool."""
 
     def callback_func(self, future):
+        """Simple callback function to store result."""
         self.last_result = future.result()
 
     def override_func(self, future):
+        """Simple callback function to store overridable result."""
         self.override_result = future.result()
 
     def test_single_job(self):
@@ -30,7 +32,7 @@ class test_thread_pool(TestCase):
         job = ThreadJob(name="test_job",
                         callback=self.callback_func,
                         function=run_me,
-                        args=(True))
+                        args=[True])
         pool = ThreadPool(max_workers=4)
         pool.new_job(job)
         time.sleep(0.2)
@@ -41,7 +43,7 @@ class test_thread_pool(TestCase):
         job = ThreadJob(name="test_job",
                         callback=self.callback_func,
                         function=run_me,
-                        args=(False))
+                        args=[False])
         pool = ThreadPool(max_workers=4)
         pool.new_job(job)
         time.sleep(0.2)
@@ -55,11 +57,11 @@ class test_thread_pool(TestCase):
         job_good = ThreadJob(name="test_job",
                              callback=self.override_func,
                              function=run_me,
-                             args=(True))
+                             args=[True])
         job_bad = ThreadJob(name="test_job",
                             callback=self.override_func,
                             function=run_me,
-                            args=(False))
+                            args=[False])
         pool = ThreadPool(max_workers=4)
         pool.new_job(job_bad)
         pool.new_job(job_good)

--- a/tests/test_thread_pool.py
+++ b/tests/test_thread_pool.py
@@ -1,0 +1,67 @@
+"""Test compilation database flags generation."""
+import imp
+import time
+from os import path
+from unittest import TestCase
+
+import EasyClangComplete.plugin.utils.thread_pool
+
+imp.reload(EasyClangComplete.plugin.utils.thread_pool)
+
+ThreadPool = EasyClangComplete.plugin.utils.thread_pool.ThreadPool
+ThreadJob = EasyClangComplete.plugin.utils.thread_pool.ThreadJob
+
+
+def run_me(succeed):
+    return succeed
+
+
+class test_thread_pool(TestCase):
+    """Test thread pool."""
+
+    def callback_func(self, future):
+        self.last_result = future.result()
+
+    def override_func(self, future):
+        self.override_result = future.result()
+
+    def test_single_job(self):
+        """Test single job."""
+        job = ThreadJob(name="test_job",
+                        callback=self.callback_func,
+                        function=run_me,
+                        args=(True))
+        pool = ThreadPool(max_workers=4)
+        pool.new_job(job)
+        time.sleep(0.2)
+        self.assertTrue(self.last_result)
+
+    def test_fail_job(self):
+        """Test fail job."""
+        job = ThreadJob(name="test_job",
+                        callback=self.callback_func,
+                        function=run_me,
+                        args=(False))
+        pool = ThreadPool(max_workers=4)
+        pool.new_job(job)
+        time.sleep(0.2)
+        self.assertFalse(self.last_result)
+
+    def test_override_job(self):
+        """Test overriding job.
+
+        The first job should be overridden by the next one.
+        """
+        job_good = ThreadJob(name="test_job",
+                             callback=self.override_func,
+                             function=run_me,
+                             args=(True))
+        job_bad = ThreadJob(name="test_job",
+                            callback=self.override_func,
+                            function=run_me,
+                            args=(False))
+        pool = ThreadPool(max_workers=4)
+        pool.new_job(job_bad)
+        pool.new_job(job_good)
+        time.sleep(0.2)
+        self.assertTrue(self.override_result)


### PR DESCRIPTION
Add a new class: a wrapper around a thread pool. Now the jobs that are submitted to it have names and only the last one of them that was submitted in the last time window is executed. This reduces the amount of time the plugin spends compiling code.