### PR TITLE
trigger settings reload on any project file change

### DIFF
--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -234,6 +234,12 @@ class EasyClangComplete(sublime_plugin.EventListener):
         # disable on_activated_async when running tests
         if view.settings().get("disable_easy_clang_complete"):
             return
+        if view.file_name().endswith('.sublime-project'):
+            if not self.settings_manager:
+                log.error(" no settings manager, no cannot reload settings")
+                return
+            log.debug(" Project file changed. Reloading settings.")
+            self.settings_manager.on_settings_changed()
         if Tools.is_valid_view(view):
             log.debug(" saving view: %s", view.buffer_id())
             settings = self.settings_manager.settings_for_view(view)

--- a/plugin/settings/settings_manager.py
+++ b/plugin/settings/settings_manager.py
@@ -29,6 +29,7 @@ class SettingsManager:
 
     def __init__(self):
         """Initialize the class by loading the default user settings."""
+        log.debug(" create new setting manager object")
         self.__default_settings = None
         self.__settings_dict = {}
         self.__change_listeners = []
@@ -98,7 +99,7 @@ class SettingsManager:
         self.__settings_dict[view_id].update_from_view(view)
         log.debug(" settings initialized for view: %s", view_id)
 
-    def __on_settings_changed(self):
+    def on_settings_changed(self):
         """When user changes settings, trigger this."""
         self.__init_default_settings()
 
@@ -122,7 +123,7 @@ class SettingsManager:
             PKG_NAME + ".sublime-settings")
         self.__subl_settings.clear_on_change(PKG_NAME)
         self.__subl_settings.add_on_change(PKG_NAME,
-                                           self.__on_settings_changed)
+                                           self.on_settings_changed)
 
         # initialize default settings
         self.__default_settings = SettingsStorage(self.__subl_settings)


### PR DESCRIPTION
Fix #273 

We will reload all setting if *any* project file has been saved by the user. Reloading settings is relatively cheap and should not be too annoying.