### PR TITLE
Added gutter marking feature and setting.

### DIFF
--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -55,6 +55,10 @@
   // Possible styles: "popups", "phantoms", "none"
   "errors_style": "popups",
 
+  // Mark the gutter (between the sidebar and text view) with a color to flag
+  // errors.
+  "mark_gutter": false,
+
   // triggers for auto-completion
   "triggers" : [ ".", "->", "::", " ", "	", "(", "[" ],
 

--- a/plugin/error_vis/popup_error_vis.py
+++ b/plugin/error_vis/popup_error_vis.py
@@ -32,9 +32,14 @@ class PopupErrorVis:
     WARNING_HTML_TEMPLATE = Template(
         open(POPUP_WARNING_HTML_FILE, encoding='utf8').read())
 
-    def __init__(self):
-        """Initialize error visualization."""
+    def __init__(self, mark_gutter=False):
+        """Initialize error visualization.
+
+        Args:
+            mark_gutter (bool): add a mark to the gutter for error regions
+        """
         self.err_regions = {}
+        self.gutter_mark = "dot" if mark_gutter else ""
 
     def generate(self, view, errors):
         """Generate a dictionary that stores all errors.
@@ -99,7 +104,7 @@ class PopupErrorVis:
         current_error_dict = self.err_regions[view.buffer_id()]
         regions = PopupErrorVis._as_region_list(current_error_dict)
         log.debug("showing error regions: %s", regions)
-        view.add_regions(PopupErrorVis._TAG, regions, "code")
+        view.add_regions(PopupErrorVis._TAG, regions, "code", self.gutter_mark)
 
     def erase_regions(self, view):
         """Erase error regions for view.

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -69,6 +69,7 @@ class SettingsStorage:
         "include_file_folder",
         "include_file_parent_folder",
         "libclang_path",
+        "mark_gutter",
         "max_cache_age",
         "objective_c_flags",
         "objective_cpp_flags",

--- a/plugin/view_config.py
+++ b/plugin/view_config.py
@@ -256,9 +256,13 @@ class ViewConfig(object):
         Returns:
             Completer: A completer. Can be lib completer or bin completer.
         """
-        error_vis = PopupErrorVis()
+        mark_gutter = settings.mark_gutter
+
         if settings.errors_style == SettingsStorage.PHANTOMS_STYLE:
-            error_vis = PhantomErrorVis()
+            error_vis = PhantomErrorVis(mark_gutter)
+        else:
+            error_vis = PopupErrorVis(mark_gutter)
+
         completer = None
         if settings.use_libclang:
             log.info("init completer based on libclang")


### PR DESCRIPTION
Note that the only problem here is that the gutter mark is white (on my instance, anyway). This is because the icon added to the gutter is coloured in the same way as the region it's added with. There are three solutions to this if it's a problem:

1. Change the scope to something like `invalid.illegal` (could be a bit extreme).
2. Use a second, equivalent set of regions purely for the gutter mark.
3. Use a bitmap icon (could be inconsistent with a user's theme).