### PR TITLE
Make sure we are not running same job over and over

### DIFF
--- a/plugin/utils/thread_pool.py
+++ b/plugin/utils/thread_pool.py
@@ -6,7 +6,7 @@ Attributes:
 import time
 import logging
 from concurrent import futures
-from threading import RLock
+from threading import Lock
 from threading import Thread
 
 from ..tools import singleton
@@ -55,8 +55,10 @@ class ThreadJob:
         """Representation."""
         return "job: '{name}'".format(name=self.name)
 
-    def is_higher_priority_than(self, other):
+    def overrides(self, other):
         """Define if one job is higher priority than the other."""
+        if self.is_same_type_as(other):
+            return True
         if self.__is_high_priority() and not other.__is_high_priority():
             return True
         return False
@@ -95,8 +97,8 @@ class ThreadPool:
         self.__thread_pool = futures.ThreadPoolExecutor(
             max_workers=max_workers)
 
-        self.__lock = RLock()
-        self.__progress_lock = RLock()
+        self.__lock = Lock()
+        self.__progress_lock = Lock()
 
         self.__show_animation = False
 
@@ -123,30 +125,32 @@ class ThreadPool:
             self.__progress_status = val
 
     def new_job(self, job):
-        """Add a new job to be submitted.
+        """Add a new job to be submitted to a thread pool.
 
         Args:
             job (ThreadJob): A job to be run asynchronously.
         """
         # Cancel all the jobs with the same name that are already running.
+        # Iterating over a list is atomic in python, so we should be safe.
+        for active_job in self.__active_jobs:
+            if job.overrides(active_job):
+                if active_job.future.cancel():
+                    log.debug("Canceled job: '%s'", job)
+                else:
+                    log.debug("Cannot cancel job: '%s'", active_job)
+        # Submit a new job to the pool.
+        future = self.__thread_pool.submit(job.function, *job.args)
+        future.add_done_callback(job.callback)
+        future.add_done_callback(self.__on_job_done)
+        job.future = future  # Set the future for this job.
         with self.__lock:
-            for active_job in self.__active_jobs:
-                if job.is_same_type_as(active_job) \
-                        or job.is_higher_priority_than(active_job):
-                    if active_job.future.cancel():
-                        log.debug("Canceled job: '%s'", job)
-                    else:
-                        log.debug("Cannot cancel job: '%s'", active_job)
-            # Submit a new job to the pool.
-            future = self.__thread_pool.submit(job.function, *job.args)
-            future.add_done_callback(job.callback)
-            future.add_done_callback(self.__on_job_done)
-            job.future = future  # Set the future for this job.
             self.__active_jobs.append(job)
             self.__show_animation = True
 
     def __on_job_done(self, future):
-        """Call this when the job is done."""
+        """Call this when the job is done or cancelled."""
+        # We want to clear the old list and alter the positions of elements.
+        # This is a potentially dangerous operation, so protect it by a mutex.
         with self.__lock:
             self.__active_jobs[:] = [
                 job for job in self.__active_jobs if not job.future.done()]

--- a/plugin/utils/thread_pool.py
+++ b/plugin/utils/thread_pool.py
@@ -1,4 +1,4 @@
-"""This file defines a class for managing a thread pool with delayed execution.
+"""Define a class for managing a thread pool with delayed execution.
 
 Attributes:
     log (logging.Logger): Logger for current module.
@@ -6,9 +6,10 @@ Attributes:
 import time
 import logging
 from concurrent import futures
-from threading import Timer
 from threading import RLock
 from threading import Thread
+
+from ..tools import singleton
 
 log = logging.getLogger("ECC")
 
@@ -19,9 +20,14 @@ class ThreadJob:
     Attributes:
         name (str): Name of this job.
         callback (func): Function to use as callback.
-        function (func): Function to run asyncronously.
+        function (func): Function to run asynchronously.
         args (object[]): Sequence of additional arguments for `function`.
     """
+
+    UPDATE_TAG = "update"
+    CLEAR_TAG = "clear"
+    COMPLETE_TAG = "complete"
+    INFO_TAG = "info"
 
     def __init__(self, name, callback, function, args):
         """Initialize a job.
@@ -29,55 +35,81 @@ class ThreadJob:
         Args:
             name (str): Name of this job.
             callback (func): Function to use as callback.
-            function (func): Function to run asyncronously.
+            function (func): Function to run asynchronously.
             args (object[]): Sequence of additional arguments for `function`.
+            future (future): A future that tracks the execution of this job.
         """
         self.name = name
         self.callback = callback
         self.function = function
         self.args = args
+        self.future = None
+
+    def __is_high_priority(self):
+        """Check if job is high priority."""
+        is_update = self.name == ThreadJob.UPDATE_TAG
+        is_clear = self.name == ThreadJob.CLEAR_TAG
+        return is_update or is_clear
 
     def __repr__(self):
         """Representation."""
-        return "job: '{name}', args: ({args})".format(
-            name=self.name, args=self.args)
+        return "job: '{name}'".format(name=self.name)
+
+    def is_higher_priority_than(self, other):
+        """Define if one job is higher priority than the other."""
+        if self.__is_high_priority() and not other.__is_high_priority():
+            return True
+        return False
+
+    def is_same_type_as(self, other):
+        """Define if these are the same type of jobs."""
+        return self.name == other.name
 
 
+@singleton
 class ThreadPool:
     """Thread pool that makes sure we don't get recurring jobs.
 
-    Whenever a job is submitted to this pool, the pool waits for a specified
-    amount of time before actually submitting the job to an async pool of
-    threads. Therefore we avoid running similar jobs over and over again.
+    Whenever a job is submitted we check if there is already a job like this
+    running. If it is, we try to cancel the previous job. We are only able to
+    cancel this job if it has not started yet.
+
+    Example:
+
+    active:     ['update', 'info'] and 'update' is running.
+    incoming:   'update' and then another 'update'.
+
+    We will try to cancel the first 'update' and will fail as it is running. We
+    still cancel the 'info' job as it has less priority (no need to get info if
+    the translation unit is not up to date). We add a new 'update' to the list.
+    Now there are two 'update' jobs, one running, one pending. Adding another
+    'update' job will replace the pending update job.
     """
 
-    __lock = RLock()
-    __progress_lock = RLock()
-
-    __jobs_to_run = {}
-    __running_jobs_count = 0
-    __show_animation = False
-
-    __progress_update_delay = 0.1
-    __progress_idle_delay = 0.3
-
-    def __init__(self, max_workers, run_delay=0.1):
+    def __init__(self, max_workers=1):
         """Create a thread pool.
 
         Args:
             max_workers (int): Maximum number of parallel workers.
-            run_delay (float, optional): Time of delay in seconds.
         """
-        self.__timer = None
-        self.__delay = run_delay
         self.__thread_pool = futures.ThreadPoolExecutor(
             max_workers=max_workers)
+
+        self.__lock = RLock()
+        self.__progress_lock = RLock()
+
+        self.__show_animation = False
+
+        self.__progress_update_delay = 0.1
+        self.__progress_idle_delay = 0.3
+
+        # All the jobs that are currently active are stored here.
+        self.__active_jobs = []
 
         # start animation thread
         self.__progress_status = None
         self.__progress_thread = Thread(target=self.__animate_progress,
-                                        daemon=True)
-        self.__progress_thread.start()
+                                        daemon=True).start()
 
     @property
     def progress_status(self):
@@ -94,55 +126,45 @@ class ThreadPool:
         """Add a new job to be submitted.
 
         Args:
-            job (ThreadJob): A job to be run asyncronously.
+            job (ThreadJob): A job to be run asynchronously.
         """
-        with ThreadPool.__lock:
-            ThreadPool.__jobs_to_run[job.name] = job
-            self.__restart_timer()
+        # Cancel all the jobs with the same name that are already running.
+        with self.__lock:
+            for active_job in self.__active_jobs:
+                if job.is_same_type_as(active_job) \
+                        or job.is_higher_priority_than(active_job):
+                    if active_job.future.cancel():
+                        log.debug("Canceled job: '%s'", job)
+                    else:
+                        log.debug("Cannot cancel job: '%s'", active_job)
+            # Submit a new job to the pool.
+            future = self.__thread_pool.submit(job.function, *job.args)
+            future.add_done_callback(job.callback)
+            future.add_done_callback(self.__on_job_done)
+            job.future = future  # Set the future for this job.
+            self.__active_jobs.append(job)
+            self.__show_animation = True
 
-    def __restart_timer(self):
-        """Restart timer because there was a change in jobs."""
-        if self.__timer:
-            self.__timer.cancel()
-        self.__timer = Timer(self.__delay, self.__submit_jobs)
-        self.__timer.start()
-
-    def __submit_jobs(self):
-        """Submit jobs that survived the delay."""
-        with ThreadPool.__lock:
-            for job in ThreadPool.__jobs_to_run.values():
-                log.debug("submitting job: %s", job)
-                future = self.__thread_pool.submit(job.function, *job.args)
-                future.add_done_callback(job.callback)
-                future.add_done_callback(self.__stop_progress_animation)
-                self.__running_jobs_count += 1
-            ThreadPool.__jobs_to_run.clear()
-            log.debug("running %s jobs", self.__running_jobs_count)
-            if self.__running_jobs_count > 0:
-                self.__progress_status.showing = True
-                self.__show_animation = True
-
-    def __stop_progress_animation(self, future):
-        """Stop progress animation thread if there are no running jobs."""
-        with ThreadPool.__lock:
-            self.__running_jobs_count -= 1
-            log.debug("Jobs still running: %s", self.__running_jobs_count)
-            if self.__running_jobs_count < 1:
-                log.debug("Stopping progress animation.")
+    def __on_job_done(self, future):
+        """Call this when the job is done."""
+        with self.__lock:
+            self.__active_jobs[:] = [
+                job for job in self.__active_jobs if not job.future.done()]
+            if len(self.__active_jobs) < 1:
                 self.__show_animation = False
 
     def __animate_progress(self):
-        """Function that changes the status message, i.e animates progress."""
+        """Change the status message, mostly used to animate progress."""
         while True:
-            sleep_time = ThreadPool.__progress_idle_delay
+            sleep_time = self.__progress_idle_delay
             with self.__progress_lock:
                 if not self.__progress_status:
-                    sleep_time = ThreadPool.__progress_idle_delay
+                    sleep_time = self.__progress_idle_delay
                 elif self.__show_animation:
                     self.__progress_status.show_next_message()
-                    sleep_time = ThreadPool.__progress_update_delay
+                    sleep_time = self.__progress_update_delay
                 else:
                     self.__progress_status.show_ready_message()
-                    sleep_time = ThreadPool.__progress_idle_delay
-            # allow some time for progress status to be updated
+                    sleep_time = self.__progress_idle_delay
+            # Allow some time for progress status to be updated.
             time.sleep(sleep_time)

--- a/tests/test_thread_pool.py
+++ b/tests/test_thread_pool.py
@@ -12,58 +12,73 @@ ThreadJob = EasyClangComplete.plugin.utils.thread_pool.ThreadJob
 
 
 def run_me(succeed):
-    """A simple function to run asyncronously."""
+    """Run this asyncronously."""
+    time.sleep(0.1)
     return succeed
+
+
+class TestContainer():
+    """A test container to store results of the operation."""
+
+    def __init__(self, cancelled, result):
+        """Initialize this object."""
+        self.cancelled = cancelled
+        self.result = result
+
+    def on_job_done(self, future):
+        """Call this when the job is done."""
+        if future.cancelled():
+            self.cancelled = True
+            self.result = False
+            return
+        self.result = future.result()
 
 
 class test_thread_pool(TestCase):
     """Test thread pool."""
 
-    def callback_func(self, future):
-        """Simple callback function to store result."""
-        self.last_result = future.result()
-
-    def override_func(self, future):
-        """Simple callback function to store overridable result."""
-        self.override_result = future.result()
-
     def test_single_job(self):
         """Test single job."""
+        test_container = TestContainer(False, False)
         job = ThreadJob(name="test_job",
-                        callback=self.callback_func,
+                        callback=test_container.on_job_done,
                         function=run_me,
                         args=[True])
-        pool = ThreadPool(max_workers=4)
+        pool = ThreadPool()
         pool.new_job(job)
         time.sleep(0.2)
-        self.assertTrue(self.last_result)
+        self.assertTrue(test_container.result)
 
     def test_fail_job(self):
         """Test fail job."""
+        test_container = TestContainer(False, False)
         job = ThreadJob(name="test_job",
-                        callback=self.callback_func,
+                        callback=test_container.on_job_done,
                         function=run_me,
                         args=[False])
-        pool = ThreadPool(max_workers=4)
+        pool = ThreadPool()
         pool.new_job(job)
         time.sleep(0.2)
-        self.assertFalse(self.last_result)
+        self.assertFalse(test_container.result)
 
     def test_override_job(self):
         """Test overriding job.
 
         The first job should be overridden by the next one.
         """
+        test_container = TestContainer(False, False)
         job_good = ThreadJob(name="test_job",
-                             callback=self.override_func,
                              function=run_me,
+                             callback=test_container.on_job_done,
                              args=[True])
         job_bad = ThreadJob(name="test_job",
-                            callback=self.override_func,
                             function=run_me,
+                            callback=test_container.on_job_done,
                             args=[False])
-        pool = ThreadPool(max_workers=4)
-        pool.new_job(job_bad)
-        pool.new_job(job_good)
-        time.sleep(0.2)
-        self.assertTrue(self.override_result)
+        pool = ThreadPool()
+        pool.new_job(job_good)  # Initial.
+        pool.new_job(job_bad)   # Cannot override as prev is running.
+        pool.new_job(job_good)  # Overrides the previous one.
+        time.sleep(0.3)
+        self.assertTrue(test_container.result)
+        self.assertTrue(test_container.cancelled)

--- a/tests/test_thread_pool.py
+++ b/tests/test_thread_pool.py
@@ -82,3 +82,23 @@ class test_thread_pool(TestCase):
         time.sleep(0.3)
         self.assertTrue(test_container.result)
         self.assertTrue(test_container.cancelled)
+
+    def test_no_override_job(self):
+        """Test adding the same job while running another instance of it."""
+        test_container = TestContainer(False, False)
+        job_good = ThreadJob(name="test_job",
+                             function=run_me,
+                             callback=test_container.on_job_done,
+                             args=[True])
+        job_bad = ThreadJob(name="test_job",
+                            function=run_me,
+                            callback=test_container.on_job_done,
+                            args=[False])
+        pool = ThreadPool()
+        pool.new_job(job_good)  # Initial.
+        time.sleep(0.05)
+        self.assertFalse(test_container.result)
+        pool.new_job(job_bad)   # Cannot override as prev is running.
+        time.sleep(0.1)
+        self.assertTrue(test_container.result)
+        self.assertFalse(test_container.cancelled)


### PR DESCRIPTION
This commit introduces a new way of handling jobs.
The number of threads is reduced from 4 to 1 as
we anyway need only 1 as there is no async access
to the translation unit.

The jobs are now all stored and we guarantee that
we never add two jobs that do the same things
to be executed.