### PR TITLE
Fix for issue #207 where the wrong libclang file was being used in linux

### DIFF
--- a/plugin/clang/utils.py
+++ b/plugin/clang/utils.py
@@ -82,7 +82,7 @@ class ClangUtils:
         current_system = platform.system()
         log.debug(" we are on '%s'", platform.system())
         # Get version string for help finding the proper libclang library on Linux
-        if (current_system == "Linux"):
+        if current_system == "Linux":
             version_str = settings_storage.SettingsStorage.CLANG_VERSION[:-2]
         for suffix in ClangUtils.suffixes[current_system]:
             # pick a name for a file

--- a/plugin/clang/utils.py
+++ b/plugin/clang/utils.py
@@ -9,6 +9,7 @@ import subprocess
 import html
 
 from os import path
+from ..settings import settings_storage
 
 log = logging.getLogger(__name__)
 
@@ -37,7 +38,7 @@ class ClangUtils:
     # MSYS2 has `clang.dll` instead of `libclang.dll`
     possible_filenames = {
         'Windows': ['libclang', 'clang'],
-        'Linux': ['libclang'],
+        'Linux': ['libclang-$version', 'libclang'],
         'Darwin': ['libclang']
     }
 
@@ -80,6 +81,9 @@ class ClangUtils:
         log.debug(" python version: %s", platform.python_version())
         current_system = platform.system()
         log.debug(" we are on '%s'", platform.system())
+        # Get version string for help finding the proper libclang library on Linux
+        if (current_system == "Linux"):
+            version_str = settings_storage.SettingsStorage.CLANG_VERSION[:-2]
         for suffix in ClangUtils.suffixes[current_system]:
             # pick a name for a file
             for name in ClangUtils.possible_filenames[current_system]:
@@ -98,7 +102,8 @@ class ClangUtils:
                     startupinfo.wShowWindow = subprocess.SW_HIDE
                     stdin = subprocess.PIPE
                     stderr = subprocess.PIPE
-                else:
+                elif platform.system() == "Linux":
+                    file = file.replace("$version", version_str)
                     get_library_path_cmd = [
                         clang_binary, "-print-file-name={}".format(file)]
                 output = subprocess.check_output(

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -62,6 +62,8 @@ class SettingsStorage:
         "show_type_info",
     ]
 
+    CLANG_VERSION = None
+
     def __init__(self, settings_handle):
         """Initialize settings storage with default settings handle.
 
@@ -235,6 +237,7 @@ class SettingsStorage:
         self.project_name = self._wildcard_values[Wildcards.PROJECT_NAME]
 
         # get clang version string
-        self._wildcard_values[Wildcards.CLANG_VERSION] =\
-            Tools.get_clang_version_str(self.clang_binary)
+        version_str = Tools.get_clang_version_str(self.clang_binary)
+        self._wildcard_values[Wildcards.CLANG_VERSION] = version_str
+        SettingsStorage.CLANG_VERSION = version_str
         self.clang_version = self._wildcard_values[Wildcards.CLANG_VERSION]


### PR DESCRIPTION
Key points:
- I've added a static member to the settings_storage class called "CLANG_VERSION" which will be updated once the version is determined. I did this because it made the least amount of change to the code to give me the version string.
- A field in ClangUtils.possible_filesnames['Linux'] was added which holds a placeholder string. The order of the strings are important since it is the order it will search for them.
- If it doesn't succeed in finding the libclang-x.x.so.1 file then it will continue through the other files names which was the original behaviour. 