### PR TITLE
Fix delay when navigating with Ctrl+P

### DIFF
--- a/plugin/settings/settings_manager.py
+++ b/plugin/settings/settings_manager.py
@@ -34,6 +34,10 @@ class SettingsManager:
         self.__settings_dict = {}
         self.__change_listeners = []
 
+    def has_settings_for_view(self, view):
+        """Check if we have settings for this view."""
+        return view.buffer_id() in self.__settings_dict
+
     def settings_for_view(self, view):
         """Get settings stored for a view.
 


### PR DESCRIPTION
There was a delay when navigating with <kbd>Ctrl</kbd> + <kbd>P</kbd> through the views into the valid files. The cause was that the files would never be properly opened, but they would be closed and this would trigger an async job to clear a non-existing translation unit in this case. Submitting a job would take time, while the `on_close` function is not async. Hence the delay.

Now only views that have been initialized will be removed.