### PR TITLE
Escape text for error and warning Markdown popups

### DIFF
--- a/plugin/popups/popups.py
+++ b/plugin/popups/popups.py
@@ -52,7 +52,7 @@ class Popup:
         """Initialize a new error popup."""
         popup = Popup()
         popup.__popup_type = 'panel-error "ECC: Error"'
-        popup.__text = text
+        popup.__text = markupsafe.escape(text)
         return popup
 
     @staticmethod
@@ -60,7 +60,7 @@ class Popup:
         """Initialize a new warning popup."""
         popup = Popup()
         popup.__popup_type = 'panel-warning "ECC: Warning"'
-        popup.__text = text
+        popup.__text = markupsafe.escape(text)
         return popup
 
     @staticmethod


### PR DESCRIPTION
Some clang errors and warnings can include characters that need to be escaped.