### PR TITLE
Fix missing popups for files with unicode characters

### DIFF
--- a/plugin/popups/popups.py
+++ b/plugin/popups/popups.py
@@ -264,7 +264,8 @@ class Popup:
         if extent.start.file.name != extent.end.file.name:
             return None
 
-        with open(extent.start.file.name, 'r') as f:
+        with open(extent.start.file.name, 'r', encoding='utf-8',
+                  errors='ignore') as f:
             lines = f.readlines()
             return "".join(lines[extent.start.line - 1:extent.end.line])
 

--- a/tests/test_error_vis.py
+++ b/tests/test_error_vis.py
@@ -139,6 +139,17 @@ class TestErrorVis:
         ext = test_extent(cursor1, cursor2)
         self.assertEqual(Popup.get_text_by_extent(ext), '  A a;\n  a.\n')
 
+    def test_get_text_by_extent_unicode(self):
+        """Test getting text from file that contains unicode."""
+        file_name = path.join(path.dirname(__file__),
+                              'test_files',
+                              'test_unicode.cpp')
+        file1 = test_file(file_name)
+        cursor1 = test_cursor(file1, 4)
+        cursor2 = test_cursor(file1, 4)
+        ext = test_extent(cursor1, cursor2)
+        self.assertEqual(Popup.get_text_by_extent(ext), 'class Foo {};\n')
+
     def test_error(self):
         """Test getting text from multiline extent."""
         error_popup = Popup.error("error_text")

--- a/tests/test_files/test_unicode.cpp
+++ b/tests/test_files/test_unicode.cpp
@@ -1,0 +1,7 @@
+// This file has some unicode characters in the comments
+// that should not disrupt ECC
+// ` ©
+class Foo {};
+int main(int argc, char const *argv[]) {
+  Foo foo;
+}


### PR DESCRIPTION
Popups.get_text_by_extent() raises a UnicodeDecodeError exception from f.readlines() if the file has a unicode character, e.g. a copyright symbol in the comments, and the file is opened with the default ascii encoding.

Fix by opening the file with utf-8 encoding, and errors ignored.

Fixes #403.