### PR TITLE
Show enum values in mouse  hover popup window

### DIFF
--- a/plugin/clang/utils.py
+++ b/plugin/clang/utils.py
@@ -334,6 +334,11 @@ class ClangUtils:
         if args_string:
             result += args_string
 
+        # Show value for enum
+        if cursor.kind == cindex.CursorKind.ENUM_CONSTANT_DECL:
+            result += " = " + str(cursor.enum_value)
+            result += "(" + hex(cursor.enum_value) + ")"
+
         # Method modifiers
         if cursor.is_const_method():
             result += " const"


### PR DESCRIPTION
Example:

```
enum {
  ENUM_VALUE1= 0x123,
  ENUM_VALUE2,
  ENUM_VALUE3,
  ENUM_VALUE4,
  ENUM_VALUE5
};
```

...

int var = ENUM_VALUE5;

When mouse is over 'var' declaration than next popup will be shown:

`"int ENUM_VALUE5 = 295(0x127)"`

<!-- maintainerd: DO NOT REMOVE -->

-----

Hi! Thanks for the PR! To keep things clean, please check the boxes below:

- [x] <!-- checklist item; required -->This PR is set to merge with `dev` branch.
 _(required)_

