### PR TITLE
Allow all window variables too

### DIFF
--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -5,6 +5,7 @@ Attributes:
 """
 import logging
 import re
+import sublime
 
 from os import path
 
@@ -21,9 +22,9 @@ class Wildcards:
         PROJECT_NAME (str): a wildcard to be replaced by the project name
         PROJECT_PATH (str): a wildcard to be replaced by the project path
     """
-    PROJECT_PATH = "$project_base_path"
-    PROJECT_NAME = "$project_name"
-    CLANG_VERSION = "$clang_version"
+    PROJECT_PATH = "project_base_path"
+    PROJECT_NAME = "project_name"
+    CLANG_VERSION = "clang_version"
     HOME = "~"
 
 
@@ -91,12 +92,7 @@ class SettingsStorage:
         self.clang_binary = ''
         self.project_folder = ''
         self.project_name = ''
-        self._wildcard_values = {
-            Wildcards.PROJECT_PATH: "",
-            Wildcards.PROJECT_NAME: "",
-            Wildcards.CLANG_VERSION: "",
-            Wildcards.HOME: ""
-        }
+        self._wildcard_values = {}
         self.__load_vars_from_settings(settings_handle,
                                        project_specific=False)
 
@@ -262,8 +258,8 @@ class SettingsStorage:
         Returns:
             str: line with replaced wildcards
         """
-        res = str(line)
-        res = path.expanduser(path.expandvars(res))
+        res = sublime.expand_variables(line, self._wildcard_values)
+        res = path.expanduser(res)
 
         # replace all wildcards in the line
         for wildcard, value in self._wildcard_values.items():
@@ -274,9 +270,8 @@ class SettingsStorage:
 
     def __update_widcard_values(self, view):
         """Update values for wildcard variables."""
-        from os.path import expanduser
-        self._wildcard_values[Wildcards.HOME] = expanduser("~")
         variables = view.window().extract_variables()
+        self._wildcard_values.update(variables)
         if 'folder' in variables:
             project_folder = variables['folder'].replace('\\', '\\\\')
             self._wildcard_values[Wildcards.PROJECT_PATH] = project_folder


### PR DESCRIPTION
This PR allows you to use things like

```json
		"ecc_flags_sources":
		[
			{
				"file": "compile_commands.json",
				"search_in": "~/dev/${project_base_name}/build"
			}
		]
```

or

```json
		"ecc_flags_sources":
		[
			{
				"file": "compile_commands.json",
				"search_in": "${project_path}/build"
			}
		]
```

Note that the old vars still work (project_base_path, project_name, clang_version, ~)