### PR TITLE
Show macro body on mouse hover popup

### DIFF
--- a/tests/test_macro_parser.py
+++ b/tests/test_macro_parser.py
@@ -45,3 +45,43 @@ class TestMacroParser(TestCase):
             macro_file_lines=[' #  define   TEST_MACRO( x ,   y,    z  ) (x)'],
             macro_line_number=1)
         self.assertEqual(parser.args_string, '(x, y, z)')
+
+    def test_body_string_macro_empty(self):
+        """Test parsing a macro without parameters."""
+        parser = MacroParser('TEST_MACRO', None)
+        parser._parse_macro_file_lines(
+            macro_file_lines=[' #  define   TEST_MACRO'],
+            macro_line_number=1)
+        self.assertEqual(parser.body_string, '')
+
+    def test_body_string_macro_inline(self):
+        """Test parsing a single-line macro."""
+        parser = MacroParser('TEST_MACRO', None)
+        parser._parse_macro_file_lines(
+            macro_file_lines=[' #  define   TEST_MACRO 42'],
+            macro_line_number=1)
+        self.assertEqual(parser.body_string, '42')
+
+    def test_body_string_macro_next_line(self):
+        """Test parsing a macro with val on next line."""
+        parser = MacroParser('TEST_MACRO', None)
+        parser._parse_macro_file_lines(
+            macro_file_lines=[' #  define   TEST_MACRO \\\n 42'],
+            macro_line_number=1)
+        self.assertEqual(parser.body_string, '\\\n 42')
+
+    def test_body_string_macro_curr_next_line(self):
+        """Test parsing a macro with val on current and next lines."""
+        parser = MacroParser('TEST_MACRO', None)
+        parser._parse_macro_file_lines(
+            macro_file_lines=[' #  define   TEST_MACRO 24\\\n 42'],
+            macro_line_number=1)
+        self.assertEqual(parser.body_string, '24\\\n 42')
+
+    def test_body_string_macro_curr_next_lines(self):
+        """Test parsing a function macro on multiple lines."""
+        parser = MacroParser('TEST_MACRO', None)
+        parser._parse_macro_file_lines(
+            macro_file_lines=[' #define TEST_MACRO(x) 24\\\n 42\\\n11\\\n123'],
+            macro_line_number=1)
+        self.assertEqual(parser.body_string, '24\\\n 42\\\n11\\\n123')


### PR DESCRIPTION
Example:
define MAX_VALUE 5

hover popup without patch:
define MAX_VALUE

hover popup with patch:
define MAX_VALUE 5

In cases when macroses have multiline body:
define DO_SWAP(a, b) \
   { \
     int tmp = a; \
     b = a; \
     a = tmp; \
   }

popup will be:
define DO_SWAP(a, b)
   {
     int tmp = a;
     b = a;
     a = tmp;
   }
<!-- maintainerd: DO NOT REMOVE -->

-----

Hi! Thanks for the PR! To keep things clean, please check the boxes below:

- [x] <!-- checklist item; required -->This PR is set to merge with `dev` branch.
 _(required)_

