### PR TITLE
Implement timers to remove old TUs in a sane way

### DIFF
--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -274,6 +274,8 @@ class EasyClangComplete(sublime_plugin.EventListener):
         # disable on_activated_async when running tests
         if view.settings().get("disable_easy_clang_complete"):
             return
+        if not view.file_name():
+            return
         if view.file_name().endswith('.sublime-project'):
             if not EasyClangComplete.settings_manager:
                 log.error("no settings manager, no cannot reload settings")

--- a/tests/test_view_config.py
+++ b/tests/test_view_config.py
@@ -167,7 +167,7 @@ class TestViewConfigManager(GuiTestWrapper):
                               'test.cpp')
         self.set_up_view(file_name)
         manager = SettingsManager()
-        config_manager = ViewConfigManager()
+        config_manager = ViewConfigManager(timer_period=1)
         settings = manager.settings_for_view(self.view)
         view_config = config_manager.load_for_view(self.view, settings)
         self.assertEqual(view_config.completer.name, "lib")
@@ -184,7 +184,7 @@ class TestViewConfigManager(GuiTestWrapper):
                               'test.cpp')
         self.set_up_view(file_name)
         manager = SettingsManager()
-        config_manager = ViewConfigManager()
+        config_manager = ViewConfigManager(timer_period=1)
         settings = manager.settings_for_view(self.view)
         view_config = config_manager.load_for_view(self.view, settings)
         self.assertIsNotNone(view_config)
@@ -201,14 +201,14 @@ class TestViewConfigManager(GuiTestWrapper):
                               'test.cpp')
         self.set_up_view(file_name)
         manager = SettingsManager()
-        config_manager = ViewConfigManager()
+        config_manager = ViewConfigManager(timer_period=1)
         settings = manager.settings_for_view(self.view)
-        settings.max_cache_age = 3  # seconds
-        initial_period = ViewConfigManager._ViewConfigManager__timer_period
+        settings.max_cache_age = 2  # seconds
+        initial_period = config_manager._ViewConfigManager__timer_period
         ViewConfigManager._ViewConfigManager__timer_period = 1
         view_config = config_manager.load_for_view(self.view, settings)
         self.assertIsNotNone(view_config)
-        time.sleep(4)
+        time.sleep(3)
         view_config = config_manager.get_from_cache(self.view)
         self.assertIsNone(view_config)
         ViewConfigManager._ViewConfigManager__timer_period = initial_period


### PR DESCRIPTION
Before I had this brilliant idea that every time we touch a file we should update a timer that would remove its TU *exactly* in a given time. This, of course, if completely unnecessary. 

Now there is a single thread that removes the view configurations along with the translation units of the views that have not been touched in a while.