### PR TITLE
Fix list index out of range in tokenize_list

### DIFF
--- a/plugin/utils/flag.py
+++ b/plugin/utils/flag.py
@@ -78,9 +78,11 @@ class Flag:
                 continue
             if entry in Flag.SEPARABLE_PREFIXES:
                 # add both this and next part to a flag
-                flags.append(Flag(all_split_line[i], all_split_line[i + 1]))
-                skip = True
-                continue
+                if (i + 1) < len(all_split_line):
+                    flags.append(
+                        Flag(all_split_line[i], all_split_line[i + 1]))
+                    skip = True
+                    continue
             flags.append(Flag(entry))
         return flags
 


### PR DESCRIPTION
IndexError occurs in `tokenize_list` when `all_split_line` is `['-m', 'elf_x86_64', '-r', '-o']`

Error message
```
ERROR:concurrent.futures:exception calling callback for <Future at 0x7fa336755dd0 state=finished raised IndexError>
Traceback (most recent call last):
  File "./python3.3/concurrent/futures/_base.py", line 296, in _invoke_callbacks
  File "/home/up/.config/sublime-text-3/Packages/EasyClangComplete/EasyClangComplete.py", line 254, in config_updated
    log.debug(" updated config: %s", future.result())
  File "./python3.3/concurrent/futures/_base.py", line 394, in result
  File "./python3.3/concurrent/futures/_base.py", line 353, in __get_result
  File "./python3.3/concurrent/futures/thread.py", line 54, in run
  File "/home/up/.config/sublime-text-3/Packages/EasyClangComplete/plugin/view_config.py", line 367, in load_for_view
    config = ViewConfig(view, settings)
  File "/home/up/.config/sublime-text-3/Packages/EasyClangComplete/plugin/view_config.py", line 63, in __init__
    completer, flags = ViewConfig.__generate_essentials(view, settings)
  File "/home/up/.config/sublime-text-3/Packages/EasyClangComplete/plugin/view_config.py", line 179, in __generate_essentials
    flags += ViewConfig.__load_source_flags(view, settings, prefixes)
  File "/home/up/.config/sublime-text-3/Packages/EasyClangComplete/plugin/view_config.py", line 224, in __load_source_flags
    flags = flag_source.get_flags(view.file_name(), search_scope)
  File "/home/up/.config/sublime-text-3/Packages/EasyClangComplete/plugin/flags_sources/compilation_db.py", line 88, in get_flags
    db = self._parse_database(File(current_db_path))
  File "/home/up/.config/sublime-text-3/Packages/EasyClangComplete/plugin/flags_sources/compilation_db.py", line 128, in _parse_database
    self._include_prefixes)
  File "/home/up/.config/sublime-text-3/Packages/EasyClangComplete/plugin/flags_sources/flags_source.py", line 63, in parse_flags
    local_flags = Flag.tokenize_list(chunks)
  File "/home/up/.config/sublime-text-3/Packages/EasyClangComplete/plugin/utils/flag.py", line 82, in tokenize_list
    Flag(all_split_line[i], all_split_line[i + 1]))
IndexError: list index out of range
```
