### PR TITLE
Use compiler built ins

### DIFF
--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -153,12 +153,34 @@
     // "{stamp}.mycustomext
   ],
 
-  // Controls if we try to retrieve built-in flags from the compiler.
-  // Compilers tend to set some pre-defined symbols as well as include
-  // paths. If this option is on, we will ask the compiler for these and
-  // explicitly append them to the list of flags passed to clang when
-  // retrieving auto-completions.
-  // Generally, this option should improve the completion quality, however,
-  // if you encounter issues, you can turn it off.
-  "use_compiler_built_in_flags": true,
+  // Controls if we try to retrieve built-in flags from the target compiler.
+  // This option is used when we use a `compile_commands.json` file
+  // either directly or indirectly e.g. via CMake.
+  // If set to true, we try to ask the compiler for the defines and
+  // include paths it sets implicitly and pass them to the
+  // clang compiler which is used to generate the code completion.
+  // Usually, this option should improve the quality of the
+  // completions, however, in some corner cases it might cause
+  // completions to fails entirely. In this case, try to
+  // set this option to false.
+  "use_target_compiler_built_in_flags": true,
+
+  // Target compilers.
+  // The below options allow to set the actual target compilers (i.e.
+  // the one you use in your build chain). If they are set, we will
+  // ask the compilers for their built in flags (defines and include
+  // paths) and pass them to the clang compiler to generate code
+  // completions. This is especially useful when working with
+  // non-host tool chains, where the compilers might set additional
+  // target specific defines which are now seen by the (host) clang
+  // compiler.
+  // Note: These settings are only used if the target compiler
+  // cannot be retrieved otherwise, e.g. from a `compile_commands.json`
+  // file.
+  // Note: The set compilers will also be passed to CMake if you use
+  // it as source.
+  "target_c_compiler": null,
+  "target_cpp_compiler": null,
+  "target_objective_c_compiler": null,
+  "target_objective_cpp_compiler": null,
 }

--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -160,5 +160,5 @@
   // retrieving auto-completions.
   // Generally, this option should improve the completion quality, however,
   // if you encounter issues, you can turn it off.
-  "use_compiler_built_in_flags": false,
+  "use_compiler_built_in_flags": true,
 }

--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -152,4 +152,13 @@
     // "exotic" file name suffix:
     // "{stamp}.mycustomext
   ],
+
+  // Controls if we try to retrieve built-in flags from the compiler.
+  // Compilers tend to set some pre-defined symbols as well as include
+  // paths. If this option is on, we will ask the compiler for these and
+  // explicitly append them to the list of flags passed to clang when
+  // retrieving auto-completions.
+  // Generally, this option should improve the completion quality, however,
+  // if you encounter issues, you can turn it off.
+  "use_compiler_built_in_flags": false,
 }

--- a/plugin/flags_sources/cmake_file.py
+++ b/plugin/flags_sources/cmake_file.py
@@ -41,9 +41,9 @@ class CMakeFile(FlagsSource):
                  include_prefixes,
                  prefix_paths,
                  flags,
-                 cmake_binary="cmake",
-                 header_to_source_mapping=None,
-                 use_target_compiler_builtins=False):
+                 cmake_binary,
+                 header_to_source_mapping,
+                 use_target_compiler_builtins):
         """Initialize a cmake-based flag storage.
 
         Args:

--- a/plugin/flags_sources/cmake_file.py
+++ b/plugin/flags_sources/cmake_file.py
@@ -43,7 +43,7 @@ class CMakeFile(FlagsSource):
                  flags,
                  cmake_binary="cmake",
                  header_to_source_mapping=None,
-                 use_compiler_builtins=False):
+                 use_target_compiler_builtins=False):
         """Initialize a cmake-based flag storage.
 
         Args:
@@ -58,7 +58,7 @@ class CMakeFile(FlagsSource):
         self.__cmake_flags = flags
         self.__cmake_binary = cmake_binary
         self.__header_to_source_mapping = header_to_source_mapping
-        self.__use_compiler_builtins = use_compiler_builtins
+        self.__use_target_compiler_builtins = use_target_compiler_builtins
 
     def get_flags(self, file_path=None, search_scope=None):
         """Get flags for file.
@@ -103,7 +103,7 @@ class CMakeFile(FlagsSource):
                 db = CompilationDb(
                     self._include_prefixes,
                     self.__header_to_source_mapping,
-                    self.__use_compiler_builtins
+                    self.__use_target_compiler_builtins
                 )
                 db_search_scope = SearchScope(
                     from_folder=path.dirname(db_file_path))

--- a/plugin/flags_sources/cmake_file.py
+++ b/plugin/flags_sources/cmake_file.py
@@ -123,7 +123,9 @@ class CMakeFile(FlagsSource):
             self._cache[current_cmake_path] = db_file.full_path()
             File.update_mod_time(current_cmake_path)
         db = CompilationDb(
-            self._include_prefixes, self.__header_to_source_mapping)
+            self._include_prefixes,
+            self.__header_to_source_mapping,
+            self.__use_target_compiler_builtins)
         db_search_scope = SearchScope(from_folder=db_file.folder())
         flags = db.get_flags(file_path, db_search_scope)
         return flags

--- a/plugin/flags_sources/cmake_file.py
+++ b/plugin/flags_sources/cmake_file.py
@@ -42,7 +42,8 @@ class CMakeFile(FlagsSource):
                  prefix_paths,
                  flags,
                  cmake_binary="cmake",
-                 header_to_source_mapping=None):
+                 header_to_source_mapping=None,
+                 use_compiler_builtins=False):
         """Initialize a cmake-based flag storage.
 
         Args:
@@ -57,6 +58,7 @@ class CMakeFile(FlagsSource):
         self.__cmake_flags = flags
         self.__cmake_binary = cmake_binary
         self.__header_to_source_mapping = header_to_source_mapping
+        self.__use_compiler_builtins = use_compiler_builtins
 
     def get_flags(self, file_path=None, search_scope=None):
         """Get flags for file.
@@ -99,7 +101,10 @@ class CMakeFile(FlagsSource):
                 log.debug("[cmake]:[unchanged]: use existing db.")
                 db_file_path = self._cache[cached_cmake_path]
                 db = CompilationDb(
-                    self._include_prefixes, self.__header_to_source_mapping)
+                    self._include_prefixes,
+                    self.__header_to_source_mapping,
+                    self.__use_compiler_builtins
+                )
                 db_search_scope = SearchScope(
                     from_folder=path.dirname(db_file_path))
                 return db.get_flags(file_path, db_search_scope)

--- a/plugin/flags_sources/compilation_db.py
+++ b/plugin/flags_sources/compilation_db.py
@@ -152,7 +152,6 @@ class CompilationDb(FlagsSource):
             # If enabled, try to retrieve default flags for the compiler
             # and language combination:
             if self._use_compiler_builtins:
-
                 # Note: Calling the CompilerBuiltIns constructor shells out to
                 # calling the compiler; however, for every
                 # compiler/standard/language

--- a/plugin/flags_sources/compilation_db.py
+++ b/plugin/flags_sources/compilation_db.py
@@ -165,7 +165,6 @@ class CompilationDb(FlagsSource):
                 argument_list = (
                     argument_list[:-1] + builtins.flags +
                     argument_list[-1:])
-                #argument_list += builtins.defines
 
             argument_list = CompilationDb.filter_bad_arguments(argument_list)
             flags = FlagsSource.parse_flags(base_path,

--- a/plugin/flags_sources/compilation_db.py
+++ b/plugin/flags_sources/compilation_db.py
@@ -32,7 +32,8 @@ class CompilationDb(FlagsSource):
     _FILE_NAME = "compile_commands.json"
 
     def __init__(self, include_prefixes,
-                 header_to_source_map=None):
+                 header_to_source_map=None,
+                 use_compiler_builtins=False):
         """Initialize a compilation database.
 
         Args:
@@ -42,6 +43,7 @@ class CompilationDb(FlagsSource):
         super().__init__(include_prefixes)
         self._cache = ComplationDbCache()
         self._header_to_source_map = header_to_source_map
+        self._use_compiler_builtins = use_compiler_builtins
 
     def get_flags(self, file_path=None, search_scope=None):
         """Get flags for file.
@@ -117,6 +119,8 @@ class CompilationDb(FlagsSource):
             unique entries for 'all' entry.
         """
         import json
+        from ..utils.compiler_builtins import CompilerBuiltIns
+
         data = None
 
         with open(database_file.full_path()) as data_file:
@@ -144,6 +148,25 @@ class CompilationDb(FlagsSource):
                 # TODO(igor): maybe show message to the user instead here
                 log.critical(" compilation database has unsupported format")
                 return None
+
+            # If enabled, try to retrieve default flags for the compiler
+            # and language combination:
+            if self._use_compiler_builtins:
+
+                # Note: Calling the CompilerBuiltIns constructor shells out to
+                # calling the compiler; however, for every
+                # compiler/standard/language
+                # combination, the results are cached by the class internally.
+                builtins = CompilerBuiltIns(argument_list)
+
+                # Append built-in flags to the end of the list:
+                # Note: Currently, we only pass through defines.
+                # If we start passing include paths, we end up nowhere
+                # right now, as clang then uses a wild mix of its own
+                # include paths and the ones of the compiler used by the
+                # project...
+                argument_list = argument_list[:-1] + builtins.defines + argument_list[-1:]
+                #argument_list += builtins.defines
 
             argument_list = CompilationDb.filter_bad_arguments(argument_list)
             flags = FlagsSource.parse_flags(base_path,

--- a/plugin/flags_sources/compilation_db.py
+++ b/plugin/flags_sources/compilation_db.py
@@ -32,13 +32,15 @@ class CompilationDb(FlagsSource):
     _FILE_NAME = "compile_commands.json"
 
     def __init__(self, include_prefixes,
-                 header_to_source_map=None,
-                 use_target_compiler_builtins=False):
+                 header_to_source_map,
+                 use_target_compiler_builtins):
         """Initialize a compilation database.
 
         Args:
             include_prefixes (str[]): A List of valid include prefixes.
             header_to_source_map (str[]): Templates to map header to sources.
+            use_target_compiler_builtins (bool): Retrieve target compiler built
+                                                 ins.
         """
         super().__init__(include_prefixes)
         self._cache = ComplationDbCache()

--- a/plugin/flags_sources/compilation_db.py
+++ b/plugin/flags_sources/compilation_db.py
@@ -33,7 +33,7 @@ class CompilationDb(FlagsSource):
 
     def __init__(self, include_prefixes,
                  header_to_source_map=None,
-                 use_compiler_builtins=False):
+                 use_target_compiler_builtins=False):
         """Initialize a compilation database.
 
         Args:
@@ -43,7 +43,7 @@ class CompilationDb(FlagsSource):
         super().__init__(include_prefixes)
         self._cache = ComplationDbCache()
         self._header_to_source_map = header_to_source_map
-        self._use_compiler_builtins = use_compiler_builtins
+        self._use_target_compiler_builtins = use_target_compiler_builtins
 
     def get_flags(self, file_path=None, search_scope=None):
         """Get flags for file.
@@ -151,12 +151,12 @@ class CompilationDb(FlagsSource):
 
             # If enabled, try to retrieve default flags for the compiler
             # and language combination:
-            if self._use_compiler_builtins:
+            if self._use_target_compiler_builtins:
                 # Note: Calling the CompilerBuiltIns constructor shells out to
                 # calling the compiler; however, for every
                 # compiler/standard/language
                 # combination, the results are cached by the class internally.
-                builtins = CompilerBuiltIns(argument_list)
+                builtins = CompilerBuiltIns(argument_list, file_path)
 
                 # Append built-in flags to the end of the list:
                 # Note: We keep the last argument as last, as it

--- a/plugin/flags_sources/compilation_db.py
+++ b/plugin/flags_sources/compilation_db.py
@@ -160,12 +160,11 @@ class CompilationDb(FlagsSource):
                 builtins = CompilerBuiltIns(argument_list)
 
                 # Append built-in flags to the end of the list:
-                # Note: Currently, we only pass through defines.
-                # If we start passing include paths, we end up nowhere
-                # right now, as clang then uses a wild mix of its own
-                # include paths and the ones of the compiler used by the
-                # project...
-                argument_list = argument_list[:-1] + builtins.defines + argument_list[-1:]
+                # Note: We keep the last argument as last, as it
+                # usually is the file name.
+                argument_list = (
+                    argument_list[:-1] + builtins.flags +
+                    argument_list[-1:])
                 #argument_list += builtins.defines
 
             argument_list = CompilationDb.filter_bad_arguments(argument_list)

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -84,6 +84,7 @@ class SettingsStorage:
         "use_libclang_caching",
         "verbose",
         "header_to_source_mapping",
+        "use_compiler_built_in_flags",
     ]
 
     def __init__(self, settings_handle):

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -84,7 +84,11 @@ class SettingsStorage:
         "use_libclang_caching",
         "verbose",
         "header_to_source_mapping",
-        "use_compiler_built_in_flags",
+        "use_target_compiler_built_in_flags",
+        "target_c_compiler",
+        "target_cpp_compiler",
+        "target_objective_c_compiler",
+        "target_objective_cpp_compiler",
     ]
 
     def __init__(self, settings_handle):

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -115,7 +115,7 @@ class SettingsStorage:
             view (sublime.View): current view
         """
         try:
-            # init current and parrent folders:
+            # init current and parent folders:
             if not Tools.is_valid_view(view):
                 log.error("no view to populate common flags from")
                 return
@@ -193,6 +193,20 @@ class SettingsStorage:
                     source_dict["file"], SettingsStorage.FLAG_SOURCES)
                 return False, error_msg
         return True, ""
+
+    @property
+    def target_compilers(self):
+        """A dictionary with the target compilers to use."""
+        result = dict()
+        if hasattr(self, "target_c_compiler"):
+            result["c"] = self.target_c_compiler
+        if hasattr(self, "target_cpp_compiler"):
+            result["c++"] = self.target_cpp_compiler
+        if hasattr(self, "target_objective_c_compiler"):
+            result["objective-c"] = self.target_objective_c_compiler
+        if hasattr(self, "target_objective_cpp_compiler"):
+            result["objective-c++"] = self.target_objective_cpp_compiler
+        return result
 
     def __load_vars_from_settings(self, settings, project_specific=False):
         """Load all settings and add them as attributes of self.

--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -684,17 +684,20 @@ class Tools:
         return PosStatus.COMPLETION_NOT_NEEDED
 
     @staticmethod
-    def run_command(command, shell=True, cwd=path.curdir, env=environ):
+    def run_command(command, shell=True, cwd=path.curdir, env=environ,
+                    stdin=None, default=None):
         """Run a generic command in a subprocess.
 
         Args:
             command (str): command to run
+            stdin: The standard input channel for the started process.
+            default (andy): The default return value in case run fails.
 
         Returns:
-            str: raw command output
+            str: raw command output or default value
         """
+        output_text = default
         try:
-            stdin = None
             startupinfo = None
             if isinstance(command, list):
                 command = subprocess.list2cmdline(command)
@@ -704,7 +707,8 @@ class Tools:
                 startupinfo = subprocess.STARTUPINFO()
                 startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
                 startupinfo.wShowWindow = subprocess.SW_HIDE
-                stdin = subprocess.PIPE
+                if stdin is None:
+                    stdin = subprocess.PIPE
             output = subprocess.check_output(command,
                                              stdin=stdin,
                                              stderr=subprocess.STDOUT,
@@ -717,6 +721,9 @@ class Tools:
             output_text = e.output.decode("utf-8")
             log.debug("command finished with code: %s", e.returncode)
             log.debug("command output: \n%s", output_text)
+        except FileNotFoundError:
+            log.debug(
+                "executable file not found executing: {}".format(command))
         return output_text
 
     @classmethod

--- a/plugin/utils/__init__.py
+++ b/plugin/utils/__init__.py
@@ -4,10 +4,12 @@ unique_list: A list that guarantees element uniqueness, but saves order.
 flag: A class that encapsulates a flag that can contain two parts.
 thread_pool: A class that encapsulates a thread pool to allow delayed run.
 progress_status: A class for showing a progress indicator in status line.
+compiler_builtins: Get built-in flags of a compiler.
 
 """
 __all__ = ("unique_list",
            "flag",
            "thread_pool",
            "progress_status",
-           "quick_panel_handler")
+           "quick_panel_handler",
+           "compiler_builtins")

--- a/plugin/utils/compiler_builtins.py
+++ b/plugin/utils/compiler_builtins.py
@@ -51,12 +51,12 @@ class CompilerBuiltIns:
             language = self._guess_language(compiler)
             # Get defines and include paths from the compier:
             cfg = (compiler, std, language)
-            self._debug("Getting default flags for {}".format(cfg))
+            _log.debug("Getting default flags for {}".format(cfg))
             if cfg in CompilerBuiltIns.__cache:
-                self._debug("Reusing flags from cache")
+                _log.debug("Reusing flags from cache")
                 (defines, includes) = CompilerBuiltIns.__cache[cfg]
             else:
-                self._debug("Querying compiler for defaults")
+                _log.debug("Querying compiler for defaults")
                 defines = self._get_default_flags(compiler, std, language)
                 includes = self._get_default_include_paths(
                     compiler, std, language)
@@ -90,7 +90,7 @@ class CompilerBuiltIns:
         if len(args) > 0:
             compiler = args[0]
         else:
-            self._debug("Got empty command line - cannot extract compiler")
+            _log.debug("Got empty command line - cannot extract compiler")
         if len(args) > 1:
             for arg in args[1:]:
                 if arg.startswith("-std="):
@@ -137,7 +137,7 @@ class CompilerBuiltIns:
                     if m is not None:
                         result.append("-D{}".format(m.group(1)))
         except FileNotFoundError:
-            self._warn("Cannot find compiler %s in PATH." % compiler)
+            _log.warning("Cannot find compiler %s in PATH." % compiler)
 
         return self._filter_defines(result)
 
@@ -175,7 +175,7 @@ class CompilerBuiltIns:
                     if m is not None:
                         result.append("-I{}".format(m.group(1)))
         except FileNotFoundError:
-            self._warn("Cannot find compiler %s in PATH." % compiler)
+            _log.warning("Cannot find compiler %s in PATH." % compiler)
 
         return result
 
@@ -188,9 +188,3 @@ class CompilerBuiltIns:
                 if define.startswith(prefix):
                     defines.remove(define)
         return defines
-
-    def _debug(self, msg):
-        _log.debug("[compilerbuiltins] %s" % msg)
-
-    def _warn(self, msg):
-        _logging.warning("[compilerbuiltins] %s" % msg)

--- a/plugin/utils/compiler_builtins.py
+++ b/plugin/utils/compiler_builtins.py
@@ -1,0 +1,197 @@
+"""Get compiler built-in flags."""
+
+import logging as _logging
+
+_log = _logging.getLogger("ECC")
+
+
+class CompilerBuiltIns:
+    """
+    Get the built in flags used by a compiler.
+
+    This class tries to retrieve the built-in flags of a compiler.
+    As an input, it gets the call to a compiler plus some default
+    flags. It tries to guess some further required inputs and then
+    queries the compiler for its built-in defines and include paths.
+    """
+
+    __cache = dict()
+
+    __DEFINES_BLACKLIST = [
+        "__USER_LABEL_PREFIX__",
+        "__STDC_HOSTED__",
+        "__REGISTER_PREFIX__",
+        "__STDC__"
+    ]
+
+    def __init__(self, args):
+        """
+        Create an object holding the built-in flags of a compiler.
+
+        This constructs a new object which holds the built-in flags
+        used by a compiler. The `args` is the call to the compiler; either
+        a string or a list of strings. If a list of strings is provided, it
+        is interpreted as the call of a compiler (i.e. the first entry
+        is the compiler to call and everything else are arguments to the
+        compiler). If a single string is given, it is parsed into a string
+        list first.
+        """
+        from shlex import split
+        super().__init__()
+        self._defines = list()
+        self._include_paths = list()
+        if isinstance(args, str):
+            # Parse arguments into list of strings first
+            args = split(args)
+        # Guess the compiler and standard:
+        (compiler, std) = self._guess_compiler(args)
+        if compiler is not None:
+            # Guess the language (we need to pass it to the compiler
+            # explicitly):
+            language = self._guess_language(compiler)
+            # Get defines and include paths from the compier:
+            cfg = (compiler, std, language)
+            self._debug("Getting default flags for {}".format(cfg))
+            if cfg in CompilerBuiltIns.__cache:
+                self._debug("Reusing flags from cache")
+                (defines, includes) = CompilerBuiltIns.__cache[cfg]
+            else:
+                self._debug("Querying compiler for defaults")
+                defines = self._get_default_flags(compiler, std, language)
+                includes = self._get_default_include_paths(
+                    compiler, std, language)
+                CompilerBuiltIns.__cache[cfg] = (defines, includes)
+            self._defines = defines
+            self._include_paths = includes
+
+
+    @property
+    def defines(self):
+        """The built-in defines provided by the compiler."""
+        return self._defines
+
+    @property
+    def include_paths(self):
+        """The list of built-in include paths used by the compiler."""
+        return self._include_paths
+
+    @property
+    def flags(self):
+        """
+        The list of built-in flags.
+
+        This property holds the combined list of built-in defines and
+        include paths of the compiler.
+        """
+        return self._defines + self._include_paths
+
+    def _guess_compiler(self, args):
+        compiler = None
+        std = None
+        if len(args) > 0:
+            compiler = args[0]
+        else:
+            self._debug("Got empty command line - cannot extract compiler")
+        if len(args) > 1:
+            for arg in args[1:]:
+                if arg.startswith("-std="):
+                    std = arg[5:]
+        return (compiler, std)
+
+    def _guess_language(self, compiler):
+        """
+        Try to guess the language based on the compiler.
+
+        This is required as we need to explicitly pass a language when asking
+        the compiler later for its default flags.
+        """
+        if compiler.endswith("++"):
+            return "c++"
+        else:
+            return "c"
+
+    def _get_default_flags(self, compiler, std, language):
+        import subprocess
+        import re
+
+        result = list()
+
+        args = [compiler, "-x", language]
+        if std is not None:
+            args += ['-std=' + std]
+        args += ["-dM", "-E", "-"]
+
+        try:
+            res = subprocess.Popen(
+                args,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT
+            )
+            res.wait()
+            for line in res.stdout.read().decode().splitlines():
+                m = re.search(r'#define ([\w()]+) (.+)', line)
+                if m is not None:
+                    result.append("-D{}={}".format(m.group(1), m.group(2)))
+                else:
+                    m = re.search(r'#define (\w+)', line)
+                    if m is not None:
+                        result.append("-D{}".format(m.group(1)))
+        except FileNotFoundError:
+            self._warn("Cannot find compiler %s in PATH." % compiler)
+
+        return self._filter_defines(result)
+
+    def _get_default_include_paths(self, compiler, std, language):
+        import subprocess
+        import re
+
+        result = list()
+
+        args = [compiler, '-x', language]
+        if std is not None:
+            args += ['-std=' + std]
+        args += ['-Wp,-v', '-E', '-']
+
+        try:
+            res = subprocess.Popen(
+                args,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT
+            )
+            res.wait()
+            pick = False
+            for line in res.stdout.read().decode().splitlines():
+                if '#include <...> search starts here:' in line:
+                    pick = True
+                    continue
+                if '#include "..." search starts here:' in line:
+                    pick = True
+                    continue
+                if 'End of search list.' in line:
+                    break
+                if pick:
+                    m = re.search(r'\s*(.*)$', line)
+                    if m is not None:
+                        result.append("-I{}".format(m.group(1)))
+        except FileNotFoundError:
+            self._warn("Cannot find compiler %s in PATH." % compiler)
+
+        return result
+
+    def _filter_defines(self, defines):
+        # Remove some default flags which get set by clang itself.
+        # Otherwise, we will get error later:
+        for flag in CompilerBuiltIns.__DEFINES_BLACKLIST:
+            prefix = "-D%s" % flag
+            for define in defines:
+                if define.startswith(prefix):
+                    defines.remove(define)
+        return defines
+
+    def _debug(self, msg):
+        _log.debug("[compilerbuiltins] %s" % msg)
+
+    def _warn(self, msg):
+        _logging.warning("[compilerbuiltins] %s" % msg)

--- a/plugin/utils/compiler_builtins.py
+++ b/plugin/utils/compiler_builtins.py
@@ -64,7 +64,6 @@ class CompilerBuiltIns:
             self._defines = defines
             self._include_paths = includes
 
-
     @property
     def defines(self):
         """The built-in defines provided by the compiler."""

--- a/plugin/utils/compiler_builtins.py
+++ b/plugin/utils/compiler_builtins.py
@@ -17,13 +17,6 @@ class CompilerBuiltIns:
 
     __cache = dict()
 
-    __DEFINES_BLACKLIST = [
-        "__USER_LABEL_PREFIX__",
-        "__STDC_HOSTED__",
-        "__REGISTER_PREFIX__",
-        "__STDC__"
-    ]
-
     def __init__(self, args, filename):
         """
         Create an object holding the built-in flags of a compiler.
@@ -184,8 +177,7 @@ class CompilerBuiltIns:
                 m = re.search(r'#define (\w+)', line)
                 if m is not None:
                     result.append("-D{}".format(m.group(1)))
-
-        return self._filter_defines(result)
+        return result
 
     def _get_default_include_paths(self, compiler, std, language):
         import subprocess
@@ -217,13 +209,3 @@ class CompilerBuiltIns:
                 if m is not None:
                     result.append("-I{}".format(m.group(1)))
         return result
-
-    def _filter_defines(self, defines):
-        # Remove some default flags which get set by clang itself.
-        # Otherwise, we will get error later:
-        for flag in CompilerBuiltIns.__DEFINES_BLACKLIST:
-            prefix = "-D%s" % flag
-            for define in defines:
-                if define.startswith(prefix):
-                    defines.remove(define)
-        return defines

--- a/plugin/view_config.py
+++ b/plugin/view_config.py
@@ -218,7 +218,8 @@ class ViewConfig(object):
                     cmake_flags,
                     settings.cmake_binary,
                     settings.header_to_source_mapping,
-                    settings.use_target_compiler_built_in_flags)
+                    settings.use_target_compiler_built_in_flags,
+                    settings.target_compilers)
             elif file_name == "compile_commands.json":
                 flag_source = CompilationDb(
                     include_prefixes,

--- a/plugin/view_config.py
+++ b/plugin/view_config.py
@@ -212,17 +212,18 @@ class ViewConfig(object):
             if file_name == "CMakeLists.txt":
                 prefix_paths = source_dict.get("prefix_paths", None)
                 cmake_flags = source_dict.get("flags", None)
-                flag_source = CMakeFile(include_prefixes,
-                                        prefix_paths,
-                                        cmake_flags,
-                                        settings.cmake_binary,
-                                        settings.header_to_source_mapping,
-                                        settings.use_compiler_built_in_flags)
+                flag_source = CMakeFile(
+                    include_prefixes,
+                    prefix_paths,
+                    cmake_flags,
+                    settings.cmake_binary,
+                    settings.header_to_source_mapping,
+                    settings.use_target_compiler_built_in_flags)
             elif file_name == "compile_commands.json":
                 flag_source = CompilationDb(
                     include_prefixes,
                     settings.header_to_source_mapping,
-                    settings.use_compiler_built_in_flags
+                    settings.use_target_compiler_built_in_flags
                 )
             elif file_name == ".clang_complete":
                 flag_source = FlagsFile(include_prefixes)

--- a/plugin/view_config.py
+++ b/plugin/view_config.py
@@ -216,10 +216,14 @@ class ViewConfig(object):
                                         prefix_paths,
                                         cmake_flags,
                                         settings.cmake_binary,
-                                        settings.header_to_source_mapping)
+                                        settings.header_to_source_mapping,
+                                        settings.use_compiler_built_in_flags)
             elif file_name == "compile_commands.json":
                 flag_source = CompilationDb(
-                    include_prefixes, settings.header_to_source_mapping)
+                    include_prefixes,
+                    settings.header_to_source_mapping,
+                    settings.use_compiler_built_in_flags
+                )
             elif file_name == ".clang_complete":
                 flag_source = FlagsFile(include_prefixes)
             # try to get flags (uses cache when needed)

--- a/plugin/view_config.py
+++ b/plugin/view_config.py
@@ -293,24 +293,47 @@ class ViewConfig(object):
         Returns:
             Flag[]: A list of language-specific flags.
         """
+        from .utils.compiler_builtins import CompilerBuiltIns
         current_lang = Tools.get_view_lang(view)
         lang_flags = []
+        target_compilers = settings.target_compilers
+        target_lang = None
+        lang_args = list()
         if current_lang == "Objective-C":
-            if need_lang_flags:
-                lang_flags += ["-x"] + ["objective-c"]
-            lang_flags += settings.objective_c_flags
+            target_lang = "objective-c"
+            lang_args = settings.objective_c_flags
         elif current_lang == "Objective-C++":
-            if need_lang_flags:
-                lang_flags += ["-x"] + ["objective-c++"]
-            lang_flags += settings.objective_cpp_flags
+            target_lang = "objective-c++"
+            lang_args = settings.objective_cpp_flags
         elif current_lang == 'C':
-            if need_lang_flags:
-                lang_flags += ["-x"] + ["c"]
-            lang_flags += settings.c_flags
+            target_lang = "c"
+            lang_args = settings.c_flags
         else:
-            if need_lang_flags:
-                lang_flags += ["-x"] + ["c++"]
-            lang_flags += settings.cpp_flags
+            target_lang = "c++"
+            lang_args = settings.cpp_flags
+        if need_lang_flags:
+            lang_flags += ["-x", target_lang]
+        lang_flags += lang_args
+
+        # If the user provided explicit target compilers, retrieve their
+        # default flags and append them to the list:
+        if target_lang in target_compilers:
+            target_compiler = target_compilers[target_lang]
+            if target_compiler is not None:
+                target_compiler_args = [target_compiler, "-x", target_lang]
+                builtIns = CompilerBuiltIns(target_compiler_args, None)
+                for builtin_flag in builtIns.flags:
+                    # Note: Only append new flags; this is done as depending
+                    # on the user's configuration we already might have
+                    # added appropriate flags from another flag source.
+                    # The approach assumes that each entry in the built-in
+                    # flags consists of a single argument (which is true
+                    # for the ones we expect to be in, i.e. only -Dxxx and
+                    # -Ixxx flags). Note that it shouldn't do any harm
+                    # if flags appear multiple times.
+                    if builtin_flag not in lang_flags:
+                        lang_flags.append(builtin_flag)
+
         return Flag.tokenize_list(lang_flags)
 
 

--- a/tests/test_cmake_file.py
+++ b/tests/test_cmake_file.py
@@ -36,7 +36,14 @@ class TestCmakeFile(object):
             path.dirname(__file__), 'cmake_tests', 'test_a.cpp')
 
         path_to_cmake_proj = path.dirname(test_file_path)
-        cmake_file = CMakeFile(['-I', '-isystem'], None, None)
+        cmake_file = CMakeFile(
+            ['-I', '-isystem'],
+            prefix_paths=None,
+            flags=None,
+            cmake_binary="cmake",
+            header_to_source_mapping=[],
+            use_target_compiler_builtins=False
+        )
         expected_lib = path.join(path_to_cmake_proj, 'lib')
         flags = cmake_file.get_flags(test_file_path)
         self.assertEqual(flags[0], Flag('-I' + expected_lib))
@@ -53,7 +60,14 @@ class TestCmakeFile(object):
 
         path_to_file_folder = path.dirname(test_file_path)
         expected_lib_include = Flag('-I' + path_to_file_folder)
-        cmake_file = CMakeFile(['-I', '-isystem'], None, None)
+        cmake_file = CMakeFile(
+            ['-I', '-isystem'],
+            prefix_paths=None,
+            flags=None,
+            cmake_binary="cmake",
+            header_to_source_mapping=[],
+            use_target_compiler_builtins=False
+        )
         flags = cmake_file.get_flags(test_file_path)
         db = CompilationDb(
             ['-I', '-isystem'],
@@ -76,7 +90,14 @@ class TestCmakeFile(object):
             path.dirname(__file__), 'cmake_tests', 'test_a.cpp')
 
         folder_with_no_cmake = path.dirname(__file__)
-        cmake_file = CMakeFile(['-I', '-isystem'], None, None)
+        cmake_file = CMakeFile(
+            ['-I', '-isystem'],
+            prefix_paths=None,
+            flags=None,
+            cmake_binary="cmake",
+            header_to_source_mapping=[],
+            use_target_compiler_builtins=False
+        )
         wrong_scope = SearchScope(from_folder=folder_with_no_cmake)
         flags = cmake_file.get_flags(test_file_path, wrong_scope)
         self.assertTrue(flags is None)

--- a/tests/test_cmake_file.py
+++ b/tests/test_cmake_file.py
@@ -55,7 +55,11 @@ class TestCmakeFile(object):
         expected_lib_include = Flag('-I' + path_to_file_folder)
         cmake_file = CMakeFile(['-I', '-isystem'], None, None)
         flags = cmake_file.get_flags(test_file_path)
-        db = CompilationDb(['-I', '-isystem'])
+        db = CompilationDb(
+            ['-I', '-isystem'],
+            header_to_source_map=[],
+            use_target_compiler_builtins=False
+        )
         self.assertEqual(flags[0], Flag('-Dliba_EXPORTS'))
         self.assertIn(test_file_path, cmake_file._cache)
         expected_cmake_file = path.join(

--- a/tests/test_cmake_file.py
+++ b/tests/test_cmake_file.py
@@ -42,7 +42,8 @@ class TestCmakeFile(object):
             flags=None,
             cmake_binary="cmake",
             header_to_source_mapping=[],
-            use_target_compiler_builtins=False
+            use_target_compiler_builtins=False,
+            target_compilers={}
         )
         expected_lib = path.join(path_to_cmake_proj, 'lib')
         flags = cmake_file.get_flags(test_file_path)
@@ -66,7 +67,8 @@ class TestCmakeFile(object):
             flags=None,
             cmake_binary="cmake",
             header_to_source_mapping=[],
-            use_target_compiler_builtins=False
+            use_target_compiler_builtins=False,
+            target_compilers={}
         )
         flags = cmake_file.get_flags(test_file_path)
         db = CompilationDb(
@@ -96,7 +98,8 @@ class TestCmakeFile(object):
             flags=None,
             cmake_binary="cmake",
             header_to_source_mapping=[],
-            use_target_compiler_builtins=False
+            use_target_compiler_builtins=False,
+            target_compilers={}
         )
         wrong_scope = SearchScope(from_folder=folder_with_no_cmake)
         flags = cmake_file.get_flags(test_file_path, wrong_scope)

--- a/tests/test_compilation_db.py
+++ b/tests/test_compilation_db.py
@@ -22,7 +22,11 @@ class TestCompilationDb(TestCase):
     def test_get_all_flags(self):
         """Test if compilation db is found."""
         include_prefixes = ['-I']
-        db = CompilationDb(include_prefixes)
+        db = CompilationDb(
+            include_prefixes,
+            header_to_source_map=[],
+            use_target_compiler_builtins=False
+        )
 
         expected = [Flag('-I' + path.normpath('/lib_include_dir')),
                     Flag('-Dlib_EXPORTS'),
@@ -49,7 +53,11 @@ class TestCompilationDb(TestCase):
     def test_strip_wrong_arguments(self):
         """Test if compilation db is found and flags loaded from arguments."""
         include_prefixes = ['-I']
-        db = CompilationDb(include_prefixes)
+        db = CompilationDb(
+            include_prefixes,
+            header_to_source_map=[],
+            use_target_compiler_builtins=False
+        )
 
         expected = [Flag('-I' + path.normpath('/lib_include_dir')),
                     Flag('-Dlib_EXPORTS'),
@@ -63,7 +71,11 @@ class TestCompilationDb(TestCase):
     def test_get_flags_for_path(self):
         """Test if compilation db is found."""
         include_prefixes = ['-I']
-        db = CompilationDb(include_prefixes)
+        db = CompilationDb(
+            include_prefixes,
+            header_to_source_map=[],
+            use_target_compiler_builtins=False
+        )
 
         expected_lib = [Flag('-Dlib_EXPORTS'), Flag('-fPIC')]
         expected_main = [Flag('-I' + path.normpath('/lib_include_dir'))]
@@ -96,7 +108,11 @@ class TestCompilationDb(TestCase):
     def test_no_db_in_folder(self):
         """Test if compilation db is found."""
         include_prefixes = ['-I']
-        db = CompilationDb(include_prefixes)
+        db = CompilationDb(
+            include_prefixes,
+            header_to_source_map=[],
+            use_target_compiler_builtins=False
+        )
 
         flags = db.get_flags(path.normpath('/home/user/dummy_main.cpp'))
         self.assertTrue(flags is None)
@@ -104,7 +120,11 @@ class TestCompilationDb(TestCase):
     def test_persistence(self):
         """Test if compilation db is persistent."""
         include_prefixes = ['-I']
-        db = CompilationDb(include_prefixes)
+        db = CompilationDb(
+            include_prefixes,
+            header_to_source_map=[],
+            use_target_compiler_builtins=False
+        )
 
         expected_lib = [Flag('-Dlib_EXPORTS'), Flag('-fPIC')]
         expected_main = [Flag('-I' + path.normpath('/lib_include_dir'))]
@@ -126,7 +146,11 @@ class TestCompilationDb(TestCase):
     def test_relative_directory(self):
         """Test if compilation db 'directory' records are applied."""
         include_prefixes = ['-I', '-isystem']
-        db = CompilationDb(include_prefixes)
+        db = CompilationDb(
+            include_prefixes,
+            header_to_source_map=[],
+            use_target_compiler_builtins=False
+        )
 
         expected = [Flag('-I' + path.normpath('/usr/local/foo')),
                     Flag('-I' + path.normpath('/foo/bar/test/include')),
@@ -142,7 +166,11 @@ class TestCompilationDb(TestCase):
     def test_get_c_flags(self):
         """Test argument filtering for c language."""
         include_prefixes = ['-I']
-        db = CompilationDb(include_prefixes)
+        db = CompilationDb(
+            include_prefixes,
+            header_to_source_map=[],
+            use_target_compiler_builtins=False
+        )
 
         main_file_path = path.normpath('/home/blah.c')
         # also try to test a header

--- a/tests/test_compiler_builtins.py
+++ b/tests/test_compiler_builtins.py
@@ -52,6 +52,7 @@ class TestFlag(TestCase):
         self.assertEqual(builtIns.std, "c99")
         self.assertEqual(builtIns.language, "c")
         self.assertIn("-D__clang__=1", builtIns.flags)
+        self.assertIn("-D__STDC__=1", builtIns.flags)
 
 
     def test_cxx(self):

--- a/tests/test_compiler_builtins.py
+++ b/tests/test_compiler_builtins.py
@@ -1,0 +1,173 @@
+"""Tests for CompilerBuiltIns class."""
+import imp
+from unittest import TestCase
+
+from EasyClangComplete.plugin.utils import compiler_builtins
+
+imp.reload(compiler_builtins)
+
+CompilerBuiltIns = compiler_builtins.CompilerBuiltIns
+
+
+class TestFlag(TestCase):
+    """Test getting built in flags from a target compiler."""
+
+    def test_empty(self):
+        builtIns = CompilerBuiltIns([], None)
+        self.assertEqual(len(builtIns.include_paths), 0)
+        self.assertEqual(len(builtIns.defines), 0)
+        self.assertEqual(builtIns.compiler, None)
+        self.assertEqual(builtIns.std, None)
+        self.assertEqual(builtIns.language, None)
+
+    def test_plain(self):
+        """
+        Test retrieval of built ins when we are uncertain about the language.
+
+        In this test we check retrieval of built ins when we cannot be sure
+        about the target language. Input is a command line with the call to the
+        compiler but without a filename. In this case, we expect only the
+        compiler to be guessed correctly. Asking it for built ins should
+        yield C flags (which are mostly a sub-set of flags for other languages).
+        """
+        builtIns = CompilerBuiltIns(["clang"], None)
+        self.assertTrue(len(builtIns.defines) > 0)
+        self.assertTrue(len(builtIns.include_paths) > 0)
+        self.assertEqual(builtIns.compiler, "clang")
+        self.assertEqual(builtIns.std, None)
+        self.assertEqual(builtIns.language, None)
+
+    def test_c(self):
+        """
+        Test retrieval of flags for a C compiler.
+
+        In this test we have in addition to the compiler an explicit hint to the
+        target language in use. Hence, the correct language (and also standard)
+        must be guessed correctly.
+        """
+        builtIns = CompilerBuiltIns(["clang", "-std=c99", "-x", "c"], None)
+        self.assertTrue(len(builtIns.defines) > 0)
+        self.assertTrue(len(builtIns.include_paths) > 0)
+        self.assertEqual(builtIns.compiler, "clang")
+        self.assertEqual(builtIns.std, "c99")
+        self.assertEqual(builtIns.language, "c")
+        self.assertIn("-D__clang__=1", builtIns.flags)
+
+
+    def test_cxx(self):
+        """
+        Test retrieval of flags for a C++ compiler.
+
+        We check if we can get flags for a C++ compiler. The language
+        can be derived from either the compiler name, an explicit
+        language given in the flags to the compiler or the filename. To make
+        sure, we check if C++ specific defines are in the retrieved flags.
+        """
+        test_data = [
+            {
+                "args": ["clang++"],
+                "filename": None,
+                "compiler": "clang++"
+            },
+            {
+                "args": ["clang", "-x", "c++"],
+                "filename": None,
+                "compiler": "clang"
+            },
+            {
+                "args": ["clang"],
+                "filename": "myfile.cpp",
+                "compiler": "clang"
+            },
+            {
+                "args": ["clang"],
+                "filename": "myfile.cc",
+                "compiler": "clang"
+            },
+            {
+                "args": ["clang"],
+                "filename": "myfile.cxx",
+                "compiler": "clang"
+            },
+            {
+                "args": ["clang"],
+                "filename": "myfile.C",
+                "compiler": "clang"
+            },
+            {
+                "args": ["clang"],
+                "filename": "myfile.c++",
+                "compiler": "clang"
+            }
+        ]
+        for test_set in test_data:
+            print("Testing using test set: {}".format(test_set))
+            builtIns = CompilerBuiltIns(test_set["args"], test_set["filename"])
+            self.assertEqual(builtIns.compiler, test_set["compiler"])
+            self.assertEqual(builtIns.language, "c++")
+            is_cpp = False
+            for define in builtIns.defines:
+                if define.startswith("-D__cplusplus="):
+                    is_cpp = True
+            self.assertTrue(is_cpp)
+
+
+    def test_objc(self):
+        """
+        Test retrieval of flags for an Objective-C compiler.
+
+        We check if we can get flags for an Objective-C compiler.
+        For this, we make sure we recognize if a compilation is for Objective-C
+        by looking at explicit target languages or the filename of the input
+        file.
+        """
+        test_data = [
+            {
+                "args": ["clang", "-x", "objective-c"],
+                "filename": None,
+                "compiler": "clang"
+            },
+            {
+                "args": ["clang"],
+                "filename": "myfile.m",
+                "compiler": "clang"
+            },
+            {
+                "args": ["clang"],
+                "filename": "myfile.mm",
+                "compiler": "clang"
+            },
+        ]
+        for test_set in test_data:
+            print("Testing using test set: {}".format(test_set))
+            builtIns = CompilerBuiltIns(test_set["args"], test_set["filename"])
+            self.assertEqual(builtIns.compiler, test_set["compiler"])
+            self.assertEqual(builtIns.language, "objective-c")
+            self.assertIn("-D__OBJC__=1", builtIns.flags)
+
+    def test_objcpp(self):
+        """
+        Test retrieval of flags for an Objective-C++ compiler.
+
+        We check if we can get flags for an Objective-C++ compiler.
+        For this, we look if we can find an explicit language flag in the
+        compiler argument list.
+        """
+        test_data = [
+            {
+                "args": ["clang", "-x", "objective-c++"],
+                "filename": None,
+                "compiler": "clang"
+            }
+        ]
+        for test_set in test_data:
+            print("Testing using test set: {}".format(test_set))
+            builtIns = CompilerBuiltIns(test_set["args"], test_set["filename"])
+            self.assertEqual(builtIns.compiler, test_set["compiler"])
+            self.assertEqual(builtIns.language, "objective-c++")
+            self.assertIn("-D__OBJC__=1", builtIns.flags)
+            is_cpp = False
+            for define in builtIns.defines:
+                if define.startswith("-D__cplusplus="):
+                    is_cpp = True
+            self.assertTrue(is_cpp)

--- a/tests/test_compiler_builtins.py
+++ b/tests/test_compiler_builtins.py
@@ -52,7 +52,10 @@ class TestFlag(TestCase):
         self.assertEqual(builtIns.std, "c99")
         self.assertEqual(builtIns.language, "c")
         self.assertIn("-D__clang__=1", builtIns.flags)
-        self.assertIn("-D__STDC__=1", builtIns.flags)
+        # TODO: It seems STDC is not set everywhere (at least the test on
+        # Appveyor fails when we check for this). Maybe there's another,
+        # C specific define which it is worth checking for?
+        # self.assertIn("-D__STDC__=1", builtIns.flags)
 
 
     def test_cxx(self):

--- a/tests/test_compiler_builtins.py
+++ b/tests/test_compiler_builtins.py
@@ -57,7 +57,6 @@ class TestFlag(TestCase):
         # C specific define which it is worth checking for?
         # self.assertIn("-D__STDC__=1", builtIns.flags)
 
-
     def test_cxx(self):
         """
         Test retrieval of flags for a C++ compiler.
@@ -114,7 +113,6 @@ class TestFlag(TestCase):
                 if define.startswith("-D__cplusplus="):
                     is_cpp = True
             self.assertTrue(is_cpp)
-
 
     def test_objc(self):
         """

--- a/tests/test_view_config.py
+++ b/tests/test_view_config.py
@@ -4,6 +4,7 @@ import sublime
 from os import path
 
 from EasyClangComplete.plugin.settings import settings_manager
+from EasyClangComplete.plugin.settings import settings_storage
 from EasyClangComplete.plugin import view_config
 from EasyClangComplete.plugin import tools
 
@@ -11,6 +12,7 @@ from EasyClangComplete.tests import gui_test_wrapper
 
 imp.reload(gui_test_wrapper)
 imp.reload(settings_manager)
+imp.reload(settings_storage)
 imp.reload(view_config)
 imp.reload(tools)
 


### PR DESCRIPTION
This PR tries to utilize compiler built-in flags for auto-completion. The idea is to query the compiler for built-in `#define`s and header search paths and append these flags in addition to other flags e.g. extracted from a `compile_commands.json` file for code completion. That way, if the user has a *special* compiler e.g for an embedded platform, `clang` is able to see platform specific defines.

This issue closes #370. In addition, it is related to #196 as - at least when using some of the completion methods - it allows the described "guessing" mechanism.

---

# Requirements #
- [x] Reference an issue in this PR. Create new one if needed.
- [x] Make sure your branch is based on `dev`.
