### PR TITLE
wip: complete includes

### DIFF
--- a/plugin/view_config.py
+++ b/plugin/view_config.py
@@ -64,6 +64,19 @@ class ViewConfig(object):
         # init creation time
         self.__last_usage_time = time.time()
 
+        # set up a proper object
+        completer, flags, include_folders = ViewConfig.__generate_essentials(
+            view, settings)
+        if not completer:
+            log.warning(" could not generate completer for view %s",
+                        view.buffer_id())
+            return
+
+        self.completer = completer
+        self.completer.clang_flags = flags
+        self.completer.update(view, settings)
+        self.include_folders = include_folders
+
     def update_if_needed(self, view, settings):
         """Check if the view config has changed.
 
@@ -84,6 +97,7 @@ class ViewConfig(object):
             self.completer = completer
             self.completer.clang_flags = flags
             self.completer.update(view, settings)
+            self.include_folders = include_folders
             File.update_mod_time(view.file_name())
             return self
         if ViewConfig.needs_reparse(view):

--- a/tests/test_view_config.py
+++ b/tests/test_view_config.py
@@ -77,9 +77,14 @@ class TestViewConfig(GuiTestWrapper):
         self.assertEqual(completer.clang_flags[2], '-x')
         self.assertEqual(completer.clang_flags[3], 'c++')
         self.assertEqual(completer.clang_flags[-1], '-std=c++14')
-        # test last one
+
         expected = path.join(path.dirname(
             path.dirname(__file__)), 'local_folder')
+        # test include folders
+        self.assertEqual(len(view_config.include_folders), 8)
+        self.assertTrue(expected in view_config.include_folders)
+
+        # test include flag
         self.assertEqual(completer.clang_flags[11], '-I' + expected)
         self.tear_down()
 


### PR DESCRIPTION
This is an attempt to implement headers completion to close #231 

- [x] When creating a `ViewConfig`, populate all available folders for includes
- [ ] When user asks for headers run an async task to generate all candidates and feed them into sublime's engine
- [ ] If the previous way is too slow, populate all the possible headers asynchronously as soon as the include folders are updated so that they are ready whenever the user asks for them. This is more complex as we need to implicitly control the life cycle of the current `view_config`
