### PR TITLE
Re-enable cindex fix for ObjC method declarations' Cursor.result_type

### DIFF
--- a/plugin/clang/cindex32.py
+++ b/plugin/clang/cindex32.py
@@ -1178,7 +1178,7 @@ class Cursor(Structure):
     def result_type(self):
         """Retrieve the Type of the result for this Cursor."""
         if not hasattr(self, '_result_type'):
-            self._result_type = conf.lib.clang_getResultType(self.type)
+            self._result_type = conf.lib.clang_getCursorResultType(self)
 
         return self._result_type
 
@@ -2657,6 +2657,11 @@ functionList = [
   ("clang_getCursorReferenceNameRange",
    [Cursor, c_uint, c_uint],
    SourceRange),
+
+  ("clang_getCursorResultType",
+   [Cursor],
+   Type,
+   Type.from_result),
 
   ("clang_getCursorSemanticParent",
    [Cursor],

--- a/plugin/clang/cindex33.py
+++ b/plugin/clang/cindex33.py
@@ -1178,7 +1178,7 @@ class Cursor(Structure):
     def result_type(self):
         """Retrieve the Type of the result for this Cursor."""
         if not hasattr(self, '_result_type'):
-            self._result_type = conf.lib.clang_getResultType(self.type)
+            self._result_type = conf.lib.clang_getCursorResultType(self)
 
         return self._result_type
 
@@ -2741,6 +2741,11 @@ functionList = [
   ("clang_getCursorReferenceNameRange",
    [Cursor, c_uint, c_uint],
    SourceRange),
+
+  ("clang_getCursorResultType",
+   [Cursor],
+   Type,
+   Type.from_result),
 
   ("clang_getCursorSemanticParent",
    [Cursor],

--- a/plugin/clang/cindex34.py
+++ b/plugin/clang/cindex34.py
@@ -1235,7 +1235,7 @@ class Cursor(Structure):
     def result_type(self):
         """Retrieve the Type of the result for this Cursor."""
         if not hasattr(self, '_result_type'):
-            self._result_type = conf.lib.clang_getResultType(self.type)
+            self._result_type = conf.lib.clang_getCursorResultType(self)
 
         return self._result_type
 
@@ -2878,6 +2878,11 @@ functionList = [
   ("clang_getCursorReferenceNameRange",
    [Cursor, c_uint, c_uint],
    SourceRange),
+
+  ("clang_getCursorResultType",
+   [Cursor],
+   Type,
+   Type.from_result),
 
   ("clang_getCursorSemanticParent",
    [Cursor],

--- a/plugin/clang/cindex35.py
+++ b/plugin/clang/cindex35.py
@@ -1249,7 +1249,7 @@ class Cursor(Structure):
     def result_type(self):
         """Retrieve the Type of the result for this Cursor."""
         if not hasattr(self, '_result_type'):
-            self._result_type = conf.lib.clang_getResultType(self.type)
+            self._result_type = conf.lib.clang_getCursorResultType(self)
 
         return self._result_type
 
@@ -2963,6 +2963,11 @@ functionList = [
   ("clang_getCursorReferenceNameRange",
    [Cursor, c_uint, c_uint],
    SourceRange),
+
+  ("clang_getCursorResultType",
+   [Cursor],
+   Type,
+   Type.from_result),
 
   ("clang_getCursorSemanticParent",
    [Cursor],

--- a/plugin/clang/cindex36.py
+++ b/plugin/clang/cindex36.py
@@ -1299,7 +1299,7 @@ class Cursor(Structure):
     def result_type(self):
         """Retrieve the Type of the result for this Cursor."""
         if not hasattr(self, '_result_type'):
-            self._result_type = conf.lib.clang_getResultType(self.type)
+            self._result_type = conf.lib.clang_getCursorResultType(self)
 
         return self._result_type
 
@@ -3004,6 +3004,11 @@ functionList = [
   ("clang_getCursorReferenceNameRange",
    [Cursor, c_uint, c_uint],
    SourceRange),
+
+  ("clang_getCursorResultType",
+   [Cursor],
+   Type,
+   Type.from_result),
 
   ("clang_getCursorSemanticParent",
    [Cursor],

--- a/plugin/clang/cindex37.py
+++ b/plugin/clang/cindex37.py
@@ -1299,7 +1299,7 @@ class Cursor(Structure):
     def result_type(self):
         """Retrieve the Type of the result for this Cursor."""
         if not hasattr(self, '_result_type'):
-            self._result_type = conf.lib.clang_getResultType(self.type)
+            self._result_type = conf.lib.clang_getCursorResultType(self)
 
         return self._result_type
 
@@ -3032,6 +3032,11 @@ functionList = [
   ("clang_getCursorReferenceNameRange",
    [Cursor, c_uint, c_uint],
    SourceRange),
+
+  ("clang_getCursorResultType",
+   [Cursor],
+   Type,
+   Type.from_result),
 
   ("clang_getCursorSemanticParent",
    [Cursor],

--- a/plugin/clang/cindex38.py
+++ b/plugin/clang/cindex38.py
@@ -1336,7 +1336,7 @@ class Cursor(Structure):
     def result_type(self):
         """Retrieve the Type of the result for this Cursor."""
         if not hasattr(self, '_result_type'):
-            self._result_type = conf.lib.clang_getResultType(self.type)
+            self._result_type = conf.lib.clang_getCursorResultType(self)
 
         return self._result_type
 
@@ -3077,6 +3077,11 @@ functionList = [
   ("clang_getCursorReferenceNameRange",
    [Cursor, c_uint, c_uint],
    SourceRange),
+
+  ("clang_getCursorResultType",
+   [Cursor],
+   Type,
+   Type.from_result),
 
   ("clang_getCursorSemanticParent",
    [Cursor],

--- a/plugin/clang/cindex39.py
+++ b/plugin/clang/cindex39.py
@@ -1495,7 +1495,7 @@ class Cursor(Structure):
     def result_type(self):
         """Retrieve the Type of the result for this Cursor."""
         if not hasattr(self, '_result_type'):
-            self._result_type = conf.lib.clang_getResultType(self.type)
+            self._result_type = conf.lib.clang_getCursorResultType(self)
 
         return self._result_type
 
@@ -3409,6 +3409,11 @@ functionList = [
   ("clang_getCursorReferenceNameRange",
    [Cursor, c_uint, c_uint],
    SourceRange),
+
+  ("clang_getCursorResultType",
+   [Cursor],
+   Type,
+   Type.from_result),
 
   ("clang_getCursorSemanticParent",
    [Cursor],

--- a/plugin/clang/cindex40.py
+++ b/plugin/clang/cindex40.py
@@ -1538,7 +1538,7 @@ class Cursor(Structure):
     def result_type(self):
         """Retrieve the Type of the result for this Cursor."""
         if not hasattr(self, '_result_type'):
-            self._result_type = conf.lib.clang_getResultType(self.type)
+            self._result_type = conf.lib.clang_getCursorResultType(self)
 
         return self._result_type
 
@@ -3330,6 +3330,11 @@ functionList = [
   ("clang_getCursorReferenceNameRange",
    [Cursor, c_uint, c_uint],
    SourceRange),
+
+  ("clang_getCursorResultType",
+   [Cursor],
+   Type,
+   Type.from_result),
 
   ("clang_getCursorSemanticParent",
    [Cursor],

--- a/plugin/clang/cindex50.py
+++ b/plugin/clang/cindex50.py
@@ -1611,7 +1611,7 @@ class Cursor(Structure):
     def result_type(self):
         """Retrieve the Type of the result for this Cursor."""
         if not hasattr(self, '_result_type'):
-            self._result_type = conf.lib.clang_getResultType(self.type)
+            self._result_type = conf.lib.clang_getCursorResultType(self)
 
         return self._result_type
 
@@ -3473,6 +3473,11 @@ functionList = [
   ("clang_getCursorReferenceNameRange",
    [Cursor, c_uint, c_uint],
    SourceRange),
+
+  ("clang_getCursorResultType",
+   [Cursor],
+   Type,
+   Type.from_result),
 
   ("clang_getCursorSemanticParent",
    [Cursor],

--- a/tests/test_error_vis.py
+++ b/tests/test_error_vis.py
@@ -534,74 +534,72 @@ class TestErrorVis:
         self.tear_down_completer()
         self.tear_down()
 
-# Test disabled due to clang cindex.py bug.
-#     def test_info_objc_instance_method_decl(self):
-#         """Test that Objective-C info message is generated correctly.
+    def test_info_objc_instance_method_decl(self):
+        """Test that Objective-C info message is generated correctly.
 
-#         For an interface/protocol/category instance method decl.
-#         """
-#         if not should_run_objc_tests() or not self.use_libclang:
-#             return
-#         file_name = path.join(path.dirname(__file__),
-#                               'test_files',
-#                               'test_objective_c.m')
-#         self.set_up_view(file_name)
-#         completer, settings = self.set_up_completer()
-#         # Check the current cursor position is completable.
-#         self.assertEqual(
-#             self.get_row(33),
-#             "  -(void)interfaceMethodVoidNoParameters {}")
-#         pos = self.view.text_point(33, 14)
-#         action_request = ActionRequest(self.view, pos)
-#         request, info_popup = completer.info(action_request, settings)
-#         self.maxDiff = None
-#         expected_info_msg = """!!! panel-info "ECC: Info"
-#     ## Declaration: ##
-#     -(void)[interfaceMethodVoidNoParameters]({file}:34:10)
-#     ### Brief documentation: ###
-#     ```
-#     Brief comment.
-#     ```
-# """.format(file=file_name)
-#         # Make sure we remove trailing spaces on the right to comply with how
-#         # sublime text handles this.
-#         actual_msg = cleanup_trailing_spaces(info_popup.as_markdown())
-#         self.assertEqual(actual_msg, expected_info_msg)
-#         # cleanup
-#         self.tear_down_completer()
-#         self.tear_down()
+        For an interface/protocol/category instance method decl.
+        """
+        if not should_run_objc_tests() or not self.use_libclang:
+            return
+        file_name = path.join(path.dirname(__file__),
+                              'test_files',
+                              'test_objective_c.m')
+        self.set_up_view(file_name)
+        completer, settings = self.set_up_completer()
+        # Check the current cursor position is completable.
+        self.assertEqual(
+            self.get_row(33),
+            "  -(void)interfaceMethodVoidNoParameters {}")
+        pos = self.view.text_point(33, 14)
+        action_request = ActionRequest(self.view, pos)
+        request, info_popup = completer.info(action_request, settings)
+        self.maxDiff = None
+        expected_info_msg = """!!! panel-info "ECC: Info"
+    ## Declaration: ##
+    -(void)[interfaceMethodVoidNoParameters]({file}:34:10)
+    ### Brief documentation: ###
+    ```
+    Brief comment.
+    ```
+""".format(file=file_name)
+        # Make sure we remove trailing spaces on the right to comply with how
+        # sublime text handles this.
+        actual_msg = cleanup_trailing_spaces(info_popup.as_markdown())
+        self.assertEqual(actual_msg, expected_info_msg)
+        # cleanup
+        self.tear_down_completer()
+        self.tear_down()
 
-# Test disabled due to clang cindex.py bug.
-#     def test_info_objc_class_method_decl(self):
-#         """Test that Objective-C info message is generated correctly.
+    def test_info_objc_class_method_decl(self):
+        """Test that Objective-C info message is generated correctly.
 
-#         For an interface/protocol/category class method decl.
-#         """
-#         if not should_run_objc_tests() or not self.use_libclang:
-#             return
-#         file_name = path.join(path.dirname(__file__),
-#                               'test_files',
-#                               'test_objective_c.m')
-#         self.set_up_view(file_name)
-#         completer, settings = self.set_up_completer()
-#         # Check the current cursor position is completable.
-#         self.assertEqual(self.get_row(13),
-#                          "  +(void)protocolClassMethod;")
-#         pos = self.view.text_point(13, 14)
-#         action_request = ActionRequest(self.view, pos)
-#         request, info_popup = completer.info(action_request, settings)
-#         self.maxDiff = None
-#         expected_info_msg = """!!! panel-info "ECC: Info"
-#     ## Declaration: ##
-#     +(void)[protocolClassMethod]({file}:14:10)
-# """.format(file=file_name)
-#         # Make sure we remove trailing spaces on the right to comply with how
-#         # sublime text handles this.
-#         actual_msg = cleanup_trailing_spaces(info_popup.as_markdown())
-#         self.assertEqual(actual_msg, expected_info_msg)
-#         # cleanup
-#         self.tear_down_completer()
-#         self.tear_down()
+        For an interface/protocol/category class method decl.
+        """
+        if not should_run_objc_tests() or not self.use_libclang:
+            return
+        file_name = path.join(path.dirname(__file__),
+                              'test_files',
+                              'test_objective_c.m')
+        self.set_up_view(file_name)
+        completer, settings = self.set_up_completer()
+        # Check the current cursor position is completable.
+        self.assertEqual(self.get_row(13),
+                         "  +(void)protocolClassMethod;")
+        pos = self.view.text_point(13, 14)
+        action_request = ActionRequest(self.view, pos)
+        request, info_popup = completer.info(action_request, settings)
+        self.maxDiff = None
+        expected_info_msg = """!!! panel-info "ECC: Info"
+    ## Declaration: ##
+    +(void)[protocolClassMethod]({file}:14:10)
+""".format(file=file_name)
+        # Make sure we remove trailing spaces on the right to comply with how
+        # sublime text handles this.
+        actual_msg = cleanup_trailing_spaces(info_popup.as_markdown())
+        self.assertEqual(actual_msg, expected_info_msg)
+        # cleanup
+        self.tear_down_completer()
+        self.tear_down()
 
     def test_info_objc_protocol_ref(self):
         """Test that Objective-C info message is generated correctly.


### PR DESCRIPTION
I originally made the fix in ECC, (89d46e895103bb6b012039cd3647426b28461dd5),
but reverted it (b16ffeef1b430df6cfe18989b6aac8b7e4713899) due to concern
over not matching llvm's cindex.py. Now, the cindex fix has been applied
upstream to llvm, so it seems safe to fix here too.

This re-enables the cindex fix and tests for it.
