### PR TITLE
Macro tooltips (#260)

### DIFF
--- a/tests/test_macro_parser.py
+++ b/tests/test_macro_parser.py
@@ -1,0 +1,47 @@
+"""Test macro parsing"""
+from unittest import TestCase
+
+from EasyClangComplete.plugin.clang.utils import MacroParser
+
+
+class TestMacroParser(TestCase):
+    """Tests MacroParser"""
+    def test_args_string_non_function_like_macro(self):
+        """Test parsing a macro with no '()'."""
+        parser = MacroParser('TEST_MACRO', None)
+        parser._parse_macro_file_lines(
+            macro_file_lines=['#define TEST_MACRO 1'],
+            macro_line_number=1)
+        self.assertEqual(parser.args_string, '')
+
+    def test_args_string_function_macro_no_args(self):
+        """Test parsing a function-like macro that takes no arguments."""
+        parser = MacroParser('TEST_MACRO', None)
+        parser._parse_macro_file_lines(
+            macro_file_lines=['#define TEST_MACRO() 1'],
+            macro_line_number=1)
+        self.assertEqual(parser.args_string, '()')
+
+    def test_args_string_function_macro_one_arg(self):
+        """Test parsing a function-like macro that takes one argument."""
+        parser = MacroParser('TEST_MACRO', None)
+        parser._parse_macro_file_lines(
+            macro_file_lines=['#define TEST_MACRO(x) (x)'],
+            macro_line_number=1)
+        self.assertEqual(parser.args_string, '(x)')
+
+    def test_args_string_function_macro_multiple_args(self):
+        """Test parsing a function-like macro that takes multiple arguments."""
+        parser = MacroParser('TEST_MACRO', None)
+        parser._parse_macro_file_lines(
+            macro_file_lines=['#define TEST_MACRO(x, y, z) (x + y + z)'],
+            macro_line_number=1)
+        self.assertEqual(parser.args_string, '(x, y, z)')
+
+    def test_args_string_macro_extra_whitespace(self):
+        """Test parsing a function-like macro with extra whitespace."""
+        parser = MacroParser('TEST_MACRO', None)
+        parser._parse_macro_file_lines(
+            macro_file_lines=[' #  define   TEST_MACRO( x ,   y,    z  ) (x)'],
+            macro_line_number=1)
+        self.assertEqual(parser.args_string, '(x, y, z)')


### PR DESCRIPTION
* Refactor ClangUtils::build_info_details to take a cindex module

Instead of a layer of redirection when lib_complete.py builds lists of
types from cindex, just keep a reference to the loaded cindex module
and pass that around. There should be no visible changes from this
commit, but this will make future work on macros easier because there
will more direct access to cindex's types and methods.

* Enable macro tooltips

Hovering over a macro instantiation will show a the macro's signature and
a hyperlink to it's definition.
Examples:
    "#define MACRO 1" will show a tooltip "#define MACRO"
    "#define MACRO() 1" will show a tooltip "#define MACRO()"
    "#define MACRO(x, y) (x + y)" will show a tooltip "#define MACRO(x, y)"

To do this, we first need to parse with PARSE_DETAILED_PROCESSING_RECORD so
libclang will give us macro cursors.

Then, we need to open the file the macro is contained in and parse the
macro definition to get its signature.

Macro doxygen comments will not be shown, but could be added to MacroParser
in the future.