### PR TITLE
Fix reloading

### DIFF
--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -22,8 +22,10 @@ from .plugin.utils import thread_job
 from .plugin.utils import progress_status
 from .plugin.utils import quick_panel_handler
 from .plugin.utils import module_reloader
+from .plugin.utils import singleton
 from .plugin.settings import settings_manager
 from .plugin.settings import settings_storage
+
 
 # Reload all modules modules ignoring those that contain the given string.
 module_reloader.ModuleReloader.reload_all(ignore_string='singleton')
@@ -39,7 +41,8 @@ ColorSublimeProgressStatus = progress_status.ColorSublimeProgressStatus
 NoneSublimeProgressStatus = progress_status.NoneSublimeProgressStatus
 PosStatus = tools.PosStatus
 CMakeFile = flags_sources.cmake_file.CMakeFile
-CMakeFileCache = flags_sources.cmake_file.CMakeFileCache
+CMakeFileCache = singleton.CMakeFileCache
+GenericCache = singleton.GenericCache
 ThreadPool = singleton_thread_pool.ThreadPool
 ThreadJob = thread_job.ThreadJob
 QuickPanelHandler = quick_panel_handler.QuickPanelHandler
@@ -70,6 +73,7 @@ def plugin_loaded():
     functionality. We can only properly init them after sublime api is
     available."""
     module_reloader.ModuleReloader.reload_all(ignore_string='singleton')
+    GenericCache.clear_all_caches()
     handle_plugin_loaded_function()
 
 

--- a/plugin/utils/singleton.py
+++ b/plugin/utils/singleton.py
@@ -56,6 +56,26 @@ class ComplationDbCache(dict):
 
 
 @singleton
+class ThreadCache(dict):
+    """Singleton for a cache of running threads."""
+    pass
+
+
+@singleton
 class FlagsFileCache(dict):
     """Singleton for .clang_fomplete file cache."""
     pass
+
+
+class GenericCache:
+    """A class to be able to import the function below."""
+    @staticmethod
+    def clear_all_caches():
+        """Clear all existing caches."""
+        CCppPropertiesCache().clear()
+        CMakeFileCache().clear()
+        ComplationDbCache().clear()
+        CppPropertiesCache().clear()
+        FlagsFileCache().clear()
+        ViewConfigCache().clear()
+        ThreadCache().clear()

--- a/plugin/view_config.py
+++ b/plugin/view_config.py
@@ -8,7 +8,7 @@ import logging
 import weakref
 from os import path
 from threading import RLock
-from threading import Thread
+from threading import Timer
 
 from .tools import File
 from .tools import Tools
@@ -18,6 +18,7 @@ from .tools import SearchScope
 from .utils.flag import Flag
 from .utils.unique_list import UniqueList
 from .utils.singleton import ViewConfigCache
+from .utils.singleton import ThreadCache
 
 from .completion import lib_complete
 from .completion import bin_complete
@@ -341,6 +342,8 @@ class ViewConfig(object):
 class ViewConfigManager(object):
     """A utility class that stores a cache of all view configurations."""
 
+    TAG = "view_config_progress"
+
     def __init__(self, timer_period=30, max_config_age=60):
         """Initialize view config manager.
 
@@ -350,15 +353,16 @@ class ViewConfigManager(object):
             timer_period (int, optional): How often to run timer in seconds.
             max_config_age (int, optional): How long should a TU stay alive.
         """
-        self.__rlock = RLock()
-        with self.__rlock:
-            self.__cache = ViewConfigCache()
-            self.__cache.clear()
-
         self.__timer_period = timer_period      # Seconds.
         self.__max_config_age = max_config_age  # Seconds.
-        self.__progress_thread = Thread(target=self.__remove_old_configs,
-                                        daemon=True).start()
+        self.__rlock = RLock()
+
+        with self.__rlock:
+            self.__cache = ViewConfigCache()
+            self.__timer_cache = ThreadCache()
+
+        # Run the timer thread correctly.
+        self.__run_timer()
 
     def get_from_cache(self, view):
         """Get config from cache with no modifications."""
@@ -455,6 +459,18 @@ class ViewConfigManager(object):
         view_config = self.get_from_cache(view)
         return view_config.completer.complete(completion_request)
 
+    def __run_timer(self):
+        """We make sure we run a single thread."""
+        if ViewConfigManager.TAG in self.__timer_cache:
+            # We need to kill the old thread before starting the new one.
+            self.__running_thread = False
+            self.__timer_cache[ViewConfigManager.TAG].cancel()
+            del self.__timer_cache[ViewConfigManager.TAG]
+        self.__running_thread = True
+        self.__timer_cache[ViewConfigManager.TAG] = Timer(
+            interval=self.__timer_period, function=self.__remove_old_configs)
+        self.__timer_cache[ViewConfigManager.TAG].start()
+
     def __remove_old_configs(self):
         """Remove old configs if they are older than max age.
 
@@ -462,16 +478,16 @@ class ViewConfigManager(object):
         if there are any new configs to remove based on a timer.
         """
         import gc
-        while True:
-            time.sleep(self.__timer_period)
-            with self.__rlock:
-                for v_id in list(self.__cache.keys()):
-                    if self.__cache[v_id].is_older_than(self.__max_config_age):
-                        log.debug("Remove old config: %s", v_id)
-                        del self.__cache[v_id]
-                        gc.collect()  # Explicitly collect garbage
-                    else:
-                        log.debug("Skip young config: Age %s < %s. View: %s.",
-                                  self.__cache[v_id].get_age(),
-                                  self.__max_config_age,
-                                  v_id)
+        with self.__rlock:
+            for v_id in list(self.__cache.keys()):
+                if self.__cache[v_id].is_older_than(self.__max_config_age):
+                    log.debug("Remove old config: %s", v_id)
+                    del self.__cache[v_id]
+                    gc.collect()  # Explicitly collect garbage
+                else:
+                    log.debug("Skip young config: Age %s < %s. View: %s.",
+                              self.__cache[v_id].get_age(),
+                              self.__max_config_age,
+                              v_id)
+        # Run the timer again.
+        self.__run_timer()

--- a/plugin/view_config.py
+++ b/plugin/view_config.py
@@ -353,6 +353,7 @@ class ViewConfigManager(object):
         self.__rlock = RLock()
         with self.__rlock:
             self.__cache = ViewConfigCache()
+            self.__cache.clear()
 
         self.__timer_period = timer_period      # Seconds.
         self.__max_config_age = max_config_age  # Seconds.

--- a/plugin/view_config.py
+++ b/plugin/view_config.py
@@ -463,10 +463,8 @@ class ViewConfigManager(object):
         """We make sure we run a single thread."""
         if ViewConfigManager.TAG in self.__timer_cache:
             # We need to kill the old thread before starting the new one.
-            self.__running_thread = False
             self.__timer_cache[ViewConfigManager.TAG].cancel()
             del self.__timer_cache[ViewConfigManager.TAG]
-        self.__running_thread = True
         self.__timer_cache[ViewConfigManager.TAG] = Timer(
             interval=self.__timer_period, function=self.__remove_old_configs)
         self.__timer_cache[ViewConfigManager.TAG].start()


### PR DESCRIPTION
There was a bug when reloading the plugin. This is fixed by making sure we clear all caches upon plugin reload. Additionally, we make sure that we don't generate too many threads for checking the config's age. We use Timers again, so the number of thread goes up, but there is a single thread at each time.
