### PR TITLE
Show type declaration on mouse hover popup

### DIFF
--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -422,7 +422,7 @@ class EasyClangComplete(sublime_plugin.EventListener):
             name=EasyClangComplete.INFO_JOB_TAG,
             callback=self.info_finished,
             function=EasyClangComplete.view_config_manager.trigger_info,
-            args=[view, tooltip_request])
+            args=[view, tooltip_request, settings])
         EasyClangComplete.thread_pool.new_job(job)
 
     def on_query_completions(self, view, prefix, locations):

--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -96,6 +96,9 @@
   // This replaces default sublime on hover behaviour
   "show_type_info": true,
 
+  // Show body of struct/class/typedef declaration.
+  "show_type_body" : true,
+
   // On some esoteric systems we cannot find libclang properly.
   // If you know where your libclang is - set the full path here.
   "libclang_path": "<some_path_here>",

--- a/plugin/clang/utils.py
+++ b/plugin/clang/utils.py
@@ -277,6 +277,37 @@ class ClangUtils:
         return result
 
     @staticmethod
+    def get_text_by_extent(extent):
+        """Load lines of code in range, pointed by extent.
+
+        Args:
+            extent (Cursor.extent): Ranges of source file.
+        """
+        if extent.start.file.name != extent.end.file.name:
+            return None
+
+        with open(extent.start.file.name, 'r') as f:
+            lines = f.readlines()
+            return "".join(lines[extent.start.line - 1:extent.end.line])
+
+    @staticmethod
+    def htmlize_text(text):
+        """Convert plain text to HTML like representation.
+
+        Args:
+            text: Plain text to convert.
+        """
+        result = html.escape(text)
+        result = result.replace("\\\n", "<br>")
+        result = result.replace("\n", "<br>")
+        result = result.replace("\t", 4 * "&nbsp;")
+        result = result.replace(" ", "&nbsp;")
+
+        # sublime does not recognize &quot;
+        result = result.replace("&quot;", "&nbsp;")
+        return result
+
+    @staticmethod
     def build_info_details(cursor, cindex):
         """Provide information about given cursor.
 
@@ -287,6 +318,17 @@ class ClangUtils:
             cindex (module): clang cindex.py module for the correct version
 
         """
+        type_decl = [
+            cindex.CursorKind.STRUCT_DECL,
+            cindex.CursorKind.UNION_DECL,
+            cindex.CursorKind.CLASS_DECL,
+            cindex.CursorKind.ENUM_DECL,
+            cindex.CursorKind.TYPEDEF_DECL,
+            cindex.CursorKind.CLASS_TEMPLATE,
+            cindex.CursorKind.TYPE_ALIAS_DECL,
+            cindex.CursorKind.TYPE_REF
+        ]
+
         result = ""
 
         result += '<b>Declaration:</b><br>'
@@ -295,6 +337,7 @@ class ClangUtils:
         # macros just show that they are a macro.
         macro_parser = None
         is_macro = cursor.kind == cindex.CursorKind.MACRO_DEFINITION
+        is_type = cursor.kind in type_decl
         if is_macro:
             macro_parser = MacroParser(cursor.spelling, cursor.location)
             result += '#define '
@@ -359,15 +402,12 @@ class ClangUtils:
 
         # Show macro body
         if is_macro:
-            body = html.escape(macro_parser.body_string)
-            body = body.replace("\\\n", "<br>")
-            body = body.replace(" ", "&nbsp;")
-            body = body.replace("\t", 4 * "&nbsp;")
+            result += " " + ClangUtils.htmlize_text(macro_parser.body_string)
 
-            # sublime does not recognize &quot;
-            body = body.replace("&quot;", "&nbsp;")
-
-            result += " " + body
+        # Show type declaration
+        if is_type and cursor.extent:
+            body = ClangUtils.get_text_by_extent(cursor.extent)
+            result += "<br><br>" + ClangUtils.htmlize_text(body)
 
         # Doxygen comments
         if cursor.brief_comment:

--- a/plugin/clang/utils.py
+++ b/plugin/clang/utils.py
@@ -308,7 +308,7 @@ class ClangUtils:
         return result
 
     @staticmethod
-    def build_info_details(cursor, cindex):
+    def build_info_details(cursor, cindex, settings):
         """Provide information about given cursor.
 
         Builds detailed information about cursor.
@@ -405,7 +405,7 @@ class ClangUtils:
             result += " " + ClangUtils.htmlize_text(macro_parser.body_string)
 
         # Show type declaration
-        if is_type and cursor.extent:
+        if settings.show_type_body and is_type and cursor.extent:
             body = ClangUtils.get_text_by_extent(cursor.extent)
             result += "<br><br>" + ClangUtils.htmlize_text(body)
 

--- a/plugin/completion/base_complete.py
+++ b/plugin/completion/base_complete.py
@@ -56,7 +56,7 @@ class BaseCompleter:
         """
         raise NotImplementedError("calling abstract method")
 
-    def info(self, tooltip_request):
+    def info(self, tooltip_request, settings):
         """Provide information about object in given location.
 
         Using the current translation unit it queries libclang for available
@@ -65,6 +65,7 @@ class BaseCompleter:
         Args:
             tooltip_request (tools.ActionRequest): A request for action
                 from the plugin.
+            settings: All plugin settings.
 
         Raises:
             NotImplementedError: Guarantees we do not call this abstract method

--- a/plugin/completion/bin_complete.py
+++ b/plugin/completion/bin_complete.py
@@ -103,7 +103,7 @@ class Completer(BaseCompleter):
         log.debug('completions: %s' % completions)
         return (completion_request, completions)
 
-    def info(self, tooltip_request):
+    def info(self, tooltip_request, settings):
         """Provide information about object in given location.
 
         Using the current translation unit it queries libclang for available
@@ -112,6 +112,7 @@ class Completer(BaseCompleter):
         Args:
             tooltip_request (tools.ActionRequest): A request for action
                 from the plugin.
+            settings: All plugin settings.
 
         Returns:
             (tools.ActionRequest, str): completion request along with the

--- a/plugin/completion/lib_complete.py
+++ b/plugin/completion/lib_complete.py
@@ -238,7 +238,7 @@ class Completer(BaseCompleter):
         log.debug('completions: %s' % completions)
         return (completion_request, completions)
 
-    def info(self, tooltip_request):
+    def info(self, tooltip_request, settings):
         """Provide information about object in given location.
 
         Using the current translation unit it queries libclang for available
@@ -247,6 +247,7 @@ class Completer(BaseCompleter):
         Args:
             tooltip_request (tools.ActionRequest): A request for action
                 from the plugin.
+            settings: All plugin settings.
 
         Returns:
             (tools.ActionRequest, str): completion request along with the
@@ -271,7 +272,7 @@ class Completer(BaseCompleter):
                 return (tooltip_request, info_details)
             if cursor.referenced:
                 info_details = ClangUtils.build_info_details(
-                    cursor.referenced, self.cindex)
+                    cursor.referenced, self.cindex, settings)
                 return (tooltip_request, info_details)
             return empty_info
 

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -74,6 +74,7 @@ class SettingsStorage:
         "objective_cpp_flags",
         "progress_style",
         "show_type_info",
+        "show_type_body",
         "triggers",
         "use_libclang",
         "use_libclang_caching",

--- a/plugin/view_config.py
+++ b/plugin/view_config.py
@@ -401,7 +401,7 @@ class ViewConfigManager(object):
         (row, col) = SublBridge.cursor_pos(view)
         return config.completer.get_declaration_location(view, row, col)
 
-    def trigger_info(self, view, tooltip_request):
+    def trigger_info(self, view, tooltip_request, settings):
         """A proxy function to handle getting info from completer.
 
         The main purpose of this function is to ensure that python correctly
@@ -412,7 +412,7 @@ class ViewConfigManager(object):
         if not config:
             log.debug("Config is not ready yet. No info tooltip shown.")
             return tooltip_request, ""
-        return config.completer.info(tooltip_request)
+        return config.completer.info(tooltip_request, settings)
 
     def trigger_completion(self, view, completion_request):
         """A proxy function to get completions.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,7 @@
 """Testing module."""
 __all__ = ("gui_test_wrapper",
            "test_clang_complete_file",
+           "test_clang_utils",
            "test_cmake_file",
            "test_compilation_db",
            "test_complete",

--- a/tests/test_clang_utils.py
+++ b/tests/test_clang_utils.py
@@ -1,0 +1,70 @@
+"""Test Clang utils."""
+from collections import namedtuple
+from os import path
+from unittest import TestCase
+
+from EasyClangComplete.plugin.clang.utils import ClangUtils
+
+test_file = namedtuple('test_file', 'name')
+test_cursor = namedtuple('test_cursor', 'file line')
+test_extent = namedtuple('test_extent', 'start end')
+
+
+class TestClangUtils(TestCase):
+    """Tests MacroParser."""
+
+    def test_htmlize_text_ltgt(self):
+        """Test a <> symbols convertion."""
+        res = ClangUtils.htmlize_text('<>')
+        self.assertEqual(res, '&lt;&gt;')
+
+    def test_htmlize_text_newline(self):
+        """Test a \n convertion."""
+        res = ClangUtils.htmlize_text('text\ntext')
+        self.assertEqual(res, 'text<br>text')
+
+    def test_htmlize_text_tab(self):
+        """Test a \t convertion."""
+        res = ClangUtils.htmlize_text('text\ttext')
+        self.assertEqual(res, 'text' + 4 * '&nbsp;' + 'text')
+
+    def test_htmlize_text_quot(self):
+        """Test a " symbol convertion."""
+        res = ClangUtils.htmlize_text('text"text')
+        self.assertEqual(res, 'text' + '&nbsp;' + 'text')
+
+    def test_htmlize_text_spaces(self):
+        """Test a single-line string with spaces."""
+        res = ClangUtils.htmlize_text('   123')
+        self.assertEqual(res, 3 * '&nbsp;' + '123')
+
+    def test_get_text_by_extent_multifile(self):
+        """Test getting text from multifile extent."""
+        file1 = test_file('file1.c')
+        file2 = test_file('file2.c')
+        cursor1 = test_cursor(file1, 1)
+        cursor2 = test_cursor(file2, 6)
+        ext = test_extent(cursor1, cursor2)
+        self.assertEqual(ClangUtils.get_text_by_extent(ext), None)
+
+    def test_get_text_by_extent_oneline(self):
+        """Test getting text from oneline extent."""
+        file_name = path.join(path.dirname(__file__),
+                              'test_files',
+                              'test.cpp')
+        file1 = test_file(file_name)
+        cursor1 = test_cursor(file1, 8)
+        cursor2 = test_cursor(file1, 8)
+        ext = test_extent(cursor1, cursor2)
+        self.assertEqual(ClangUtils.get_text_by_extent(ext), '  A a;\n')
+
+    def test_get_text_by_extent_multiline(self):
+        """Test getting text from multiline extent."""
+        file_name = path.join(path.dirname(__file__),
+                              'test_files',
+                              'test.cpp')
+        file1 = test_file(file_name)
+        cursor1 = test_cursor(file1, 8)
+        cursor2 = test_cursor(file1, 9)
+        ext = test_extent(cursor1, cursor2)
+        self.assertEqual(ClangUtils.get_text_by_extent(ext), '  A a;\n  a.\n')


### PR DESCRIPTION
Example:
```c++
typedef struct {
   int a;
   int b;
   int c;
} my_type;
```    
and usage:    
```c++
my_type t;
```
When mouse over "my_type"
Popup without patch:
```
my_type
```  
Popup with patch:
```c++
my_type
 
typedef struct {
  int a;
  int b;
  int c;
} my_type;
````
<!-- maintainerd: DO NOT REMOVE -->

-----

Hi! Thanks for the PR! To keep things clean, please check the boxes below:

- [x] <!-- checklist item; required -->This PR is set to merge with `dev` branch.
 _(required)_

