### PR TITLE
Use lists for commands

### DIFF
--- a/plugin/flags_sources/cmake_file.py
+++ b/plugin/flags_sources/cmake_file.py
@@ -28,7 +28,6 @@ class CMakeFile(FlagsSource):
             analyzed view path.
     """
     _FILE_NAME = 'CMakeLists.txt'
-    _CMAKE_MASK = '{cmake} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON {flags} "{path}"'
     _DEP_REGEX = re.compile(r'\"(.+\..+)\"')
 
     def __init__(self,
@@ -166,10 +165,9 @@ class CMakeFile(FlagsSource):
             prefix_paths = []
         if not flags:
             flags = []
-        cmake_cmd = CMakeFile._CMAKE_MASK.format(
-            cmake=cmake_binary,
-            flags=" ".join(flags),
-            path=cmake_file.folder())
+
+        cmake_cmd = [cmake_binary, '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON'] \
+            + flags + [cmake_file.folder()]
         tempdir = CMakeFile.unique_folder_name(cmake_file.full_path())
         try:
             os.makedirs(tempdir)
@@ -203,8 +201,8 @@ class CMakeFile(FlagsSource):
                 if cpp_compiler is not None:
                     file.write(
                         "set(CMAKE_CPP_COMPILER  {})\n".format(cpp_compiler))
-            cmake_cmd += " -DCMAKE_TOOLCHAIN_FILE={}".format(
-                toolchain_file_path)
+            cmake_cmd += ["-DCMAKE_TOOLCHAIN_FILE={}".format(
+                toolchain_file_path)]
 
         log.debug(' running command: %s', cmake_cmd)
         output_text = Tools.run_command(

--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -646,7 +646,7 @@ class Tools:
         return PosStatus.COMPLETION_NOT_NEEDED
 
     @staticmethod
-    def run_command(command, shell=True, cwd=path.curdir, env=environ,
+    def run_command(command, shell=False, cwd=path.curdir, env=environ,
                     stdin=None, default=None):
         """Run a generic command in a subprocess.
 
@@ -658,20 +658,9 @@ class Tools:
         Returns:
             str: raw command output or default value
         """
-        def list_to_line(cmd_list):
-            """Convert list of commands into a single string."""
-            if sublime.platform() == "windows":
-                return subprocess.list2cmdline(cmd_list)
-            # Make the args POSIX conformant.
-            from shlex import quote
-            return " ".join([quote(entry) for entry in cmd_list])
-
         output_text = default
         try:
             startupinfo = None
-            if isinstance(command, list):
-                command = list_to_line(command)
-                log.debug("running command: \n%s", command)
             if sublime.platform() == "windows":
                 # Don't let console window pop-up briefly.
                 startupinfo = subprocess.STARTUPINFO()
@@ -710,9 +699,10 @@ class Tools:
             too important to continue. If this fails the plugin will not work
             at all.
         """
-        check_version_cmd = clang_binary + " -v"
-        log.info("Getting version from command: `%s`", check_version_cmd)
-        output_text = Tools.run_command(check_version_cmd, shell=True)
+        check_version_cmd = [clang_binary, "-v"]
+        log.info("Getting version from command: `%s`",
+                 " ".join(check_version_cmd))
+        output_text = Tools.run_command(check_version_cmd, shell=False)
 
         if "Apple" in output_text:
             return cls._get_apple_clang_version_str(output_text)

--- a/plugin/utils/compiler_builtins.py
+++ b/plugin/utils/compiler_builtins.py
@@ -191,7 +191,7 @@ class CompilerBuiltIns:
             args += ["-x", language]
         if std is not None:
             args += ['-std=' + std]
-        args += ['-Wp,-v', '-E', '-']
+        args += ['-Wp', '-v', '-E', '-']
 
         output = Tools.run_command(args, stdin=subprocess.DEVNULL, default="")
         pick = False

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -28,7 +28,7 @@ class TestStyle(TestCase):
     def test_pep8(self):
         """Test conformance to pep8."""
         cmd = PEP8_CMD.format(PLUGIN_SOURCE_FOLDER)
-        output = Tools.run_command(cmd)
+        output = Tools.run_command(cmd, shell=True)
         print(output)
         if LINUX_MISSING_MSG in output or WINDOWS_MISSING_MSG in output:
             print('no pep8 found in path!')
@@ -39,7 +39,7 @@ class TestStyle(TestCase):
         """Test conformance to pep257."""
         cmd = PEP257_CMD.format(PLUGIN_SOURCE_FOLDER, ','.join(PEP_257_IGNORE))
         print(cmd)
-        output = Tools.run_command(cmd)
+        output = Tools.run_command(cmd, shell=True)
         print(output)
         if LINUX_MISSING_MSG in output or WINDOWS_MISSING_MSG in output:
             print('no pep257 found in path!')

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -205,7 +205,7 @@ class test_tools(TestCase):
         """Test getting clang version."""
         version = Tools.get_clang_version_str('clang++')
         print("version: ", version)
-        self.assertGreater(len(version), 3)
+        self.assertTrue('.' in version)
 
 
 class test_file(TestCase):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -201,6 +201,13 @@ class test_tools(TestCase):
         self.assertEqual(id(b), id(bb))
         self.assertNotEqual(id(a), id(b))
 
+    def test_get_clang_version(self):
+        """Test getting clang version."""
+        version = Tools.get_clang_version_str('clang++')
+        print("version: ", version)
+        self.assertGreater(len(version), 3)
+        self.assertEquals('3', version[0])
+
 
 class test_file(TestCase):
     """Testing file related stuff."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -205,7 +205,7 @@ class test_tools(TestCase):
         """Test getting clang version."""
         version = Tools.get_clang_version_str('clang++')
         print("version: ", version)
-        self.assertTrue('.' in version)
+        self.assertIn('.', version)
 
 
 class test_file(TestCase):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -206,7 +206,6 @@ class test_tools(TestCase):
         version = Tools.get_clang_version_str('clang++')
         print("version: ", version)
         self.assertGreater(len(version), 3)
-        self.assertEquals('3', version[0])
 
 
 class test_file(TestCase):


### PR DESCRIPTION
This should fix #458 

As suggested by @nolange we now use `shell=False` everywhere by default which should solve the issues with quoting variables.
