### PR TITLE
Refactor errors

### DIFF
--- a/plugin/completion/base_complete.py
+++ b/plugin/completion/base_complete.py
@@ -6,7 +6,6 @@ Attributes:
 """
 import logging
 
-from .. import error_vis
 from ..tools import Tools
 
 log = logging.getLogger(__name__)
@@ -16,24 +15,22 @@ class BaseCompleter:
     """A base class for clang based completions.
 
     Attributes:
-        completions (list): current list of completions
-        error_vis (plugin.CompileErrors): object of compile errors class
         compiler_variant (CompilerVariant): compiler specific options
         valid (bool): is completer valid
         version_str (str): version string of format "3.4.0"
+        error_vis (obj): an object of error visualizer
     """
     name = "base"
-    version_str = None
-    error_vis = None
-    compiler_variant = None
 
     valid = False
 
-    def __init__(self, clang_binary, version_str):
+    def __init__(self, clang_binary, version_str, error_vis):
         """Initialize the BaseCompleter.
 
         Args:
-            clang_binary (str): string for clang binary e.g. 'clang-3.6++'
+            clang_binary (str): string for clang binary e.g. 'clang-3.8++'
+            version_str (str): string for clang version e.g. '3.8.0'
+            error_vis (obj): an object of error visualizer
 
         Raises:
             RuntimeError: if clang not defined we throw an error
@@ -43,9 +40,10 @@ class BaseCompleter:
         if not clang_binary:
             raise RuntimeError("clang binary not defined")
 
+        self.compiler_variant = None
         self.version_str = version_str
         # initialize error visualization
-        self.error_vis = error_vis.CompileErrors()
+        self.error_vis = error_vis
 
     def complete(self, completion_request):
         """Function to generate completions. See children for implementation.
@@ -88,7 +86,7 @@ class BaseCompleter:
         """
         raise NotImplementedError("calling abstract method")
 
-    def show_errors(self, view, output, show_phantoms):
+    def show_errors(self, view, output):
         """Show current complie errors.
 
         Args:
@@ -100,4 +98,4 @@ class BaseCompleter:
             log.error(" cannot show errors. View became invalid!")
             return
         self.error_vis.generate(view, errors)
-        self.error_vis.show_regions(view, show_phantoms)
+        self.error_vis.show_errors(view)

--- a/plugin/completion/bin_complete.py
+++ b/plugin/completion/bin_complete.py
@@ -67,16 +67,17 @@ class Completer(BaseCompleter):
 
     opts_regex = re.compile("{#|#}")
 
-    def __init__(self, clang_binary, version_str):
+    def __init__(self, clang_binary, version_str, error_vis):
         """Initialize the Completer.
 
         Args:
             clang_binary (str): string for clang binary e.g. 'clang-3.8++'
             version_str (str): string for clang version e.g. '3.8.0'
+            error_vis (obj): an object of error visualizer
 
         """
         # init common completer interface
-        super().__init__(clang_binary, version_str)
+        super().__init__(clang_binary, version_str, error_vis)
         self.clang_binary = clang_binary
 
         # Create compiler options of specific variant of the compiler.
@@ -152,8 +153,7 @@ class Completer(BaseCompleter):
         log.debug(" rebuilding done in %s seconds", end - start)
 
         if show_errors:
-            self.show_errors(view, output_text,
-                             settings.show_phantoms_for_errors)
+            self.show_errors(view, output_text)
 
     def run_clang_command(self, view, task_type, cursor_pos=0):
         """Construct and run clang command based on task.

--- a/plugin/completion/lib_complete.py
+++ b/plugin/completion/lib_complete.py
@@ -53,7 +53,7 @@ class Completer(BaseCompleter):
     name = "lib"
     rlock = RLock()
 
-    def __init__(self, clang_binary, version_str, libclang_path):
+    def __init__(self, clang_binary, version_str, error_vis, libclang_path):
         """Initialize the Completer from clang binary, reading its version.
 
         Picks an according cindex for the found version.
@@ -61,11 +61,12 @@ class Completer(BaseCompleter):
         Args:
             clang_binary (str): string for clang binary e.g. 'clang++-3.8'
             version_str (str): string for clang version e.g. '3.8.0'
+            error_vis (obj): an object of error visualizer
             libclang_path (str): in case a user knows the path to libclang
                 he can provide it here. Does not have to be valid.
 
         """
-        super().__init__(clang_binary, version_str)
+        super().__init__(clang_binary, version_str, error_vis)
 
         # Create compiler options of specific variant of the compiler.
         self.compiler_variant = LibClangCompilerVariant()
@@ -314,8 +315,7 @@ class Completer(BaseCompleter):
             end = time.time()
             log.debug(" reparsed in %s seconds", end - start)
             if settings.errors_on_save:
-                self.show_errors(view, self.tu.diagnostics,
-                                 settings.show_phantoms_for_errors)
+                self.show_errors(view, self.tu.diagnostics)
             return True
         log.error(" no translation unit for view id %s", v_id)
         return False

--- a/plugin/error_vis/__init__.py
+++ b/plugin/error_vis/__init__.py
@@ -1,0 +1,7 @@
+"""Error visualization module.
+
+phantom_error_vis: Error visualization uses phantoms.
+popup_error_vis: Error visualization uses popups.
+
+"""
+__all__ = ("phantom_error_vis", "popup_error_vis")

--- a/plugin/error_vis/phantom_error_vis.py
+++ b/plugin/error_vis/phantom_error_vis.py
@@ -104,5 +104,6 @@ class PhantomErrorVis(PopupErrorVis):
         # add error to html template
         html_file_path = path.join(
             PopupErrorVis._PATH_TO_HTML_FOLDER, html_file_name)
-        errors_html_mask = Template(open(html_file_path).read())
+        errors_html_mask = Template(
+            open(html_file_path, encoding='utf8').read())
         return errors_html_mask.substitute(content=errors_html)

--- a/plugin/error_vis/phantom_error_vis.py
+++ b/plugin/error_vis/phantom_error_vis.py
@@ -6,11 +6,15 @@ Attributes:
 import logging
 import sublime
 from os import path
+from string import Template
 
 from ..tools import SublBridge
 from .popup_error_vis import PopupErrorVis
+from .popup_error_vis import PATH_TO_HTML_FOLDER
 
 log = logging.getLogger(__name__)
+
+HTML_FILE_PATH = path.join(PATH_TO_HTML_FOLDER, "error_phantom.html")
 
 
 class PhantomErrorVis(PopupErrorVis):
@@ -21,6 +25,8 @@ class PhantomErrorVis(PopupErrorVis):
     """
 
     phantom_sets = {}
+
+    HTML_TEMPLATE = Template(open(HTML_FILE_PATH, encoding='utf8').read())
 
     def show_phantoms(self, view):
         """Show phantoms for compilation errors.
@@ -90,8 +96,6 @@ class PhantomErrorVis(PopupErrorVis):
             errors_dict (dict): Current error
         """
         import cgi
-        from string import Template
-        html_file_name = "error_phantom.html"
         errors_html = ""
         first_error_processed = False
         for entry in errors_dict:
@@ -102,8 +106,4 @@ class PhantomErrorVis(PopupErrorVis):
             errors_html += processed_error
             first_error_processed = True
         # add error to html template
-        html_file_path = path.join(
-            PopupErrorVis._PATH_TO_HTML_FOLDER, html_file_name)
-        errors_html_mask = Template(
-            open(html_file_path, encoding='utf8').read())
-        return errors_html_mask.substitute(content=errors_html)
+        return PhantomErrorVis.HTML_TEMPLATE.substitute(content=errors_html)

--- a/plugin/error_vis/phantom_error_vis.py
+++ b/plugin/error_vis/phantom_error_vis.py
@@ -1,0 +1,108 @@
+"""Module for compile error visualization.
+
+Attributes:
+    log (logging): this module logger
+"""
+import logging
+import sublime
+from os import path
+
+from ..tools import SublBridge
+from .popup_error_vis import PopupErrorVis
+
+log = logging.getLogger(__name__)
+
+
+class PhantomErrorVis(PopupErrorVis):
+    """A class for compile error visualization with phantoms.
+
+    Attributes:
+        phantom_sets (dict): dictionary of phantom sets for view ids
+    """
+
+    phantom_sets = {}
+
+    def show_phantoms(self, view):
+        """Show phantoms for compilation errors.
+
+        Args:
+            view (sublime.View): current view
+        """
+        view.erase_phantoms(PopupErrorVis._TAG)
+        if view.buffer_id() not in self.phantom_sets:
+            phantom_set = sublime.PhantomSet(view, PopupErrorVis._TAG)
+            self.phantom_sets[view.buffer_id()] = phantom_set
+        else:
+            phantom_set = self.phantom_sets[view.buffer_id()]
+        phantoms = []
+        current_error_dict = self.err_regions[view.buffer_id()]
+        for err in current_error_dict:
+            errors_dict = current_error_dict[err]
+            errors_html = PhantomErrorVis._as_phantom_html(errors_dict)
+            pt = view.text_point(err - 1, 1)
+            phantoms.append(sublime.Phantom(
+                sublime.Region(pt, view.line(pt).b),
+                errors_html,
+                sublime.LAYOUT_BELOW,
+                on_navigate=self._on_phantom_navigate))
+        phantom_set.update(phantoms)
+
+    def show_errors(self, view):
+        """Show current error regions as phantoms.
+
+        We rely on the parent to generate highlights and will just add the
+        phantoms on top of them.
+
+        Args:
+            view (sublime.View): Current view
+        """
+        super().show_errors(view)
+        self.show_phantoms(view)
+
+    def show_popup_if_needed(self, view, row):
+        """We override an implementation from popup class here with empty one.
+
+        Args:
+            view (sublime.View): current view
+            row (int): number of row
+        """
+        log.debug(" not showing popup as we use phantoms")
+
+    def clear(self, view):
+        """Clear errors from dict for view.
+
+        Args:
+            view (sublime.View): current view
+        """
+        super().clear(view)
+        SublBridge.erase_phantoms(PopupErrorVis._TAG)
+
+    @staticmethod
+    def _on_phantom_navigate(self):
+        """Close all phantoms in active view."""
+        SublBridge.erase_phantoms(PopupErrorVis._TAG)
+
+    @staticmethod
+    def _as_phantom_html(errors_dict):
+        """Get error as html for phantom.
+
+        Args:
+            errors_dict (dict): Current error
+        """
+        import cgi
+        from string import Template
+        html_file_name = "error_phantom.html"
+        errors_html = ""
+        first_error_processed = False
+        for entry in errors_dict:
+            processed_error = cgi.escape(entry['error'])
+            processed_error = processed_error.replace(' ', '&nbsp;')
+            if first_error_processed:
+                processed_error = '<br>' + processed_error
+            errors_html += processed_error
+            first_error_processed = True
+        # add error to html template
+        html_file_path = path.join(
+            PopupErrorVis._PATH_TO_HTML_FOLDER, html_file_name)
+        errors_html_mask = Template(open(html_file_path).read())
+        return errors_html_mask.substitute(content=errors_html)

--- a/plugin/html/error_phantom.html
+++ b/plugin/html/error_phantom.html
@@ -1,0 +1,34 @@
+<body id="ecc_phantom_error">
+    <style>
+        div.error {
+            padding: 0.4rem 0 0.4rem 0.7rem;
+            margin: 0.2rem 0;
+            border-radius: 2px;
+        }
+
+        div.error span.message {
+            padding-right: 0.7rem;
+        }
+
+        div.error a {
+            text-decoration: inherit;
+            padding: 0.35rem 0.7rem 0.45rem 0.8rem;
+            position: relative;
+            bottom: 0.05rem;
+            border-radius: 0 2px 2px 0;
+            font-weight: bold;
+        }
+        html.dark div.error a {
+            color: #CCCCCC;
+        }
+        html.light div.error a {
+            color: #222222;
+        }
+    </style>
+    <div class="error">
+      <span class="message">
+      $content
+      </span>
+      <a href=hide>❌</a>
+    </div>
+</body>

--- a/plugin/html/error_popup.html
+++ b/plugin/html/error_popup.html
@@ -1,0 +1,10 @@
+<body id="ecc_popup_error">
+    <style>
+        html {
+            background-color: #883333;
+            color: #EEEEEE;
+        }
+    </style>
+    <b>Error:</b>
+    $content
+</body>

--- a/plugin/html/warning_popup.html
+++ b/plugin/html/warning_popup.html
@@ -1,0 +1,10 @@
+<body id="ecc_popup_warning">
+    <style>
+        html {
+            background-color: #886622;
+            color: #EEEEEE;
+        }
+    </style>
+    <b>Warning:</b>
+    $content
+</body>

--- a/plugin/view_config.py
+++ b/plugin/view_config.py
@@ -20,6 +20,9 @@ from .utils.unique_list import UniqueList
 from .completion import lib_complete
 from .completion import bin_complete
 
+from .error_vis.phantom_error_vis import PhantomErrorVis
+from .error_vis.popup_error_vis import PopupErrorVis
+
 from .flags_sources.flags_file import FlagsFile
 from .flags_sources.cmake_file import CMakeFile
 from .flags_sources.flags_source import FlagsSource
@@ -251,11 +254,15 @@ class ViewConfig(object):
         Returns:
             Completer: A completer. Can be lib completer or bin completer.
         """
+        error_vis = PopupErrorVis()
+        if settings.show_phantoms_for_errors:
+            error_vis = PhantomErrorVis()
         completer = None
         if settings.use_libclang:
             log.info(" init completer based on libclang")
             completer = lib_complete.Completer(settings.clang_binary,
                                                settings.clang_version,
+                                               error_vis,
                                                settings.libclang_path)
             if not completer.valid:
                 log.error(" cannot initialize completer with libclang.")
@@ -264,7 +271,8 @@ class ViewConfig(object):
         if not completer:
             log.info(" init completer based on clang from cmd")
             completer = bin_complete.Completer(settings.clang_binary,
-                                               settings.clang_version)
+                                               settings.clang_version,
+                                               error_vis)
         return completer
 
     @staticmethod

--- a/tests/test_error_vis.py
+++ b/tests/test_error_vis.py
@@ -1,0 +1,130 @@
+"""Tests for error visualizer."""
+import imp
+from os import path
+
+from EasyClangComplete.plugin.error_vis import popup_error_vis
+from EasyClangComplete.plugin.error_vis import phantom_error_vis
+from EasyClangComplete.plugin.settings import settings_manager
+from EasyClangComplete.plugin import view_config
+
+from EasyClangComplete.tests import gui_test_wrapper
+
+imp.reload(gui_test_wrapper)
+imp.reload(popup_error_vis)
+imp.reload(phantom_error_vis)
+imp.reload(settings_manager)
+imp.reload(view_config)
+
+PopupErrorVis = popup_error_vis.PopupErrorVis
+PhantomErrorVis = phantom_error_vis.PhantomErrorVis
+GuiTestWrapper = gui_test_wrapper.GuiTestWrapper
+SettingsManager = settings_manager.SettingsManager
+ViewConfigManager = view_config.ViewConfigManager
+
+PHANTOMS = "phantoms"
+POPUPS = "popups"
+
+
+class TestErrorVis:
+    """Test error visualization."""
+
+    def set_up_completer(self, error_style):
+        """Utility method to set up a completer for the current view.
+
+        Returns:
+            BaseCompleter: completer for the current view.
+        """
+        manager = SettingsManager()
+        settings = manager.settings_for_view(self.view)
+        settings.use_libclang = self.use_libclang
+
+        if error_style == PHANTOMS:
+            settings.show_phantoms_for_errors = True
+        else:
+            settings.show_phantoms_for_errors = False
+
+        view_config_manager = ViewConfigManager()
+        view_config = view_config_manager.load_for_view(self.view, settings)
+        completer = view_config.completer
+        return completer
+
+    def tear_down_completer(self):
+        """Utility method to set up a completer for the current view.
+
+        Returns:
+            BaseCompleter: completer for the current view.
+        """
+        view_config_manager = ViewConfigManager()
+        view_config_manager.clear_for_view(self.view.buffer_id())
+
+    def test_phantoms_init(self):
+        """Test that setup view correctly sets up the view."""
+        file_name = path.join(path.dirname(__file__),
+                              'test_files',
+                              'test.cpp')
+        self.set_up_view(file_name)
+        completer = self.set_up_completer(PHANTOMS)
+        completer.error_vis.err_regions = {}
+        self.assertIsNotNone(completer.error_vis)
+        self.assertTrue(isinstance(completer.error_vis, PhantomErrorVis))
+        self.tear_down_completer()
+        self.tear_down()
+
+    def test_popups_init(self):
+        """Test that setup view correctly sets up the view."""
+        file_name = path.join(path.dirname(__file__),
+                              'test_files',
+                              'test.cpp')
+        self.set_up_view(file_name)
+        completer = self.set_up_completer(POPUPS)
+        self.assertIsNotNone(completer.error_vis)
+        self.assertTrue(isinstance(completer.error_vis, PopupErrorVis))
+        self.tear_down_completer()
+        self.tear_down()
+
+    def test_generate_errors(self):
+        """Test that setup view correctly sets up the view."""
+        for err_type in [PHANTOMS, POPUPS]:
+            file_name = path.join(path.dirname(__file__),
+                                  'test_files',
+                                  'test.cpp')
+            self.set_up_view(file_name)
+            completer = self.set_up_completer(err_type)
+            self.assertIsNotNone(completer.error_vis)
+            err_dict = completer.error_vis.err_regions
+            v_id = self.view.buffer_id()
+            self.assertTrue(v_id in err_dict)
+            self.assertEqual(len(err_dict[v_id]), 1)
+            self.assertTrue(10 in err_dict[v_id])
+            self.assertEqual(len(err_dict[v_id][10]), 1)
+            self.assertEqual(err_dict[v_id][10][0]['row'], '10')
+            self.assertEqual(err_dict[v_id][10][0]['col'], '3')
+            expected_error = "expected unqualified-id"
+            self.assertEqual(err_dict[v_id][10][0]['error'], expected_error)
+
+            self.tear_down_completer()
+            self.tear_down()
+
+    def test_show_phantoms(self):
+        """Test that setup view correctly sets up the view."""
+        file_name = path.join(path.dirname(__file__),
+                              'test_files',
+                              'test.cpp')
+        self.set_up_view(file_name)
+        completer = self.set_up_completer(PHANTOMS)
+        self.assertIsNotNone(completer.error_vis)
+        phantom_sets = completer.error_vis.phantom_sets
+        v_id = self.view.buffer_id()
+        self.assertTrue(v_id in phantom_sets)
+        self.tear_down_completer()
+        self.tear_down()
+
+
+class TestErrorVisBin(TestErrorVis, GuiTestWrapper):
+    """Test class for the binary based completer."""
+    use_libclang = False
+
+
+class TestErrorVisLib(TestErrorVis, GuiTestWrapper):
+    """Test class for the binary based completer."""
+    use_libclang = True

--- a/tests/test_error_vis.py
+++ b/tests/test_error_vis.py
@@ -97,7 +97,7 @@ class TestErrorVis:
             self.assertEqual(err_dict[v_id][10][0]['row'], '10')
             self.assertEqual(err_dict[v_id][10][0]['col'], '3')
             expected_error = "expected unqualified-id"
-            self.assertEqual(err_dict[v_id][10][0]['error'], expected_error)
+            self.assertTrue(expected_error in err_dict[v_id][10][0]['error'])
 
             self.tear_down_completer()
             self.tear_down()

--- a/tests/test_error_vis.py
+++ b/tests/test_error_vis.py
@@ -38,10 +38,7 @@ class TestErrorVis:
         settings = manager.settings_for_view(self.view)
         settings.use_libclang = self.use_libclang
 
-        if error_style == PHANTOMS:
-            settings.show_phantoms_for_errors = True
-        else:
-            settings.show_phantoms_for_errors = False
+        settings.show_phantoms_for_errors = bool(error_style == PHANTOMS)
 
         view_config_manager = ViewConfigManager()
         view_config = view_config_manager.load_for_view(self.view, settings)


### PR DESCRIPTION
We now have two backends to show errors: popups and phantoms. 

It would be cool to separate them into two classes and reduce duplication.