### PR TITLE
Fix plugin not loading on the first time properly

### DIFF
--- a/plugin/completion/bin_complete.py
+++ b/plugin/completion/bin_complete.py
@@ -18,7 +18,6 @@ from .compiler_variant import ClangClCompilerVariant
 from ..settings.settings_storage import SettingsStorage
 
 log = logging.getLogger(__name__)
-log.debug(" reloading module")
 
 
 class Completer(BaseCompleter):

--- a/plugin/completion/compiler_variant.py
+++ b/plugin/completion/compiler_variant.py
@@ -9,7 +9,6 @@ import logging
 from ..utils.flag import Flag
 
 log = logging.getLogger(__name__)
-log.debug(" reloading module")
 
 
 class CompilerVariant(object):

--- a/plugin/completion/lib_complete.py
+++ b/plugin/completion/lib_complete.py
@@ -22,7 +22,6 @@ from threading import RLock
 from os import path
 
 log = logging.getLogger(__name__)
-log.debug(" reloading module")
 
 cindex_dict = {
     '3.2': PKG_NAME + ".plugin.clang.cindex32",

--- a/plugin/completion/lib_complete.py
+++ b/plugin/completion/lib_complete.py
@@ -297,15 +297,22 @@ class Completer(BaseCompleter):
             if not self.tu:
                 log.critical(" cannot create translation unit. Abort.")
                 return False
-            if self.tu.cursor.displayname != view.file_name():
+            if isinstance(self.tu.cursor.displayname, bytes):
+                # it is bytes, convert!
+                log.debug(" converting bytes '%s' into str",
+                          self.tu.cursor.displayname)
+                displayname = self.tu.cursor.displayname.decode('utf-8')
+            else:
+                # it is a normal string, no conversion needed
+                displayname = self.tu.cursor.displayname
+            if displayname != view.file_name():
                 # In case the file was renamed, the translation unit still has
                 # the old name in it and crashes the plugin host. We need to
                 # completely recreate a translation unit if the filename has
                 # changed. Addressed in issue #191.
                 log.debug(" translation unit file does not match view one")
                 log.debug(" names: '%s' vs '%s'",
-                          self.tu.cursor.displayname,
-                          view.file_name())
+                          displayname, view.file_name())
                 log.debug(" recreate translation unit completely")
                 self.parse_tu(view, settings)
             log.debug(" reparsing translation_unit for view %s", v_id)

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -11,7 +11,6 @@ from os import path
 from ..tools import Tools
 
 log = logging.getLogger(__name__)
-log.debug(" reloading module %s", __name__)
 
 
 class Wildcards:
@@ -84,6 +83,7 @@ class SettingsStorage:
         Args:
             settings_handle (sublime.Settings): handle to sublime settings
         """
+        log.debug(" creating new settings storage object")
         self.clang_version = ''
         self.libclang_path = ''
         self.clang_binary = ''
@@ -124,6 +124,25 @@ class SettingsStorage:
             log.error(" view became None. Do not continue.")
             log.error(" original error: %s", e)
 
+    def need_reparse(self):
+        """A very hacky check that there was an incomplete load.
+
+        This is needed because of something I believe is a bug in sublime text
+        plugin handling. When we enable the plugin and load its settings with
+        on_plugin_loaded() function not all settings are active.
+        'progress_style' is one of the missing settings. The settings will
+        just need to be loaded at a later time then.
+
+        Returns:
+            bool: True if needs reparsing, False otherwise
+
+        """
+        if 'progress_style' in self.__dict__:
+            log.debug(' settings complete')
+            return False
+        log.warning(' settings incomplete')
+        return True
+
     def is_valid(self):
         """Check settings validity.
 
@@ -139,6 +158,7 @@ class SettingsStorage:
             if value is None:
                 error_msg = "No value for setting '{}' found!".format(key)
                 return False, error_msg
+
         if self.progress_style not in SettingsStorage.PROGRESS_STYLES:
             error_msg = "Progress style '{}' is not one of {}".format(
                 self.progress_style, SettingsStorage.PROGRESS_STYLES)

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -140,7 +140,7 @@ class SettingsStorage:
         if 'progress_style' in self.__dict__:
             log.debug(' settings complete')
             return False
-        log.warning(' settings incomplete')
+        log.debug(' settings incomplete and will be reloaded a bit later')
         return True
 
     def is_valid(self):

--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -69,8 +69,11 @@ class Reloader:
         """Reload all loaded modules."""
         prefix = PKG_NAME + '.plugin.'
         # reload all twice to make sure all dependencies are satisfied
+        log.debug(" reload all modules first time")
         Reloader.reload_once(prefix)
+        log.debug(" reload all modules second time")
         Reloader.reload_once(prefix)
+        log.debug(" all modules reloaded")
 
     @staticmethod
     def reload_once(prefix):

--- a/plugin/utils/progress_status.py
+++ b/plugin/utils/progress_status.py
@@ -56,7 +56,7 @@ class MoonProgressStatus(BaseProgressStatus):
 
     def __init__(self):
         """Init moon progress status."""
-        super(MoonProgressStatus, self).__init__()
+        super().__init__()
         self.idx = 0
         self.msg_chars = MSG_CHARS_MOON
         self.msg_ready = MSG_READY_MOON
@@ -77,7 +77,7 @@ class ColorSublimeProgressStatus(BaseProgressStatus):
 
     def __init__(self):
         """Init color sublime like progress status."""
-        super(ColorSublimeProgressStatus, self).__init__()
+        super().__init__()
         self.msg_chars = MSG_CHARS_COLOR_SUBLIME
         self.msg_ready = MSG_READY_COLOR_SUBLIME
 


### PR DESCRIPTION
- fix #275
- initialize setting in a lazy way
- make sure the settings get fully loaded. The original issue is that when
  loading the setting for the first time of loading the plugin after enabling
  it not all settings get loaded. They get loaded later, so we just avoid
  loading anything that depends on settings until this happens