### PR TITLE
Fixing bin_complete Completer.info popup to appear even though use_libclang is true.

### DIFF
--- a/plugin/completion/bin_complete.py
+++ b/plugin/completion/bin_complete.py
@@ -85,6 +85,9 @@ class Completer(BaseCompleter):
         else:
             self.compiler_variant = ClangCompilerVariant()
 
+        # pass in use_libclang option for to prevent info poput if true.
+        self.use_libclang = settings.use_libclang
+
     def complete(self, completion_request):
         """Called asynchronously to create a list of autocompletions.
 
@@ -128,7 +131,15 @@ class Completer(BaseCompleter):
 
         Please use libclang or set "show_type_info" to false.
         """
-        sublime.error_message(msg)
+        # This error message can also occur when lib_complete completer cannot
+        # be initialized. This can happen for newly created files for folders
+        # that have cached cmake output. Therefore, it makes more sense to log
+        # here instead of a pop up error message.
+        if not self.use_libclang:
+            sublime.error_message(msg)
+        else:
+            log.info("clear cmake cache.")
+        return (tooltip_request, "")
 
     def update(self, view, settings):
         """Update build for current view.


### PR DESCRIPTION
The _Completer.info_ _sublime.error_message_ poput in _bin_complete_ appears even when _use_libclang_ is true. This happens when the _lib_complete_ _Completer_ is not valid (as it defaults back to using the _bin_complete_ _Completer_ in _view_config.py_ line 270). This could occur when a new file is added to a folder with a cached cmake output. (_ECC: Clean current CMake cache_ would fix the issue).

I just checked and there has not been an issue reported for this bug yet.