### PR TITLE
Allow more digits for clang

### DIFF
--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -37,7 +37,8 @@ OSX_CLANG_VERSION_DICT = {
     '8.1': '3.9',
     '8.2': '3.9',
     '9.0': '4.0',
-    '9.1': '4.0'
+    '9.1': '4.0',
+    '10.0': '6.0'
 }
 
 log = logging.getLogger("ECC")
@@ -324,7 +325,7 @@ class File:
         Returns:
             bool: True if contains str, False if not
         """
-        with open(file_path) as f:
+        with open(file_path, encoding='utf-8') as f:
             for line in f:
                 if line.lower().startswith(query):
                     log.debug("found needed line: '%s'", line)
@@ -712,7 +713,7 @@ class Tools:
     @classmethod
     def _get_regular_clang_version_str(cls, output_text):
         # now we have the output, and can extract version from it
-        version_regex = re.compile(r"\d\.\d\.*\d*")
+        version_regex = re.compile(r"\d+\.\d+\.*\d*")
         match = version_regex.search(output_text)
         if match:
             version_str = match.group()
@@ -723,12 +724,12 @@ class Tools:
 
     @classmethod
     def _get_apple_clang_version_str(cls, output_text):
-        version_regex = re.compile(r"\d\.\d\.*\d*")
+        version_regex = re.compile(r"\d+\.\d+\.*\d*")
         match = version_regex.search(output_text)
         if match:
             version_str = match.group()
             # throw away the patch number
-            osx_version = version_str[:3]
+            osx_version = ".".join(version_str.split(".")[:-1])
             try:
                 # info from this table:
                 # https://gist.github.com/yamaya/2924292


### PR DESCRIPTION
This solves the issue with apple clang 10.0 by adapting version regex
