### PR TITLE
Changed error highlight style.

### DIFF
--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -55,6 +55,10 @@
   // Possible styles: "popups", "phantoms", "none"
   "errors_style": "popups",
 
+  // Mark the gutter (between the sidebar and text view) with a color to flag
+  // errors.
+  "mark_gutter": false,
+
   // triggers for auto-completion
   "triggers" : [ ".", "->", "::", " ", "	", "(", "[" ],
 

--- a/plugin/error_vis/popup_error_vis.py
+++ b/plugin/error_vis/popup_error_vis.py
@@ -7,6 +7,8 @@ import logging
 from os import path
 from string import Template
 
+import sublime
+
 from ..completion.compiler_variant import LibClangCompilerVariant
 
 log = logging.getLogger("ECC")
@@ -26,6 +28,8 @@ class PopupErrorVis:
     """
     _TAG = "easy_clang_complete_errors"
     _MAX_POPUP_WIDTH = 1800
+    _ERROR_FLAGS = sublime.DRAW_EMPTY | sublime.DRAW_NO_FILL
+    _ERROR_SCOPE = "invalid.illegal"
 
     ERROR_HTML_TEMPLATE = Template(
         open(POPUP_ERROR_HTML_FILE, encoding='utf8').read())
@@ -104,7 +108,12 @@ class PopupErrorVis:
         current_error_dict = self.err_regions[view.buffer_id()]
         regions = PopupErrorVis._as_region_list(current_error_dict)
         log.debug("showing error regions: %s", regions)
-        view.add_regions(PopupErrorVis._TAG, regions, "code", self.gutter_mark)
+        view.add_regions(
+            PopupErrorVis._TAG,
+            regions,
+            PopupErrorVis._ERROR_SCOPE,
+            self.gutter_mark,
+            PopupErrorVis._ERROR_FLAGS)
 
     def erase_regions(self, view):
         """Erase error regions for view.

--- a/plugin/error_vis/popup_error_vis.py
+++ b/plugin/error_vis/popup_error_vis.py
@@ -32,9 +32,14 @@ class PopupErrorVis:
     WARNING_HTML_TEMPLATE = Template(
         open(POPUP_WARNING_HTML_FILE, encoding='utf8').read())
 
-    def __init__(self):
-        """Initialize error visualization."""
+    def __init__(self, mark_gutter=False):
+        """Initialize error visualization.
+
+        Args:
+            mark_gutter (bool): add a mark to the gutter for error regions
+        """
         self.err_regions = {}
+        self.gutter_mark = "dot" if mark_gutter else ""
 
     def generate(self, view, errors):
         """Generate a dictionary that stores all errors.
@@ -99,7 +104,7 @@ class PopupErrorVis:
         current_error_dict = self.err_regions[view.buffer_id()]
         regions = PopupErrorVis._as_region_list(current_error_dict)
         log.debug("showing error regions: %s", regions)
-        view.add_regions(PopupErrorVis._TAG, regions, "code")
+        view.add_regions(PopupErrorVis._TAG, regions, "code", self.gutter_mark)
 
     def erase_regions(self, view):
         """Erase error regions for view.

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -69,6 +69,7 @@ class SettingsStorage:
         "include_file_folder",
         "include_file_parent_folder",
         "libclang_path",
+        "mark_gutter",
         "max_cache_age",
         "objective_c_flags",
         "objective_cpp_flags",

--- a/plugin/view_config.py
+++ b/plugin/view_config.py
@@ -256,9 +256,13 @@ class ViewConfig(object):
         Returns:
             Completer: A completer. Can be lib completer or bin completer.
         """
-        error_vis = PopupErrorVis()
+        mark_gutter = settings.mark_gutter
+
         if settings.errors_style == SettingsStorage.PHANTOMS_STYLE:
-            error_vis = PhantomErrorVis()
+            error_vis = PhantomErrorVis(mark_gutter)
+        else:
+            error_vis = PopupErrorVis(mark_gutter)
+
         completer = None
         if settings.use_libclang:
             log.info("init completer based on libclang")


### PR DESCRIPTION
This is related to #354. I removed the white fill and used the `invalid.illegal` scope instead. In most schemes this means a red or dark pink border.

Unfortunately the gutter icon doesn't always change colour, I think this is related to [ST3 issue #315](https://github.com/SublimeTextIssues/Core/issues/315).

You don't have to accept this one, it's just a suggestion to address the issue I linked to. It includes a commit from my other PR to avoid rebasing later.