### PR TITLE
Show an inline "error" popup instead of dialog

### DIFF
--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -158,7 +158,14 @@ class SublBridge:
     @staticmethod
     def show_error_dialog(message):
         """Show an error message dialog."""
-        sublime.error_message(message)
+        log.error(message)
+        view = sublime.active_window().active_view()
+        content = "<strong>\u26A0 Error:</strong><br/><pre>{}</pre>"
+        content = content.format(message)
+        flags = (
+            sublime.COOPERATE_WITH_AUTO_COMPLETE |
+            sublime.HIDE_ON_MOUSE_MOVE)
+        view.show_popup(content, flags)
 
 
 class PosStatus:


### PR DESCRIPTION
With this change, the error dialog is converted to a simple popup. This
is less intrusive than the dialog, as it does not block the user from
interacting with other parts of the GUI - on the other side, this is
more visible than just writing a log entry.

This contributes to #417 (by removing the dialog) but does not solve the
root cause (i.e. latest when editing a file where ECC uses combined
flags from build commands and hence we get multiple `-std=XXX` flags,
the error will be shown to the user).
