### PR TITLE
Fix ObjC method popups with covariant types like NSArray

### DIFF
--- a/plugin/popups/popups.py
+++ b/plugin/popups/popups.py
@@ -395,7 +395,7 @@ class Popup:
             else:
                 declaration_text += location_cursor.spelling
         popup.__text = DECLARATION_TEMPLATE.format(
-            type_declaration=declaration_text)
+            type_declaration=markupsafe.escape(declaration_text))
 
         if comment_cursor and comment_cursor.brief_comment:
             popup.__text += BRIEF_DOC_TEMPLATE.format(

--- a/tests/test_error_vis.py
+++ b/tests/test_error_vis.py
@@ -730,6 +730,38 @@ class TestErrorVis:
         self.tear_down_completer()
         self.tear_down()
 
+    def test_info_objc_covariant_method(self):
+        """Test Objective-C info messages for covariant types.
+
+        Covariant types like NSArray, NSDictionary are special cases
+        because they have angle brackets that need special escaping.
+        """
+        if not should_run_objc_tests() or not self.use_libclang:
+            return
+        file_name = path.join(path.dirname(__file__),
+                              'test_files',
+                              'test_objective_c_covariant.m')
+        self.set_up_view(file_name)
+        completer, settings = self.set_up_completer()
+        # Check the current cursor position is completable.
+        self.assertEqual(self.get_row(3),
+                         "-(MyCovariant<Foo*>*)covariantMethod;")
+        pos = self.view.text_point(3, 22)
+        action_request = ActionRequest(self.view, pos)
+        request, info_popup = completer.info(action_request, settings)
+        self.maxDiff = None
+        expected_info_msg = """!!! panel-info "ECC: Info"
+    ## Declaration: ##
+    -([MyCovariant&lt;Foo *&gt; *]({file}:3:12))[covariantMethod]({file}:4:22)
+""".format(file=file_name)
+        # Make sure we remove trailing spaces on the right to comply with how
+        # sublime text handles this.
+        actual_msg = cleanup_trailing_spaces(info_popup.as_markdown())
+        self.assertEqual(actual_msg, expected_info_msg)
+        # cleanup
+        self.tear_down_completer()
+        self.tear_down()
+
 
 class TestErrorVisBin(TestErrorVis, GuiTestWrapper):
     """Test class for the binary based completer."""

--- a/tests/test_files/test_objective_c_covariant.m
+++ b/tests/test_files/test_objective_c_covariant.m
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+@class Foo;
+@interface MyCovariant<__covariant ObjectType> : NSObject
+-(MyCovariant<Foo*>*)covariantMethod;
+@end


### PR DESCRIPTION
Hovering over methods that return covariant types, e.g. NSArray<Foo*>*
would show a cut-off popup, e.g. "-(NSArray \*" instead of the whole type
and method, e.g. "-(NSArray<Foo\*>\*)methodName".

Covariant types' spelling includes angle brackets that were
causing the problem. Fix by escaping the angle brackets for mdpopups.

Before:
![image](https://user-images.githubusercontent.com/20820660/40033215-ef11763a-57bc-11e8-955d-c471b6d6a00b.png)


After:
![image](https://user-images.githubusercontent.com/20820660/40033190-dd264856-57bc-11e8-8a0d-13c4e448d9fd.png)

