### PR TITLE
Popups for methods with arguments have hyperlinks to argument types

### DIFF
--- a/plugin/popups/popups.py
+++ b/plugin/popups/popups.py
@@ -118,10 +118,13 @@ class Popup:
         else:
             args = []
             for arg in cursor.get_arguments():
+                arg_type_location = Popup.location_from_type(arg.type)
+                arg_type_link = Popup.link_from_location(arg_type_location,
+                                                         arg.type.spelling)
                 if arg.spelling:
-                    args.append(arg.type.spelling + ' ' + arg.spelling)
+                    args.append(arg_type_link + arg.spelling)
                 else:
-                    args.append(arg.type.spelling + ' ')
+                    args.append(arg_type_link)
             if cursor.kind in [cindex.CursorKind.FUNCTION_DECL,
                                cindex.CursorKind.CXX_METHOD]:
                 args_string = '('
@@ -326,7 +329,11 @@ class Popup:
         # Params declaration.
         method_params_index = 1
         for arg in method_cursor.get_arguments():
-            declaration_text += ":(" + arg.type.spelling + ")"
+            arg_type_location = Popup.location_from_type(arg.type)
+            arg_type_link = Popup.link_from_location(arg_type_location,
+                                                     arg.type.spelling)
+
+            declaration_text += ":(" + arg_type_link + ")"
             if arg.spelling:
                 declaration_text += arg.spelling + " "
             declaration_text += method_and_params[method_params_index]

--- a/tests/test_error_vis.py
+++ b/tests/test_error_vis.py
@@ -281,6 +281,34 @@ class TestErrorVis:
         self.tear_down_completer()
         self.tear_down()
 
+    def test_info_arguments_link(self):
+        """Test that the info message with arg links is generated correctly."""
+        if not self.use_libclang:
+            # Ignore this test for binary completer.
+            return
+        file_name = path.join(path.dirname(__file__),
+                              'test_files',
+                              'test_info_arguments_link.cpp')
+        self.set_up_view(file_name)
+        completer, settings = self.set_up_completer()
+        # Check the current cursor position is completable.
+        self.assertEqual(self.get_row(9), "  cool_class.foo(Foo(), nullptr);")
+        pos = self.view.text_point(9, 15)
+        action_request = ActionRequest(self.view, pos)
+        request, info_popup = completer.info(action_request, settings)
+        self.maxDiff = None
+        expected_info_msg = """!!! panel-info "ECC: Info"
+    ## Declaration: ##
+    void [foo]({file}:5:8) ([Foo]({file}:1:7) a, [Foo *]({file}:1:7) b)
+""".format(file=file_name)
+        # Make sure we remove trailing spaces on the right to comply with how
+        # sublime text handles this.
+        actual_msg = cleanup_trailing_spaces(info_popup.as_markdown())
+        self.assertEqual(actual_msg, expected_info_msg)
+        # cleanup
+        self.tear_down_completer()
+        self.tear_down()
+
 
 class TestErrorVisBin(TestErrorVis, GuiTestWrapper):
     """Test class for the binary based completer."""

--- a/tests/test_files/test_info_arguments_link.cpp
+++ b/tests/test_files/test_info_arguments_link.cpp
@@ -1,0 +1,12 @@
+class Foo {};
+
+class MyCoolClass {
+ public:
+  void foo(Foo a, Foo* b);
+};
+
+int main(int argc, char const *argv[]) {
+  MyCoolClass cool_class;
+  cool_class.foo(Foo(), nullptr);
+  return 0;
+}


### PR DESCRIPTION
Popups for methods with arguments have hyperlinks to argument types.
Closes #397 

Before:
![link return type only](https://user-images.githubusercontent.com/20820660/35314234-6ef00586-008a-11e8-8ae1-30c853239188.png)

After:
![link arguments](https://user-images.githubusercontent.com/20820660/35314233-6edd27ae-008a-11e8-8e8b-e471f1e855ea.png)

Similar for ObjC/ObjC++ methods, the method below will now link to `Bar`
in addition to `Foo`:
    `-(Foo*) method:(Bar*) bar;`


