### PR TITLE
Fixed relative include normalizing from compile_commands.json.

### DIFF
--- a/plugin/flags_sources/compilation_db.py
+++ b/plugin/flags_sources/compilation_db.py
@@ -123,6 +123,11 @@ class CompilationDb(FlagsSource):
                                             database_file.folder())
             file_path = path.splitext(file_path)[0]
             argument_list = []
+
+            base_path = database_file.folder()
+            if 'directory' in entry:
+                base_path = entry['directory']
+
             if 'command' in entry:
                 import shlex
                 argument_list = shlex.split(entry['command'])
@@ -132,8 +137,9 @@ class CompilationDb(FlagsSource):
                 # TODO(igor): maybe show message to the user instead here
                 log.critical(" compilation database has unsupported format")
                 return None
+
             argument_list = CompilationDb.filter_bad_arguments(argument_list)
-            flags = FlagsSource.parse_flags(database_file.folder(),
+            flags = FlagsSource.parse_flags(base_path,
                                             argument_list,
                                             self._include_prefixes)
             # set these flags for current file

--- a/tests/compilation_db_files/directory/compile_commands.json
+++ b/tests/compilation_db_files/directory/compile_commands.json
@@ -1,0 +1,15 @@
+[
+{
+  "arguments": [
+    "/usr/bin/c++",
+    "-I/usr/local/foo",
+    "-I./include",
+    "-I../../include",
+    "-isystem",
+    "../matilda",
+    "test.cpp"
+    ],
+  "directory": "/foo/bar/test",
+  "file": "test.cpp"
+}
+]

--- a/tests/test_compilation_db.py
+++ b/tests/test_compilation_db.py
@@ -126,3 +126,19 @@ class TestCompilationDb(TestCase):
                          db._cache[main_file_path])
         self.assertEqual(path.join(path_to_db, "compile_commands.json"),
                          db._cache[lib_file_path])
+
+    def test_relative_directory(self):
+        """Test if compilation db 'directory' records are applied."""
+        include_prefixes = ['-I', '-isystem']
+        db = CompilationDb(include_prefixes)
+
+        expected = [Flag('-I' + path.normpath('/usr/local/foo')),
+                    Flag('-I' + path.normpath('/foo/bar/test/include')),
+                    Flag('-I' + path.normpath('/foo/include')),
+                    Flag('-isystem', path.normpath('/foo/bar/matilda'))]
+
+        path_to_db = path.join(path.dirname(__file__),
+                               'compilation_db_files',
+                               'directory')
+        scope = SearchScope(from_folder=path_to_db)
+        self.assertEqual(expected, db.get_flags(search_scope=scope))


### PR DESCRIPTION
`compile_commands.json` may contain `directory` records which need to be taken into account when processing relative include paths. 
Fixes https://github.com/niosus/EasyClangComplete/issues/313.