### PR TITLE
Make sure we do not reimport singletons. Should fix #379

### DIFF
--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -17,16 +17,18 @@ from os import path
 from .plugin import tools
 from .plugin import view_config
 from .plugin import flags_sources
-from .plugin.utils import thread_pool
+from .plugin.utils import singleton_thread_pool
+from .plugin.utils import thread_job
 from .plugin.utils import progress_status
 from .plugin.utils import quick_panel_handler
+from .plugin.utils import module_reloader
 from .plugin.settings import settings_manager
 from .plugin.settings import settings_storage
 
-# reload the modules
-tools.Reloader.reload_all()
+# Reload all modules modules ignoring those that contain the given string.
+module_reloader.ModuleReloader.reload_all(ignore_string='singleton')
 
-# some aliases
+# Set some aliases for simplicity.
 SettingsManager = settings_manager.SettingsManager
 SettingsStorage = settings_storage.SettingsStorage
 ViewConfigManager = view_config.ViewConfigManager
@@ -38,8 +40,8 @@ NoneSublimeProgressStatus = progress_status.NoneSublimeProgressStatus
 PosStatus = tools.PosStatus
 CMakeFile = flags_sources.cmake_file.CMakeFile
 CMakeFileCache = flags_sources.cmake_file.CMakeFileCache
-ThreadPool = thread_pool.ThreadPool
-ThreadJob = thread_pool.ThreadJob
+ThreadPool = singleton_thread_pool.ThreadPool
+ThreadJob = thread_job.ThreadJob
 QuickPanelHandler = quick_panel_handler.QuickPanelHandler
 
 log = logging.getLogger("ECC")
@@ -67,7 +69,7 @@ def plugin_loaded():
     We need it to initialize all the different classes that encapsulate
     functionality. We can only properly init them after sublime api is
     available."""
-    tools.Reloader.reload_all()
+    module_reloader.ModuleReloader.reload_all(ignore_string='singleton')
     handle_plugin_loaded_function()
 
 

--- a/plugin/flags_sources/CppProperties.py
+++ b/plugin/flags_sources/CppProperties.py
@@ -7,7 +7,7 @@ Attributes:
 """
 from .flags_source import FlagsSource
 from ..tools import File
-from ..tools import singleton
+from ..utils.singleton import CppPropertiesCache
 
 import json
 import os
@@ -15,12 +15,6 @@ import re
 import logging
 
 log = logging.getLogger("ECC")
-
-
-@singleton
-class CppPropertiesCache(dict):
-    """Singleton for CppProperties.json file cache."""
-    pass
 
 
 class CppProperties(FlagsSource):
@@ -116,11 +110,12 @@ class CppProperties(FlagsSource):
             return defines
 
         if not os.path.exists(file.full_path()):
-            log.debug(
-                "{} does not exist yet. No flags present.".format(_FILE_NAME))
+            log.error("File '%s' does not exist yet. No flags present.",
+                      CppProperties._FILE_NAME)
             return []
         if not file.loaded():
-            log.error("cannot get flags from {}. No file.".format(_FILE_NAME))
+            log.error("cannot get flags from %s. No file.",
+                      CppProperties._FILE_NAME)
             return []
 
         flags = []

--- a/plugin/flags_sources/c_cpp_properties.py
+++ b/plugin/flags_sources/c_cpp_properties.py
@@ -7,7 +7,7 @@ Attributes:
 """
 from .flags_source import FlagsSource
 from ..tools import File
-from ..tools import singleton
+from ..utils.singleton import CCppPropertiesCache
 
 from os import path
 import json
@@ -15,12 +15,6 @@ import json
 import logging
 
 log = logging.getLogger("ECC")
-
-
-@singleton
-class CCppPropertiesCache(dict):
-    """Singleton for c_cpp_properties.json file cache."""
-    pass
 
 
 class CCppProperties(FlagsSource):
@@ -112,11 +106,12 @@ class CCppProperties(FlagsSource):
             return defines
 
         if not path.exists(file.full_path()):
-            log.debug(
-                "{} does not exist yet. No flags present.".format(_FILE_NAME))
+            log.error("File '%s' does not exist yet. No flags present.",
+                      CCppProperties._FILE_NAME)
             return []
         if not file.loaded():
-            log.error("cannot get flags from {}. No file.".format(_FILE_NAME))
+            log.error("cannot get flags from %s. No file.",
+                      CCppProperties._FILE_NAME)
             return []
 
         flags = []

--- a/plugin/flags_sources/cmake_file.py
+++ b/plugin/flags_sources/cmake_file.py
@@ -8,7 +8,7 @@ from .compilation_db import CompilationDb
 from ..tools import File
 from ..tools import Tools
 from ..tools import SearchScope
-from ..tools import singleton
+from ..utils.singleton import CMakeFileCache
 
 from os import path
 
@@ -17,12 +17,6 @@ import re
 import os
 
 log = logging.getLogger("ECC")
-
-
-@singleton
-class CMakeFileCache(dict):
-    """Singleton for CMakeLists.txt file cache."""
-    pass
 
 
 class CMakeFile(FlagsSource):
@@ -213,12 +207,10 @@ class CMakeFile(FlagsSource):
             cmake_cmd += " -DCMAKE_TOOLCHAIN_FILE={}".format(
                 toolchain_file_path)
 
-        log.info(' running command: %s', cmake_cmd)
+        log.debug(' running command: %s', cmake_cmd)
         output_text = Tools.run_command(
             command=cmake_cmd, cwd=tempdir, env=my_env)
-
-        log.info("cmake produced output: \n%s", output_text)
-
+        log.debug("cmake produced output: \n%s", output_text)
         database_path = path.join(tempdir, CompilationDb._FILE_NAME)
         if not path.exists(database_path):
             log.error("cmake has finished, but no compilation database.")

--- a/plugin/flags_sources/compilation_db.py
+++ b/plugin/flags_sources/compilation_db.py
@@ -5,8 +5,8 @@ Attributes:
 """
 from .flags_source import FlagsSource
 from ..tools import File
-from ..tools import singleton
 from ..utils.unique_list import UniqueList
+from ..utils.singleton import ComplationDbCache
 
 from os import path
 from fnmatch import fnmatch
@@ -14,12 +14,6 @@ from fnmatch import fnmatch
 import logging
 
 log = logging.getLogger("ECC")
-
-
-@singleton
-class ComplationDbCache(dict):
-    """Singleton for compilation database cache."""
-    pass
 
 
 class CompilationDb(FlagsSource):

--- a/plugin/flags_sources/flags_file.py
+++ b/plugin/flags_sources/flags_file.py
@@ -5,19 +5,13 @@ Attributes:
 """
 from .flags_source import FlagsSource
 from ..tools import File
-from ..tools import singleton
+from ..utils.singleton import FlagsFileCache
 
 from os import path
 
 import logging
 
 log = logging.getLogger("ECC")
-
-
-@singleton
-class FlagsFileCache(dict):
-    """Singleton for .clang_fomplete file cache."""
-    pass
 
 
 class FlagsFile(FlagsSource):

--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -1,4 +1,4 @@
-"""This module contains various tools.
+"""Collection of various tools.
 
 Attributes:
     log (logging): logger for this module
@@ -21,8 +21,7 @@ import tempfile
 import subprocess
 
 import re
-import sys
-import imp
+
 
 PKG_NAME = path.basename(path.dirname(path.dirname(__file__)))
 
@@ -41,60 +40,6 @@ OSX_CLANG_VERSION_DICT = {
 }
 
 log = logging.getLogger("ECC")
-
-
-def singleton(class_):
-    """Singleton class wrapper.
-
-    Args:
-      class_ (Class): Class to wrap.
-
-    Returns:
-      class_: unique instance of object.
-    """
-    instances = {}
-
-    def getinstance(*args, **kwargs):
-        """Get instance of a class."""
-        if class_ not in instances:
-            instances[class_] = class_(*args, **kwargs)
-        return instances[class_]
-    return getinstance
-
-
-class Reloader:
-    """Reloader for all dependencies."""
-
-    MAX_RELOAD_TRIES = 10
-
-    @staticmethod
-    def reload_all():
-        """Reload all loaded modules."""
-        prefix = PKG_NAME + '.plugin.'
-        # reload all twice to make sure all dependencies are satisfied
-        log.debug("reload all modules first time")
-        Reloader.reload_once(prefix)
-        log.debug("reload all modules second time")
-        Reloader.reload_once(prefix)
-        log.debug("all modules reloaded")
-
-    @staticmethod
-    def reload_once(prefix):
-        """Reload all modules once."""
-        try_counter = 0
-        try:
-            for name, module in sys.modules.items():
-                if name.startswith(prefix):
-                    log.debug("reloading module: '%s'", name)
-                    imp.reload(module)
-        except OSError as e:
-            if try_counter >= Reloader.MAX_RELOAD_TRIES:
-                log.fatal("Too many tries to reload and no success. Fail.")
-                return
-            try_counter += 1
-            log.error("Received an error: %s on try %s. Try again.",
-                      e, try_counter)
-            Reloader.reload_once(prefix)
 
 
 class SublBridge:
@@ -194,7 +139,7 @@ class SublBridge:
 
     @staticmethod
     def show_auto_complete(view):
-        """Calling this function reopens completion popup.
+        """Reopen completion popup.
 
         It therefore subsequently calls
         EasyClangComplete.on_query_completions(...)
@@ -721,7 +666,7 @@ class Tools:
             output_text = e.output.decode("utf-8")
             log.debug("command finished with code: %s", e.returncode)
             log.debug("command output: \n%s", output_text)
-        except FileNotFoundError:
+        except OSError:
             log.debug(
                 "executable file not found executing: {}".format(command))
         return output_text

--- a/plugin/utils/module_reloader.py
+++ b/plugin/utils/module_reloader.py
@@ -1,0 +1,46 @@
+"""A class needed to reload modules."""
+import sys
+import imp
+import logging
+
+from ..tools import PKG_NAME
+
+log = logging.getLogger("ECC")
+
+
+class ModuleReloader:
+    """Reloader for all dependencies."""
+
+    MAX_RELOAD_TRIES = 10
+
+    @staticmethod
+    def reload_all(ignore_string='singleton'):
+        """Reload all loaded modules."""
+        prefix = PKG_NAME + '.plugin.'
+        # reload all twice to make sure all dependencies are satisfied
+        log.debug(
+            "Reloading modules that start with '%s' and don't contain '%s'",
+            prefix, ignore_string)
+        log.debug("Reload all modules first time")
+        ModuleReloader.reload_once(prefix, ignore_string)
+        log.debug("Reload all modules second time")
+        ModuleReloader.reload_once(prefix, ignore_string)
+        log.debug("All modules reloaded")
+
+    @staticmethod
+    def reload_once(prefix, ignore_string):
+        """Reload all modules once."""
+        try_counter = 0
+        try:
+            for name, module in sys.modules.items():
+                if name.startswith(prefix) and ignore_string not in name:
+                    log.debug("Reloading module: '%s'", name)
+                    imp.reload(module)
+        except OSError as e:
+            if try_counter >= ModuleReloader.MAX_RELOAD_TRIES:
+                log.fatal("Too many tries to reload and no success. Fail.")
+                return
+            try_counter += 1
+            log.error("Received an error: %s on try %s. Try again.",
+                      e, try_counter)
+            ModuleReloader.reload_once(prefix)

--- a/plugin/utils/singleton.py
+++ b/plugin/utils/singleton.py
@@ -1,0 +1,61 @@
+"""Singleton related stuff. Should only be imported ONCE."""
+
+
+def singleton(class_):
+    """Singleton class wrapper.
+
+    Args:
+      class_ (Class): Class to wrap.
+
+    Returns:
+      class_: unique instance of object.
+    """
+    instances = {}
+
+    def getinstance(*args, **kwargs):
+        """Get instance of a class."""
+        if class_ not in instances:
+            instances[class_] = class_(*args, **kwargs)
+        return instances[class_]
+    return getinstance
+
+# ALL the singletons used throughout the codebase go below this line:
+##############################################################################
+##############################################################################
+##############################################################################
+
+
+@singleton
+class ViewConfigCache(dict):
+    """Singleton for view configurations cache."""
+    pass
+
+
+@singleton
+class CppPropertiesCache(dict):
+    """Singleton for CppProperties.json file cache."""
+    pass
+
+
+@singleton
+class CCppPropertiesCache(dict):
+    """Singleton for c_cpp_properties.json file cache."""
+    pass
+
+
+@singleton
+class CMakeFileCache(dict):
+    """Singleton for CMakeLists.txt file cache."""
+    pass
+
+
+@singleton
+class ComplationDbCache(dict):
+    """Singleton for compilation database cache."""
+    pass
+
+
+@singleton
+class FlagsFileCache(dict):
+    """Singleton for .clang_fomplete file cache."""
+    pass

--- a/plugin/utils/singleton_thread_pool.py
+++ b/plugin/utils/singleton_thread_pool.py
@@ -9,63 +9,9 @@ from concurrent import futures
 from threading import Lock
 from threading import Thread
 
-from ..tools import singleton
+from .singleton import singleton
 
 log = logging.getLogger("ECC")
-
-
-class ThreadJob:
-    """A class for a job that can be submitted to ThreadPool.
-
-    Attributes:
-        name (str): Name of this job.
-        callback (func): Function to use as callback.
-        function (func): Function to run asynchronously.
-        args (object[]): Sequence of additional arguments for `function`.
-    """
-
-    UPDATE_TAG = "update"
-    CLEAR_TAG = "clear"
-    COMPLETE_TAG = "complete"
-    INFO_TAG = "info"
-
-    def __init__(self, name, callback, function, args):
-        """Initialize a job.
-
-        Args:
-            name (str): Name of this job.
-            callback (func): Function to use as callback.
-            function (func): Function to run asynchronously.
-            args (object[]): Sequence of additional arguments for `function`.
-            future (future): A future that tracks the execution of this job.
-        """
-        self.name = name
-        self.callback = callback
-        self.function = function
-        self.args = args
-        self.future = None
-
-    def __is_high_priority(self):
-        """Check if job is high priority."""
-        is_update = self.name == ThreadJob.UPDATE_TAG
-        is_clear = self.name == ThreadJob.CLEAR_TAG
-        return is_update or is_clear
-
-    def __repr__(self):
-        """Representation."""
-        return "job: '{name}'".format(name=self.name)
-
-    def overrides(self, other):
-        """Define if one job is higher priority than the other."""
-        if self.is_same_type_as(other):
-            return True
-        if self.__is_high_priority() and not other.__is_high_priority():
-            return True
-        return False
-
-    def is_same_type_as(self, other):
-        """Define if these are the same type of jobs."""
-        return self.name == other.name
 
 
 @singleton

--- a/plugin/utils/thread_job.py
+++ b/plugin/utils/thread_job.py
@@ -1,0 +1,63 @@
+"""Class that defined a job to be run in a thread pool.
+
+Attributes:
+    log (logging.Logger): Logger for current module.
+"""
+import logging
+
+
+log = logging.getLogger("ECC")
+
+
+class ThreadJob:
+    """A class for a job that can be submitted to ThreadPool.
+
+    Attributes:
+        name (str): Name of this job.
+        callback (func): Function to use as callback.
+        function (func): Function to run asynchronously.
+        args (object[]): Sequence of additional arguments for `function`.
+    """
+
+    UPDATE_TAG = "update"
+    CLEAR_TAG = "clear"
+    COMPLETE_TAG = "complete"
+    INFO_TAG = "info"
+
+    def __init__(self, name, callback, function, args):
+        """Initialize a job.
+
+        Args:
+            name (str): Name of this job.
+            callback (func): Function to use as callback.
+            function (func): Function to run asynchronously.
+            args (object[]): Sequence of additional arguments for `function`.
+            future (future): A future that tracks the execution of this job.
+        """
+        self.name = name
+        self.callback = callback
+        self.function = function
+        self.args = args
+        self.future = None
+
+    def __is_high_priority(self):
+        """Check if job is high priority."""
+        is_update = self.name == ThreadJob.UPDATE_TAG
+        is_clear = self.name == ThreadJob.CLEAR_TAG
+        return is_update or is_clear
+
+    def __repr__(self):
+        """Representation."""
+        return "job: '{name}'".format(name=self.name)
+
+    def overrides(self, other):
+        """Define if one job is higher priority than the other."""
+        if self.is_same_type_as(other):
+            return True
+        if self.__is_high_priority() and not other.__is_high_priority():
+            return True
+        return False
+
+    def is_same_type_as(self, other):
+        """Define if these are the same type of jobs."""
+        return self.name == other.name

--- a/plugin/view_config.py
+++ b/plugin/view_config.py
@@ -12,12 +12,12 @@ from threading import Thread
 
 from .tools import File
 from .tools import Tools
-from .tools import singleton
 from .tools import SublBridge
 from .tools import SearchScope
 
 from .utils.flag import Flag
 from .utils.unique_list import UniqueList
+from .utils.singleton import ViewConfigCache
 
 from .completion import lib_complete
 from .completion import bin_complete
@@ -344,20 +344,13 @@ class ViewConfig(object):
         return Flag.tokenize_list(lang_flags)
 
 
-@singleton
-class ViewConfigCache(dict):
-    """Singleton for view configurations cache."""
-    pass
-
-
-@singleton
 class ViewConfigManager(object):
     """A utility class that stores a cache of all view configurations."""
 
     def __init__(self, timer_period=30, max_config_age=60):
         """Initialize view config manager.
 
-        All the values aregiven in seconds and can be overridden by settings.
+        All the values are given in seconds and can be overridden by settings.
 
         Args:
             timer_period (int, optional): How often to run timer in seconds.

--- a/tests/test_thread_pool.py
+++ b/tests/test_thread_pool.py
@@ -1,14 +1,12 @@
 """Test delayed thread pool."""
-import imp
 import time
 from unittest import TestCase
 
-import EasyClangComplete.plugin.utils.thread_pool
+import EasyClangComplete.plugin.utils.singleton_thread_pool
+import EasyClangComplete.plugin.utils.thread_job
 
-imp.reload(EasyClangComplete.plugin.utils.thread_pool)
-
-ThreadPool = EasyClangComplete.plugin.utils.thread_pool.ThreadPool
-ThreadJob = EasyClangComplete.plugin.utils.thread_pool.ThreadJob
+ThreadPool = EasyClangComplete.plugin.utils.singleton_thread_pool.ThreadPool
+ThreadJob = EasyClangComplete.plugin.utils.thread_job.ThreadJob
 
 
 def run_me(succeed):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -16,11 +16,12 @@ from EasyClangComplete.plugin.tools import Tools
 from EasyClangComplete.plugin.tools import File
 from EasyClangComplete.plugin.tools import PosStatus
 from EasyClangComplete.plugin.tools import PKG_NAME
-from EasyClangComplete.plugin.tools import singleton
+from EasyClangComplete.plugin.utils.singleton import singleton
 
 
 class test_tools_command(TestCase):
     """Test sublime commands."""
+
     def setUp(self):
         """Set up testing environment."""
         self.view = sublime.active_window().new_file()
@@ -28,9 +29,8 @@ class test_tools_command(TestCase):
         s = sublime.load_settings("Preferences.sublime-settings")
         s.set("close_windows_when_empty", False)
 
-    def setUpView(self, filename):
-        """
-        Utility method to set up a view for a given file.
+    def set_up_view(self, filename):
+        """Set up a view for a given file.
 
         Args:
             filename (str): The filename to open in a new view.
@@ -119,7 +119,7 @@ class test_tools_command(TestCase):
     def test_wrong_triggers(self):
         """Test that we don't complete on numbers and wrong triggers."""
         self.tearDown()
-        self.setUpView(path.join('test_files', 'test_wrong_triggers.cpp'))
+        self.set_up_view(path.join('test_files', 'test_wrong_triggers.cpp'))
         # Load the completions.
         manager = SettingsManager()
         settings = manager.user_settings()
@@ -204,14 +204,15 @@ class test_tools(TestCase):
 
 class test_file(TestCase):
     """Testing file related stuff."""
+
     def test_find_file(self):
         """Test if we can find a file."""
         current_folder = path.dirname(path.abspath(__file__))
         parent_folder = path.dirname(current_folder)
         file = File.search(
-             file_name='README.md',
-             from_folder=current_folder,
-             to_folder=parent_folder)
+            file_name='README.md',
+            from_folder=current_folder,
+            to_folder=parent_folder)
         expected = path.join(parent_folder, 'README.md')
         self.assertTrue(file.loaded())
         self.assertEqual(file.full_path(), expected)


### PR DESCRIPTION
As discussed with @braindevices in #380 this PR aims at making sure we never reimport singletons. Whenever we have a singleton it should reside in a module that contains a word `singleton` in its name so that the reloader would ignore it when reloading the modules.

Fix #379 

---

# Requirements #
- [x] Reference an issue in this PR. Create new one if needed.
- [x] Make sure your branch is based on `dev`.
