### PR TITLE
Update macOS clang for Xcode 10

### DIFF
--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -37,7 +37,8 @@ OSX_CLANG_VERSION_DICT = {
     '8.1': '3.9',
     '8.2': '3.9',
     '9.0': '4.0',
-    '9.1': '4.0'
+    '9.1': '5.0',
+    '10.0': '6.0',
 }
 
 log = logging.getLogger("ECC")
@@ -712,7 +713,7 @@ class Tools:
     @classmethod
     def _get_regular_clang_version_str(cls, output_text):
         # now we have the output, and can extract version from it
-        version_regex = re.compile(r"\d\.\d\.*\d*")
+        version_regex = re.compile(r"\d*\.\d*\.\d*")
         match = version_regex.search(output_text)
         if match:
             version_str = match.group()
@@ -723,12 +724,12 @@ class Tools:
 
     @classmethod
     def _get_apple_clang_version_str(cls, output_text):
-        version_regex = re.compile(r"\d\.\d\.*\d*")
+        version_regex = re.compile(r"\d*\.\d*\.\d*")
         match = version_regex.search(output_text)
         if match:
             version_str = match.group()
             # throw away the patch number
-            osx_version = version_str[:3]
+            osx_version = ".".join(version_str.split(".")[:-1])
             try:
                 # info from this table:
                 # https://gist.github.com/yamaya/2924292

--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -325,7 +325,7 @@ class File:
         Returns:
             bool: True if contains str, False if not
         """
-        with open(file_path) as f:
+        with open(file_path, encoding='utf-8') as f:
             for line in f:
                 if line.lower().startswith(query):
                     log.debug("found needed line: '%s'", line)


### PR DESCRIPTION
This pull request:

1. Opens files as UTF-8 so we don't fail on files with Unicode in them
2. Adds newer Apple clangs, with version numbers based on `_LIBCPP_VERSION`.