### PR TITLE
Minor unit test fixes for local machines

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,4 +1,6 @@
 """Tests for settings."""
+import sublime
+
 from os import path
 
 from EasyClangComplete.plugin.settings.settings_manager import SettingsManager
@@ -48,6 +50,18 @@ class test_settings(GuiTestWrapper):
         settings = manager.user_settings()
         valid, _ = settings.is_valid()
         self.assertTrue(valid)
+
+        p = path.join(sublime.packages_path(),
+                      "User",
+                      "EasyClangComplete.sublime-settings")
+        if path.exists(p):
+            user = sublime.load_resource(
+                "Packages/User/EasyClangComplete.sublime-settings")
+            if "common_flags" in user:
+                # The user modified the default common flags, just skip the
+                # next few tests.
+                self.tear_down()
+                return
 
         initial_common_flags = list(settings.common_flags)
         settings = manager.settings_for_view(self.view)

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -4,8 +4,8 @@ from os import path
 
 from EasyClangComplete.plugin.tools import Tools
 
-PEP257_CMD = "pep257 {} --match-dir='^(?!clang$).*' --ignore=D204,D203,D209"
-PEP8_CMD = "pep8 {} --exclude=clang --count --max-line-length=80"
+PEP257_CMD = "pep257 '{}' --match-dir='^(?!clang$).*' --ignore=D204,D203,D209"
+PEP8_CMD = "pep8 '{}' --exclude=clang --count --max-line-length=80"
 
 PLUGIN_SOURCE_FOLDER = path.dirname(path.dirname(__file__))
 

--- a/tests/test_view_config.py
+++ b/tests/test_view_config.py
@@ -56,6 +56,17 @@ class TestViewConfig(GuiTestWrapper):
         view_config = ViewConfig(self.view, settings)
 
         self.assertIsNotNone(view_config.completer)
+        p = path.join(sublime.packages_path(),
+                      "User",
+                      "EasyClangComplete.sublime-settings")
+        if path.exists(p):
+            user = sublime.load_resource(
+                "Packages/User/EasyClangComplete.sublime-settings")
+            if "common_flags" in user:
+                # The user modified the default common flags, just skip the
+                # next few tests.
+                self.tear_down()
+                return
         completer = view_config.completer
         self.assertEqual(len(completer.clang_flags), 14)
         # test from the start


### PR DESCRIPTION
This makes all unit tests pass for me on macOS.

I disable some tests when there's a `"common_flags"` key in Packages/User/EasyClangComplete.sublime-settings, because the unit tests assume that's not there. Furthermore, I add single quotes around the path arguments for pep8 and pep257, because the packages path on macOS contains spaces.