### PR TITLE
Fix crash when using clang 4.0 on windows

### DIFF
--- a/plugin/completion/lib_complete.py
+++ b/plugin/completion/lib_complete.py
@@ -201,11 +201,17 @@ class Completer(BaseCompleter):
             try:
                 if not file_name or not path.exists(file_name):
                     raise ValueError("file name does not exist anymore")
+                # It is important to set this option for clang 4.0 as there is
+                # an assert in ASTUnit.cpp that checks if this flag
+                # corresponds to the one that was used for building the
+                # translation unit. As we use it to create the unit, we need
+                # it here too. See issue #230.
                 complete_obj = self.tu.codeComplete(
                     file_name,
                     row, col,
                     unsaved_files=files,
-                    include_macros=True)
+                    include_macros=True,
+                    include_brief_comments=True)
             except Exception as e:
                 log.error(" error while completing view %s: %s", file_name, e)
                 complete_obj = None

--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -17,9 +17,6 @@ def has_libclang():
     Returns:
         str: row contents
     """
-    # HACK: Disable libclang for windows until #230 is fixed
-    if platform.system() == "Windows":
-        return False
     # Older version of Sublime Text x64 have ctypes crash bug.
     if platform.system() == "Windows" and sublime.arch() == "x64" and \
             int(sublime.version()) < 3123:


### PR DESCRIPTION
- the original problem was caused by clang enforsing using flags for
inclusion of brief comments in both: creation of the translation unit
and code completion. We have been doing only the first part.