### PR TITLE
Fix parsing unsaved files using old libclang

### DIFF
--- a/plugin/clang/cindex32.py
+++ b/plugin/clang/cindex32.py
@@ -2148,8 +2148,8 @@ class TranslationUnit(ClangObject):
                     print(value)
                 if not isinstance(value, str):
                     raise TypeError('Unexpected unsaved file contents.')
-                unsaved_files_array[i].name = name
-                unsaved_files_array[i].contents = value
+                unsaved_files_array[i].name = name.encode('utf-8')
+                unsaved_files_array[i].contents = value.encode('utf-8')
                 unsaved_files_array[i].length = len(value)
         ptr = conf.lib.clang_reparseTranslationUnit(self, len(unsaved_files),
                 unsaved_files_array, options)

--- a/plugin/clang/cindex33.py
+++ b/plugin/clang/cindex33.py
@@ -2228,8 +2228,8 @@ class TranslationUnit(ClangObject):
                     print(value)
                 if not isinstance(value, str):
                     raise TypeError('Unexpected unsaved file contents.')
-                unsaved_files_array[i].name = name
-                unsaved_files_array[i].contents = value
+                unsaved_files_array[i].name = name.encode('utf-8')
+                unsaved_files_array[i].contents = value.encode('utf-8')
                 unsaved_files_array[i].length = len(value)
         ptr = conf.lib.clang_reparseTranslationUnit(self, len(unsaved_files),
                 unsaved_files_array, options)

--- a/plugin/clang/cindex34.py
+++ b/plugin/clang/cindex34.py
@@ -2361,8 +2361,8 @@ class TranslationUnit(ClangObject):
                     print(value)
                 if not isinstance(value, str):
                     raise TypeError('Unexpected unsaved file contents.')
-                unsaved_files_array[i].name = name
-                unsaved_files_array[i].contents = value
+                unsaved_files_array[i].name = name.encode('utf-8')
+                unsaved_files_array[i].contents = value.encode('utf-8')
                 unsaved_files_array[i].length = len(value)
         ptr = conf.lib.clang_reparseTranslationUnit(self, len(unsaved_files),
                 unsaved_files_array, options)

--- a/plugin/clang/cindex35.py
+++ b/plugin/clang/cindex35.py
@@ -2433,8 +2433,8 @@ class TranslationUnit(ClangObject):
                     print(value)
                 if not isinstance(value, str):
                     raise TypeError('Unexpected unsaved file contents.')
-                unsaved_files_array[i].name = name
-                unsaved_files_array[i].contents = value
+                unsaved_files_array[i].name = name.encode('utf-8')
+                unsaved_files_array[i].contents = value.encode('utf-8')
                 unsaved_files_array[i].length = len(value)
         ptr = conf.lib.clang_reparseTranslationUnit(self, len(unsaved_files),
                 unsaved_files_array, options)

--- a/plugin/clang/cindex36.py
+++ b/plugin/clang/cindex36.py
@@ -2474,8 +2474,8 @@ class TranslationUnit(ClangObject):
                     print(value)
                 if not isinstance(value, str):
                     raise TypeError('Unexpected unsaved file contents.')
-                unsaved_files_array[i].name = name
-                unsaved_files_array[i].contents = value
+                unsaved_files_array[i].name = name.encode('utf-8')
+                unsaved_files_array[i].contents = value.encode('utf-8')
                 unsaved_files_array[i].length = len(value)
         ptr = conf.lib.clang_reparseTranslationUnit(self, len(unsaved_files),
                 unsaved_files_array, options)

--- a/plugin/clang/cindex37.py
+++ b/plugin/clang/cindex37.py
@@ -2501,8 +2501,8 @@ class TranslationUnit(ClangObject):
                     print(value)
                 if not isinstance(value, str):
                     raise TypeError('Unexpected unsaved file contents.')
-                unsaved_files_array[i].name = name
-                unsaved_files_array[i].contents = value
+                unsaved_files_array[i].name = name.encode('utf-8')
+                unsaved_files_array[i].contents = value.encode('utf-8')
                 unsaved_files_array[i].length = len(value)
         ptr = conf.lib.clang_reparseTranslationUnit(self, len(unsaved_files),
                 unsaved_files_array, options)


### PR DESCRIPTION
Adapting the various `cindexXX.py` files for older libclang versions.
Otherwise, autocompletion is not working with an old libclang (as
present e.g. in CentOS) and we get an error like:

```
Traceback (most recent call last):
  File "./python3.3/concurrent/futures/_base.py", line 296, in
_invoke_callbacks
  File
"/home/mhoeher/.config/sublime-text-3/Packages/EasyClangComplete/EasyClangComplete.py",
line 385, in config_updated
    log.debug("updated config: %s", future.result())
  File "./python3.3/concurrent/futures/_base.py", line 394, in result
  File "./python3.3/concurrent/futures/_base.py", line 353, in
__get_result
  File "./python3.3/concurrent/futures/thread.py", line 54, in run
  File
"/home/mhoeher/.config/sublime-text-3/Packages/EasyClangComplete/plugin/view_config.py",
line 461, in load_for_view
    config = ViewConfig(view, settings)
  File
"/home/mhoeher/.config/sublime-text-3/Packages/EasyClangComplete/plugin/view_config.py",
line 76, in __init__
    self.completer.update(view, settings)
  File
"/home/mhoeher/.config/sublime-text-3/Packages/EasyClangComplete/plugin/completion/lib_complete.py",
line 333, in update
    self.tu.reparse(unsaved_files=unsaved_files)
  File
"/home/mhoeher/.config/sublime-text-3/Packages/EasyClangComplete/plugin/clang/cindex34.py",
line 2364, in reparse
    unsaved_files_array[i].name = name
```
