### PR TITLE
Fix missing `@param` entry doxygen

### DIFF
--- a/plugin/clang/utils.py
+++ b/plugin/clang/utils.py
@@ -422,32 +422,18 @@ class ClangUtils:
     @staticmethod
     def cleanup_comment(raw_comment):
         """Cleanup raw doxygen comment."""
+        import string
         lines = raw_comment.split('\n')
+        chars_to_strip = '/' + '*' + string.whitespace
+        lines = [line.lstrip(chars_to_strip) for line in lines]
         clean_lines = []
-        prev_line = ''
-        is_brief_comment = False
-        non_brief_found = False
+        print(lines)
+        is_brief_comment = True
         for line in lines:
-            clean = line.strip()
-            if clean.startswith('/'):
-                clean = clean[3:]
-            elif clean.startswith('*'):
-                clean = clean[2:]
-            prev_line = clean
-            if clean[1:].startswith('brief'):
-                is_brief_comment = True
-                continue
-            if clean == '':
+            if line == '' and is_brief_comment:
                 is_brief_comment = False
-            if clean == '' and prev_line == '':
-                # We want to ignore trailing empty lines.
                 continue
             if is_brief_comment:
                 continue
-            if not non_brief_found:
-                non_brief_found = True
-                is_brief_comment = True
-                continue
-            non_brief_found = True
-            clean_lines.append(clean)
+            clean_lines.append(line)
         return '<br>'.join(clean_lines)


### PR DESCRIPTION
I have removed all the boilerplate code from parsing the Doxygen comments. The code is cleaner and performs better. Close #293 while still using it as inspiration.