### PR TITLE
Fix macro parse bug for files containing non-ASCII characters

### DIFF
--- a/plugin/clang/utils.py
+++ b/plugin/clang/utils.py
@@ -37,7 +37,8 @@ class MacroParser(object):
         self._name = name
         self._body = ''
         if location and location.file and location.file.name:
-            with open(location.file.name, 'r') as f:
+            with open(location.file.name, 'r', encoding='utf-8',
+                      errors='ignore') as f:
                 macro_file_lines = f.readlines()
                 self._parse_macro_file_lines(macro_file_lines, location.line)
 


### PR DESCRIPTION
Before, reading files with non-ASCII characters would fail, i.e. a file
with a unicode copyright symbol in a comment:
```c++
// ©
#define MACRO() printf("foo")
MACRO();
```

Hovering over MACRO() would give this error in the console:
```
ERROR:concurrent.futures:exception calling callback for <Future at 0x10aa5b610 state=finished raised UnicodeDecodeError>
Traceback (most recent call last):
  File "./python3.3/concurrent/futures/_base.py", line 296, in _invoke_callbacks
  File "/Users/kyleteske/Library/Application Support/Sublime Text 3/Packages/EasyClangComplete/EasyClangComplete.py", line 329, in info_finished
    (tooltip_request, result) = future.result()
  File "./python3.3/concurrent/futures/_base.py", line 394, in result
  File "./python3.3/concurrent/futures/_base.py", line 353, in __get_result
  File "./python3.3/concurrent/futures/thread.py", line 54, in run
  File "/Users/kyleteske/Library/Application Support/Sublime Text 3/Packages/EasyClangComplete/plugin/view_config.py", line 403, in trigger_info
    return config.completer.info(tooltip_request)
  File "/Users/kyleteske/Library/Application Support/Sublime Text 3/Packages/EasyClangComplete/plugin/completion/lib_complete.py", line 274, in info
    cursor.referenced, self.cindex)
  File "/Users/kyleteske/Library/Application Support/Sublime Text 3/Packages/EasyClangComplete/plugin/clang/utils.py", line 300, in build_info_details
    macro_parser = MacroParser(cursor.spelling, cursor.location)
  File "/Users/kyleteske/Library/Application Support/Sublime Text 3/Packages/EasyClangComplete/plugin/clang/utils.py", line 43, in __init__
    macro_file_lines = f.readlines()
  File "./python3.3/encodings/ascii.py", line 26, in decode
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 3: ordinal not in range(128)
```
<!-- maintainerd: DO NOT REMOVE -->

-----

Hi! Thanks for the PR! To keep things clean, please check the boxes below:

- [x] <!-- checklist item; required -->This PR is set to merge with `dev` branch.
 _(required)_

