### PR TITLE
Allow to specify custom header-to-source lookups

### DIFF
--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -122,14 +122,34 @@
   // compile flags for header files. In order to find a best matching
   // source file instead, you can use templates. Such templates describe how
   // to find (relative to the header file) a source file which we can
-  // use to get compile flags for. You can use UNIX style globbing patterns.
-  // In addition, you can use some pre-defined placeholders that are derived
-  // from the file we try to look up flags for:
-  // - basename: The base file name without the directory part.
-  // - stamp: Like "basename", but with the file name extension removed.
-  // - ext: The file name extension of the header file.
+  // use to get compile flags for. 
+  // In the simplest case, one can just use the (relative) path to where
+  // the source files are relative to your header file. For example, if
+  // your headers are in a subdirectory "inc" and your sources in a
+  // subdirectory "src" next to the first one, then you can use
+  // "../src/" as lookup.
+  // If needed, you can also use finer granular lookup templates by using
+  // UNIX style globbing patterns and placeholders. Placeholders are of the
+  // form '{placeholdername}'. The following placeholders can be used:
+  // - basename:  The base file name without the directory part.
+  // - stamp:     Like "basename", but with the file name extension removed.
+  // - ext:       The file name extension of the header file.
   "header_to_source_mapping": [
-    "{stamp}.*", "../inc/{stamp}.*", "../src/{stamp}.*", "*.*", "../inc/*.*",
-    "../src/*.*"
+    // Look for related files in the header's directory:
+    "./",
+
+    // And in the "src" directory:
+    "../src/",
+
+    // And in the "source" directory:
+    "../source/",
+
+    // Example: Use flags but only from the source file
+    // belonging to the header in question:
+    // "{stamp}.cpp",
+
+    // Example: Use flags from a file with an
+    // "exotic" file name suffix:
+    // "{stamp}.mycustomext 
   ],
 }

--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -116,4 +116,20 @@
   // Controls if libclang will cache the results.
   // This works faster, but in rare cases can generate wrong completions.
   "use_libclang_caching": true,
+
+  // Templates to find source files for headers in case we use a
+  // compilation database: Such a DB does not contain the required
+  // compile flags for header files. In order to find a best matching
+  // source file instead, you can use templates. Such templates describe how
+  // to find (relative to the header file) a source file which we can
+  // use to get compile flags for. You can use UNIX style globbing patterns.
+  // In addition, you can use some pre-defined placeholders that are derived
+  // from the file we try to look up flags for:
+  // - basename: The base file name without the directory part.
+  // - stamp: Like "basename", but with the file name extension removed.
+  // - ext: The file name extension of the header file.
+  "header_to_source_mapping": [
+    "{stamp}.*", "../inc/{stamp}.*", "../src/{stamp}.*", "*.*", "../inc/*.*",
+    "../src/*.*"
+  ],
 }

--- a/plugin/flags_sources/cmake_file.py
+++ b/plugin/flags_sources/cmake_file.py
@@ -42,7 +42,7 @@ class CMakeFile(FlagsSource):
                  prefix_paths,
                  flags,
                  cmake_binary="cmake",
-                 header_to_source_mapping=["{stamp}.*"]):
+                 header_to_source_mapping=None):
         """Initialize a cmake-based flag storage.
 
         Args:

--- a/plugin/flags_sources/cmake_file.py
+++ b/plugin/flags_sources/cmake_file.py
@@ -42,7 +42,7 @@ class CMakeFile(FlagsSource):
                  prefix_paths,
                  flags,
                  cmake_binary="cmake",
-                 header_to_source_mapping=[]):
+                 header_to_source_mapping=["{stamp}.*"]):
         """Initialize a cmake-based flag storage.
 
         Args:

--- a/plugin/flags_sources/cmake_file.py
+++ b/plugin/flags_sources/cmake_file.py
@@ -41,7 +41,8 @@ class CMakeFile(FlagsSource):
                  include_prefixes,
                  prefix_paths,
                  flags,
-                 cmake_binary="cmake"):
+                 cmake_binary="cmake",
+                 header_to_source_mapping=[]):
         """Initialize a cmake-based flag storage.
 
         Args:
@@ -55,6 +56,7 @@ class CMakeFile(FlagsSource):
         self.__cmake_prefix_paths = prefix_paths
         self.__cmake_flags = flags
         self.__cmake_binary = cmake_binary
+        self.__header_to_source_mapping = header_to_source_mapping
 
     def get_flags(self, file_path=None, search_scope=None):
         """Get flags for file.
@@ -96,7 +98,8 @@ class CMakeFile(FlagsSource):
             if use_cached:
                 log.debug("[cmake]:[unchanged]: use existing db.")
                 db_file_path = self._cache[cached_cmake_path]
-                db = CompilationDb(self._include_prefixes)
+                db = CompilationDb(
+                    self._include_prefixes, self.__header_to_source_mapping)
                 db_search_scope = SearchScope(
                     from_folder=path.dirname(db_file_path))
                 return db.get_flags(file_path, db_search_scope)
@@ -114,7 +117,8 @@ class CMakeFile(FlagsSource):
             self._cache[file_path] = current_cmake_path
             self._cache[current_cmake_path] = db_file.full_path()
             File.update_mod_time(current_cmake_path)
-        db = CompilationDb(self._include_prefixes)
+        db = CompilationDb(
+            self._include_prefixes, self.__header_to_source_mapping)
         db_search_scope = SearchScope(from_folder=db_file.folder())
         flags = db.get_flags(file_path, db_search_scope)
         return flags

--- a/plugin/flags_sources/compilation_db.py
+++ b/plugin/flags_sources/compilation_db.py
@@ -197,6 +197,8 @@ class CompilationDb(FlagsSource):
         return new_args
 
     def _find_related_sources(self, file_path):
+        if not file_path:
+            return
         templates = self._header_to_source_map
         dirname = path.dirname(file_path)
         basename = path.basename(file_path)

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -83,6 +83,7 @@ class SettingsStorage:
         "use_libclang",
         "use_libclang_caching",
         "verbose",
+        "header_to_source_mapping",
     ]
 
     def __init__(self, settings_handle):

--- a/plugin/view_config.py
+++ b/plugin/view_config.py
@@ -215,9 +215,11 @@ class ViewConfig(object):
                 flag_source = CMakeFile(include_prefixes,
                                         prefix_paths,
                                         cmake_flags,
-                                        settings.cmake_binary)
+                                        settings.cmake_binary,
+                                        settings.header_to_source_mapping)
             elif file_name == "compile_commands.json":
-                flag_source = CompilationDb(include_prefixes)
+                flag_source = CompilationDb(
+                    include_prefixes, settings.header_to_source_mapping)
             elif file_name == ".clang_complete":
                 flag_source = FlagsFile(include_prefixes)
             # try to get flags (uses cache when needed)

--- a/tests/test_compilation_db.py
+++ b/tests/test_compilation_db.py
@@ -78,8 +78,6 @@ class TestCompilationDb(TestCase):
         self.assertEqual(expected_lib, db.get_flags(lib_file_path, scope))
         self.assertEqual(expected_lib, db.get_flags(lib_file_path_h, scope))
         self.assertEqual(expected_main, db.get_flags(main_file_path, scope))
-        lib_file_path = path.splitext(lib_file_path)[0]
-        main_file_path = path.splitext(main_file_path)[0]
         self.assertIn(lib_file_path, db._cache)
         self.assertIn(main_file_path, db._cache)
         path_to_db = path.join(path.dirname(__file__),
@@ -118,8 +116,6 @@ class TestCompilationDb(TestCase):
         scope = SearchScope(from_folder=path_to_db)
         self.assertEqual(expected_lib, db.get_flags(lib_file_path, scope))
         self.assertEqual(expected_main, db.get_flags(main_file_path, scope))
-        lib_file_path = path.splitext(lib_file_path)[0]
-        main_file_path = path.splitext(main_file_path)[0]
         # check persistence
         self.assertGreater(len(db._cache), 2)
         self.assertEqual(path.join(path_to_db, "compile_commands.json"),


### PR DESCRIPTION
When using a compilation DB (i.e. directly or via CMake), one can now
use templates to find a "related" source file for a header file. This is
done by using globbing expressions which may contain additional
placeholders. These expressions describe how to look for a related
source file relative to a given header file. The first match that is
found in the DB is then used as flags source. This reduced the number of
flags passed to clang for auto-completion which in turn might avoid some
compilation issues in more complex project setups.

This should fix #353.