### PR TITLE
Show all errors for a view

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,3 +1,0 @@
-[
-  { "keys": ["shift+f12"], "command": "ecc_goto_declaration"}
-]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,3 +1,0 @@
-[
-  { "keys": ["shift+f12"], "command": "ecc_goto_declaration"}
-]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,3 +1,0 @@
-[
-  { "keys": ["shift+f12"], "command": "ecc_goto_declaration"}
-]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -14,6 +14,10 @@
         }
     },
     {
+        "caption": "EasyClangComplete: Show all errors",
+        "command": "ecc_show_all_errors"
+    },
+    {
         "caption": "EasyClangComplete: Clean current CMake cache",
         "command": "clean_cmake"
     },

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,0 +1,4 @@
+[
+  { "keys": ["shift+f12"], "command": "ecc_goto_declaration"},
+  { "keys": ["ctrl+shift+e"], "command": "ecc_show_all_errors"}
+]

--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -19,6 +19,7 @@ from .plugin import view_config
 from .plugin import flags_sources
 from .plugin.utils import thread_pool
 from .plugin.utils import progress_status
+from .plugin.utils import quick_panel_handler
 from .plugin.settings import settings_manager
 from .plugin.settings import settings_storage
 
@@ -38,6 +39,7 @@ CMakeFile = flags_sources.cmake_file.CMakeFile
 CMakeFileCache = flags_sources.cmake_file.CMakeFileCache
 ThreadPool = thread_pool.ThreadPool
 ThreadJob = thread_pool.ThreadJob
+QuickPanelHandler = quick_panel_handler.QuickPanelHandler
 
 log = logging.getLogger("ECC")
 log.setLevel(logging.DEBUG)
@@ -71,6 +73,39 @@ def plugin_loaded():
 def plugin_unloaded():
     """Call right before the package was unloaded."""
     handle_plugin_unloaded_function()
+
+
+class EccShowAllErrorsCommand(sublime_plugin.TextCommand):
+    """Handle easy_clang_goto_declaration command."""
+
+    def run(self, edit):
+        """Show all errors available in this view.
+
+        This function shows all errors that are available from within a view.
+        Note that the errors can be from different files.
+        """
+        if not Tools.is_valid_view(self.view):
+            return
+        config_manager = EasyClangComplete.view_config_manager
+        if not config_manager:
+            log.error("No ViewConfigManager available.")
+            return
+        config = config_manager.get_from_cache(self.view)
+        log.debug("config: %s", config)
+        if not config:
+            log.error("No ViewConfig for view: %s.", self.view.buffer_id())
+            return
+        if not config.completer:
+            log.error("No Completer for view: %s.", self.view.buffer_id())
+        handler = QuickPanelHandler(self.view, config.completer.latest_errors)
+        start_idx = 0
+        self.view.window().show_quick_panel(
+            handler.items_to_show(),
+            handler.on_done,
+            sublime.MONOSPACE_FONT,
+            start_idx,
+            handler.on_highlighted)
+        print(config.completer.latest_errors)
 
 
 class EccGotoDeclarationCommand(sublime_plugin.TextCommand):

--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -24,6 +24,7 @@ from .plugin.settings import settings_manager
 from .plugin.settings import settings_storage
 
 # reload the modules
+tools.Reloader.reload_all()
 
 # some aliases
 SettingsManager = settings_manager.SettingsManager

--- a/plugin/completion/base_complete.py
+++ b/plugin/completion/base_complete.py
@@ -44,9 +44,11 @@ class BaseCompleter:
         self.clang_binary = settings.clang_binary
         # initialize error visualization
         self.error_vis = error_vis
+        # Store the latest errors here
+        self.latest_errors = None
 
     def complete(self, completion_request):
-        """Function to generate completions. See children for implementation.
+        """Generate completions. See children for implementation.
 
         Args:
             completion_request (ActionRequest): request object
@@ -98,16 +100,22 @@ class BaseCompleter:
         """
         raise NotImplementedError("calling abstract method")
 
-    def show_errors(self, view, output):
+    def save_errors(self, output):
+        """Generate and store the errors.
+
+        Args:
+            output (object): opaque output to be parsed by compiler variant
+        """
+        self.latest_errors = self.compiler_variant.errors_from_output(output)
+
+    def show_errors(self, view):
         """Show current complie errors.
 
         Args:
             view (sublime.View): Current view
-            output (object): opaque output to be parsed by compiler variant
         """
-        errors = self.compiler_variant.errors_from_output(output)
         if not Tools.is_valid_view(view):
             log.error("cannot show errors. View became invalid!")
             return
-        self.error_vis.generate(view, errors)
+        self.error_vis.generate(view, self.latest_errors)
         self.error_vis.show_errors(view)

--- a/plugin/completion/lib_complete.py
+++ b/plugin/completion/lib_complete.py
@@ -160,13 +160,14 @@ class Completer(BaseCompleter):
                     unsaved_files=unsaved_files,
                     options=parse_options)
                 self.tu = trans_unit
+                self.save_errors(self.tu.diagnostics)  # Store for the future.
             except Exception as e:
                 log.error("error while compiling: %s", e)
             end = time.time()
             log.debug("compilation done in %s seconds", end - start)
 
     def complete(self, completion_request):
-        """Called asynchronously to create a list of autocompletions.
+        """Create a list of autocompletions. Called asynchronously.
 
         Using the current translation unit it queries libclang for the
         possible completions.
@@ -325,8 +326,10 @@ class Completer(BaseCompleter):
             self.tu.reparse()
             end = time.time()
             log.debug("reparsed in %s seconds", end - start)
+            # Store and potentially show errors to the user.
+            self.save_errors(self.tu.diagnostics)  # Store for the future.
             if settings.errors_style != SettingsStorage.NONE_STYLE:
-                self.show_errors(view, self.tu.diagnostics)
+                self.show_errors(view)
             return True
         log.error("no translation unit for view id %s", v_id)
         return False

--- a/plugin/utils/__init__.py
+++ b/plugin/utils/__init__.py
@@ -6,4 +6,8 @@ thread_pool: A class that encapsulates a thread pool to allow delayed run.
 progress_status: A class for showing a progress indicator in status line.
 
 """
-__all__ = ("unique_list", "flag", "thread_pool", "progress_status")
+__all__ = ("unique_list",
+           "flag",
+           "thread_pool",
+           "progress_status",
+           "quick_panel_handler")

--- a/plugin/utils/quick_panel_handler.h
+++ b/plugin/utils/quick_panel_handler.h
@@ -1,7 +1,0 @@
-class QuickPannelHandler
-{
-public:
-  QuickPannelHandler();
-  ~QuickPannelHandler();
-
-};

--- a/plugin/utils/quick_panel_handler.h
+++ b/plugin/utils/quick_panel_handler.h
@@ -1,0 +1,7 @@
+class QuickPannelHandler
+{
+public:
+  QuickPannelHandler();
+  ~QuickPannelHandler();
+
+};

--- a/plugin/utils/quick_panel_handler.py
+++ b/plugin/utils/quick_panel_handler.py
@@ -1,0 +1,43 @@
+"""Host a class that controls the way we interact with quick pannel."""
+
+import logging
+import sublime
+
+log = logging.getLogger("ECC")
+
+
+class QuickPanelHandler(object):
+    """Handle the quick panel."""
+
+    def __init__(self, view, errors):
+        """Initialize the object.
+
+        Args:
+            view (sublime.View): Current view.
+            errors (list(dict)): A list of error dicts.
+        """
+        self.view = view
+        self.errors = errors
+
+    def items_to_show(self):
+        """Present errors as list of lists."""
+        contents = []
+        for error_dict in self.errors:
+            contents.append([error_dict['error'], error_dict['file']])
+        return contents
+
+    def on_done(self, idx):
+        """Pick this error to navigate to a file."""
+        log.debug("Picked idx: %s", idx)
+        if idx < 0:
+            return
+        picked_entry = self.errors[idx]
+        file_str = "{file}:{row}:{col}".format(file=picked_entry['file'],
+                                               row=picked_entry['row'],
+                                               col=picked_entry['col'])
+        self.view.window().open_file(file_str, sublime.ENCODED_POSITION)
+
+    def on_highlighted(self, idx):
+        """Peek into a file upon highlighting the error from it."""
+        log.debug("Navigated to idx: %s", idx)
+        pass

--- a/plugin/view_config.py
+++ b/plugin/view_config.py
@@ -344,8 +344,9 @@ class ViewConfigManager(object):
             return None
         v_id = view.buffer_id()
         if v_id in self.__cache:
-            log.debug("config exists for path: %s", v_id)
+            log.debug("config exists for view: %s", v_id)
             self.__cache[v_id].touch()
+            log.debug("config: %s", self.__cache[v_id])
             return self.__cache[v_id]
         return None
 


### PR DESCRIPTION
This PR adds functionality to show all errors for an open file.
This can be triggered either from a command palette or by pressing a key combination <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>E</kbd> 

This is useful for finding out the issues in the files higher in the hierarchy that cause arbitrary errors in the current file. Should fix #350 