### PR TITLE
Escape declaration text for Markdown popups

### DIFF
--- a/plugin/popups/popups.py
+++ b/plugin/popups/popups.py
@@ -2,6 +2,7 @@
 
 import sublime
 import mdpopups
+import markupsafe
 import logging
 
 from ..utils.macro_parser import MacroParser
@@ -142,7 +143,7 @@ class Popup:
             declaration_text += " const"
         # Save declaration text.
         popup.__text = DECLARATION_TEMPLATE.format(
-            type_declaration=declaration_text)
+            type_declaration=markupsafe.escape(declaration_text))
         # Doxygen comments
         if cursor.brief_comment:
             popup.__text += BRIEF_DOC_TEMPLATE.format(


### PR DESCRIPTION
Otherwise template declarations like std::vector<int> are cut off at the
< because the angle brackets are interpreted by Markdown.

Fixes #413.

---

# Requirements #
- [x] Reference an issue in this PR. Create new one if needed.
- [x] Make sure your branch is based on `dev`.
