### PR TITLE
Improve popups for C++ templates by adding hyperlinks to template parameters

### DIFF
--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -184,4 +184,11 @@
   "target_cpp_compiler": null,
   "target_objective_c_compiler": null,
   "target_objective_cpp_compiler": null,
+
+  // Expand template types and add more hyperlinks when showing info on hover.
+  // For example, "std::shared_ptr<Foo> foo" will expand to show hyperlinks
+  // to both std::shared_ptr and the template type, Foo. This may cause
+  // some types and typedefs to be verbose. For example, "std::string foo"
+  // expands to "std::string<char, char_traits<char>, allocator<char>> foo".
+  "expand_template_types": true,
 }

--- a/plugin/clang/cindex32.py
+++ b/plugin/clang/cindex32.py
@@ -1529,6 +1529,12 @@ class Type(Structure):
 
         return res
 
+    def get_num_template_arguments(self):
+        return conf.lib.clang_Type_getNumTemplateArguments(self)
+
+    def get_template_argument_type(self, num):
+        return conf.lib.clang_Type_getTemplateArgumentAsType(self, num)
+
     def get_canonical(self):
         """
         Return the canonical type for a Type.
@@ -3004,6 +3010,15 @@ functionList = [
    [Cursor, c_uint],
    Cursor,
    Cursor.from_result),
+
+  ("clang_Type_getNumTemplateArguments",
+   [Type],
+   c_int),
+
+  ("clang_Type_getTemplateArgumentAsType",
+   [Type, c_uint],
+   Type,
+   Type.from_result),
 ]
 
 class LibclangError(Exception):

--- a/plugin/clang/cindex33.py
+++ b/plugin/clang/cindex33.py
@@ -1552,6 +1552,12 @@ class Type(Structure):
 
         return res
 
+    def get_num_template_arguments(self):
+        return conf.lib.clang_Type_getNumTemplateArguments(self)
+
+    def get_template_argument_type(self, num):
+        return conf.lib.clang_Type_getTemplateArgumentAsType(self, num)
+
     def get_canonical(self):
         """
         Return the canonical type for a Type.
@@ -3096,6 +3102,15 @@ functionList = [
   ("clang_Type_getAlignOf",
    [Type],
    c_longlong),
+
+  ("clang_Type_getNumTemplateArguments",
+   [Type],
+   c_int),
+
+  ("clang_Type_getTemplateArgumentAsType",
+   [Type, c_uint],
+   Type,
+   Type.from_result),
 
   ("clang_Type_getOffsetOf",
    [Type, c_char_p],

--- a/plugin/clang/cindex34.py
+++ b/plugin/clang/cindex34.py
@@ -1667,6 +1667,12 @@ class Type(Structure):
 
         return res
 
+    def get_num_template_arguments(self):
+        return conf.lib.clang_Type_getNumTemplateArguments(self)
+
+    def get_template_argument_type(self, num):
+        return conf.lib.clang_Type_getTemplateArgumentAsType(self, num)
+
     def get_canonical(self):
         """
         Return the canonical type for a Type.
@@ -3251,6 +3257,15 @@ functionList = [
 
   ("clang_Type_getClassType",
    [Type],
+   Type,
+   Type.from_result),
+
+  ("clang_Type_getNumTemplateArguments",
+   [Type],
+   c_int),
+
+  ("clang_Type_getTemplateArgumentAsType",
+   [Type, c_uint],
    Type,
    Type.from_result),
 

--- a/plugin/clang/cindex35.py
+++ b/plugin/clang/cindex35.py
@@ -1739,6 +1739,12 @@ class Type(Structure):
 
         return res
 
+    def get_num_template_arguments(self):
+        return conf.lib.clang_Type_getNumTemplateArguments(self)
+
+    def get_template_argument_type(self, num):
+        return conf.lib.clang_Type_getTemplateArgumentAsType(self, num)
+
     def get_canonical(self):
         """
         Return the canonical type for a Type.
@@ -3336,6 +3342,15 @@ functionList = [
 
   ("clang_Type_getClassType",
    [Type],
+   Type,
+   Type.from_result),
+
+  ("clang_Type_getNumTemplateArguments",
+   [Type],
+   c_int),
+
+  ("clang_Type_getTemplateArgumentAsType",
+   [Type, c_uint],
    Type,
    Type.from_result),
 

--- a/plugin/clang/cindex36.py
+++ b/plugin/clang/cindex36.py
@@ -1780,6 +1780,12 @@ class Type(Structure):
 
         return res
 
+    def get_num_template_arguments(self):
+        return conf.lib.clang_Type_getNumTemplateArguments(self)
+
+    def get_template_argument_type(self, num):
+        return conf.lib.clang_Type_getTemplateArgumentAsType(self, num)
+
     def get_canonical(self):
         """
         Return the canonical type for a Type.
@@ -3403,6 +3409,15 @@ functionList = [
 
   ("clang_Type_getClassType",
    [Type],
+   Type,
+   Type.from_result),
+
+  ("clang_Type_getNumTemplateArguments",
+   [Type],
+   c_int),
+
+  ("clang_Type_getTemplateArgumentAsType",
+   [Type, c_uint],
    Type,
    Type.from_result),
 

--- a/plugin/clang/cindex37.py
+++ b/plugin/clang/cindex37.py
@@ -1792,6 +1792,12 @@ class Type(Structure):
 
         return res
 
+    def get_num_template_arguments(self):
+        return conf.lib.clang_Type_getNumTemplateArguments(self)
+
+    def get_template_argument_type(self, num):
+        return conf.lib.clang_Type_getTemplateArgumentAsType(self, num)
+
     def get_canonical(self):
         """
         Return the canonical type for a Type.

--- a/plugin/clang/cindex38.py
+++ b/plugin/clang/cindex38.py
@@ -1830,6 +1830,12 @@ class Type(Structure):
 
         return res
 
+    def get_num_template_arguments(self):
+        return conf.lib.clang_Type_getNumTemplateArguments(self)
+
+    def get_template_argument_type(self, num):
+        return conf.lib.clang_Type_getTemplateArgumentAsType(self, num)
+
     def get_canonical(self):
         """
         Return the canonical type for a Type.
@@ -3484,6 +3490,15 @@ functionList = [
 
   ("clang_Type_getClassType",
    [Type],
+   Type,
+   Type.from_result),
+
+  ("clang_Type_getNumTemplateArguments",
+   [Type],
+   c_int),
+
+  ("clang_Type_getTemplateArgumentAsType",
+   [Type, c_uint],
    Type,
    Type.from_result),
 

--- a/plugin/clang/cindex39.py
+++ b/plugin/clang/cindex39.py
@@ -2106,6 +2106,12 @@ class Type(Structure):
 
         return res
 
+    def get_num_template_arguments(self):
+        return conf.lib.clang_Type_getNumTemplateArguments(self)
+
+    def get_template_argument_type(self, num):
+        return conf.lib.clang_Type_getTemplateArgumentAsType(self, num)
+
     def get_canonical(self):
         """
         Return the canonical type for a Type.
@@ -3824,6 +3830,15 @@ functionList = [
 
   ("clang_Type_getClassType",
    [Type],
+   Type,
+   Type.from_result),
+
+  ("clang_Type_getNumTemplateArguments",
+   [Type],
+   c_int),
+
+  ("clang_Type_getTemplateArgumentAsType",
+   [Type, c_uint],
    Type,
    Type.from_result),
 

--- a/plugin/clang/cindex40.py
+++ b/plugin/clang/cindex40.py
@@ -2034,6 +2034,12 @@ class Type(Structure):
 
         return res
 
+    def get_num_template_arguments(self):
+        return conf.lib.clang_Type_getNumTemplateArguments(self)
+
+    def get_template_argument_type(self, num):
+        return conf.lib.clang_Type_getTemplateArgumentAsType(self, num)
+
     def get_canonical(self):
         """
         Return the canonical type for a Type.
@@ -3745,6 +3751,15 @@ functionList = [
 
   ("clang_Type_getClassType",
    [Type],
+   Type,
+   Type.from_result),
+
+  ("clang_Type_getNumTemplateArguments",
+   [Type],
+   c_int),
+
+  ("clang_Type_getTemplateArgumentAsType",
+   [Type, c_uint],
    Type,
    Type.from_result),
 

--- a/plugin/clang/cindex50.py
+++ b/plugin/clang/cindex50.py
@@ -2161,6 +2161,12 @@ class Type(Structure):
 
         return res
 
+    def get_num_template_arguments(self):
+        return conf.lib.clang_Type_getNumTemplateArguments(self)
+
+    def get_template_argument_type(self, num):
+        return conf.lib.clang_Type_getTemplateArgumentAsType(self, num)
+
     def get_canonical(self):
         """
         Return the canonical type for a Type.
@@ -3895,6 +3901,15 @@ functionList = [
 
   ("clang_Type_getClassType",
    [Type],
+   Type,
+   Type.from_result),
+
+  ("clang_Type_getNumTemplateArguments",
+   [Type],
+   c_int),
+
+  ("clang_Type_getTemplateArgumentAsType",
+   [Type, c_uint],
    Type,
    Type.from_result),
 

--- a/plugin/popups/popups.py
+++ b/plugin/popups/popups.py
@@ -36,6 +36,84 @@ BODY_TEMPLATE = """### Body: ###
 """
 
 
+def log_location(location, name):
+    """Log info about a cindex.SourceLocation."""
+    if location is None:
+        log.debug("%s: none" % name)
+        return
+    log.debug("%s" % str(location))
+    file_name = "none"
+    if location.file and location.file.name:
+        file_name = location.file.name
+    log.debug("%s: file: %s" % (name, file_name))
+    log.debug("%s: line: %u" % (name, location.line))
+    log.debug("%s: col: %u" % (name, location.column))
+
+
+def log_type(clang_type, name):
+    """Log info about a cindex.Type."""
+    if clang_type is None:
+        log.debug("%s: none" % name)
+        return
+    log.debug("%s" % str(clang_type))
+    log.debug("%s.kind: %s" % (name, clang_type.kind))
+    log_location(Popup.location_from_type(clang_type), "%s.location" % name)
+    log.debug("%s.spelling: %s" % (name, clang_type.spelling or "none"))
+    num_template_arguments = clang_type.get_num_template_arguments()
+    log.debug("%s.get_num_template_arguments(): %i" % (
+        name, num_template_arguments))
+    if num_template_arguments != -1:
+        for arg_index in range(num_template_arguments):
+            templ_type = clang_type.get_template_argument_type(arg_index)
+            log.debug("%s.template_argument[%i].spelling: %s" % (
+                name, arg_index, templ_type.spelling))
+            log_location(Popup.location_from_type(templ_type),
+                         "%s.template_argument[%i].location" % (
+                         name, arg_index))
+    log.debug("%s.get_declaration().get_num_template_arguments(): %i" % (
+        name,
+        clang_type.get_declaration().get_num_template_arguments()))
+    log.debug("%s.get_declaration().spelling: %s" % (
+        name,
+        clang_type.get_declaration().spelling))
+
+
+def log_cursor(cursor, name):
+    """Log info about a cindex.Cursor."""
+    if cursor is None:
+        log.debug("%s: none" % name)
+        return
+    log.debug("%s.kind: %s" % (name, cursor.kind))
+    log.debug("%s.spelling: %s" % (name, cursor.spelling or "none"))
+    log.debug("%s.displayname: %s" % (name, cursor.displayname or "none"))
+    log.debug("%s.get_usr(): %s" % (name, cursor.get_usr() or "none"))
+    log.debug("%s.is_definition(): %s" % (name, cursor.is_definition()))
+    # I've never seen this 'num_template_args' be anything other than -1.
+    num_template_args = cursor.get_num_template_arguments()
+    log.debug("%s.get_num_template_arguments(): %i" % (name, num_template_args))
+    log_type(cursor.type, "%s.type" % name)
+    log_type(cursor.result_type, "%s.result_type" % name)
+    log_location(cursor.location, "%s.location" % name)
+    log.debug("%s.extent: %r" % (name, cursor.extent or "none"))
+
+
+def log_extent(extent, name):
+    """Log info about a cindex.SourceRange."""
+    if extent is None:
+        log.debug("%s: none" % name)
+        return
+    if extent and extent.start and extent.start.file:
+        log.debug("%s.start.file.name: %s" % (name, extent.start.file.name))
+        log.debug("%s.start.line: %i" % (name, extent.start.line))
+        log.debug("%s.end.file.name: %s" % (name, extent.end.file.name))
+        log.debug("%s.start.end.line: %i" % (name, extent.end.line))
+    else:
+        log.debug("%s.start.file.name: none" % name)
+        log.debug("%s.start.line: none" % name)
+        log.debug("%s.end.file.name: none" % name)
+        log.debug("%s.start.end.line: none" % name)
+
+
 class Popup:
     """Incapsulate popup creation."""
 

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -65,6 +65,7 @@ class SettingsStorage:
         "cmake_binary",
         "common_flags",
         "cpp_flags",
+        "expand_template_types",
         "flags_sources",
         "hide_default_completions",
         "include_file_folder",

--- a/tests/test_error_vis.py
+++ b/tests/test_error_vis.py
@@ -322,7 +322,7 @@ class TestErrorVis:
         self.maxDiff = None
         expected_info_msg = """!!! panel-info "ECC: Info"
     ## Declaration: ##
-    void [foo]({file}:5:8) ([Foo]({file}:1:7) a, [Foo *]({file}:1:7) b)
+    void [foo]({file}:5:8) ([Foo]({file}:1:7) a, [Foo]({file}:1:7) \\* b)
 """.format(file=file_name)
         # Make sure we remove trailing spaces on the right to comply with how
         # sublime text handles this.
@@ -754,6 +754,287 @@ class TestErrorVis:
     ## Declaration: ##
     -([MyCovariant&lt;Foo *&gt; *]({file}:3:12))[covariantMethod]({file}:4:22)
 """.format(file=file_name)
+        # Make sure we remove trailing spaces on the right to comply with how
+        # sublime text handles this.
+        actual_msg = cleanup_trailing_spaces(info_popup.as_markdown())
+        self.assertEqual(actual_msg, expected_info_msg)
+        # cleanup
+        self.tear_down_completer()
+        self.tear_down()
+
+    def test_template_instance_class_and_builtin_type_and_number_value(self):
+        """Test template instance with class, built-in types, and number types.
+
+        E.g. hover over 'instance' of 'TemplateClass<Foo, int, 123> instance;'
+        should link to Foo and properly display int and 123.
+        """
+        if not self.use_libclang:
+            # Ignore this test for binary completer.
+            return
+        file_name = path.join(path.dirname(__file__),
+                              'test_files',
+                              'test_templates.cpp')
+        self.set_up_view(file_name)
+        completer, settings = self.set_up_completer()
+        # Check the current cursor position is completable.
+        self.assertEqual(self.get_row(8),
+                         "  TemplateClass<Foo, int, 123> instanceClassTypeInt;")
+        pos = self.view.text_point(8, 32)
+        action_request = ActionRequest(self.view, pos)
+        request, info_popup = completer.info(action_request, settings)
+        self.maxDiff = None
+        fmt = '!!! panel-info "ECC: Info"\n'
+        fmt += '    ## Declaration: ##\n'
+        fmt += '    [TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7), int, '
+        fmt += '*ECC: unknown*&gt; [instanceClassTypeInt]({file}:9:32)\n'
+        expected_info_msg = fmt.format(file=file_name)
+
+        # Make sure we remove trailing spaces on the right to comply with how
+        # sublime text handles this.
+        actual_msg = cleanup_trailing_spaces(info_popup.as_markdown())
+        self.assertEqual(actual_msg, expected_info_msg)
+        # cleanup
+        self.tear_down_completer()
+        self.tear_down()
+
+    def test_template_instance_default_template_params(self):
+        """Test template instance with some template args left empty (default)
+
+        E.g. hover over 'instance' of 'TemplateClass<Foo, int> instance;'
+        where TemplateClass has an option 3rd template argument.
+        """
+        if not self.use_libclang:
+            # Ignore this test for binary completer.
+            return
+        file_name = path.join(path.dirname(__file__),
+                              'test_files',
+                              'test_templates.cpp')
+        self.set_up_view(file_name)
+        completer, settings = self.set_up_completer()
+        # Check the current cursor position is completable.
+        self.assertEqual(self.get_row(9),
+                         "  TemplateClass<Foo> instanceClassAndDefaults;")
+        pos = self.view.text_point(9, 22)
+        action_request = ActionRequest(self.view, pos)
+        request, info_popup = completer.info(action_request, settings)
+        self.maxDiff = None
+        fmt = '!!! panel-info "ECC: Info"\n'
+        fmt += '    ## Declaration: ##\n'
+        fmt += '    [TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7)&gt; '
+        fmt += '[instanceClassAndDefaults]({file}:10:22)\n'
+        expected_info_msg = fmt.format(file=file_name)
+
+        # Make sure we remove trailing spaces on the right to comply with how
+        # sublime text handles this.
+        actual_msg = cleanup_trailing_spaces(info_popup.as_markdown())
+        self.assertEqual(actual_msg, expected_info_msg)
+        # cleanup
+        self.tear_down_completer()
+        self.tear_down()
+
+    def test_template_instance_nested_template_parameters(self):
+        """Test instance with template arguments that are themselves templates
+
+        E.g. hover over 'instance' of the line:
+        'std::shared_ptr<std::vector<Foo>>> instance;'
+        """
+        if not self.use_libclang:
+            # Ignore this test for binary completer.
+            return
+        file_name = path.join(path.dirname(__file__),
+                              'test_files',
+                              'test_templates.cpp')
+        self.set_up_view(file_name)
+        completer, settings = self.set_up_completer()
+        # Check the current cursor position is completable.
+        self.assertEqual(self.get_row(10),
+                         "  TemplateClass<TemplateClass<Foo>> instanceNested;")
+        pos = self.view.text_point(10, 37)
+        action_request = ActionRequest(self.view, pos)
+        request, info_popup = completer.info(action_request, settings)
+        self.maxDiff = None
+        fmt = '!!! panel-info "ECC: Info"\n'
+        fmt += '    ## Declaration: ##\n'
+        fmt += '    [TemplateClass]({file}:3:7)&lt;[TemplateClass]({file}:3:7)'
+        fmt += '&lt;[Foo]({file}:1:7)&gt;&gt; [instanceNested]({file}:11:37)\n'
+        expected_info_msg = fmt.format(file=file_name)
+        # Make sure we remove trailing spaces on the right to comply with how
+        # sublime text handles this.
+        actual_msg = cleanup_trailing_spaces(info_popup.as_markdown())
+        self.assertEqual(actual_msg, expected_info_msg)
+        # cleanup
+        self.tear_down_completer()
+        self.tear_down()
+
+    def test_template_instance_pointer_to_class(self):
+        """Test instance with a pointer template argument.
+
+        E.g. hover over 'instance' of the line:
+        'TemplateClass<Foo*> instance;'
+        """
+        if not self.use_libclang:
+            # Ignore this test for binary completer.
+            return
+        file_name = path.join(path.dirname(__file__),
+                              'test_files',
+                              'test_templates.cpp')
+        self.set_up_view(file_name)
+        completer, settings = self.set_up_completer()
+        # Check the current cursor position is completable.
+        self.assertEqual(self.get_row(11),
+                         "  TemplateClass<Foo*> instancePointer;")
+        pos = self.view.text_point(11, 23)
+        action_request = ActionRequest(self.view, pos)
+        request, info_popup = completer.info(action_request, settings)
+        self.maxDiff = None
+        fmt = '!!! panel-info "ECC: Info"\n'
+        fmt += '    ## Declaration: ##\n'
+        fmt += '    [TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7) \\*&gt; '
+        fmt += '[instancePointer]({file}:12:23)\n'
+        expected_info_msg = fmt.format(file=file_name)
+        # Make sure we remove trailing spaces on the right to comply with how
+        # sublime text handles this.
+        actual_msg = cleanup_trailing_spaces(info_popup.as_markdown())
+        self.assertEqual(actual_msg, expected_info_msg)
+        # cleanup
+        self.tear_down_completer()
+        self.tear_down()
+
+    def test_template_instance_ref_to_class(self):
+        """Test instance with a reference template argument.
+
+        E.g. hover over 'instance' of the line:
+        'TemplateClass<Foo&> instance;'
+        """
+        if not self.use_libclang:
+            # Ignore this test for binary completer.
+            return
+        file_name = path.join(path.dirname(__file__),
+                              'test_files',
+                              'test_templates.cpp')
+        self.set_up_view(file_name)
+        completer, settings = self.set_up_completer()
+        # Check the current cursor position is completable.
+        self.assertEqual(self.get_row(12),
+                         "  TemplateClass<Foo&> instanceRef;")
+        pos = self.view.text_point(12, 23)
+        action_request = ActionRequest(self.view, pos)
+        request, info_popup = completer.info(action_request, settings)
+        fmt = '!!! panel-info "ECC: Info"\n'
+        fmt += '    ## Declaration: ##\n'
+        fmt += '    [TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7) &amp;&gt; '
+        fmt += '[instanceRef]({file}:13:23)\n'
+        expected_info_msg = fmt.format(file=file_name)
+        # Make sure we remove trailing spaces on the right to comply with how
+        # sublime text handles this.
+        actual_msg = cleanup_trailing_spaces(info_popup.as_markdown())
+        self.assertEqual(actual_msg, expected_info_msg)
+        # cleanup
+        self.tear_down_completer()
+        self.tear_down()
+
+    def test_template_instance_rvalueref_to_class(self):
+        """Test instance with an r-value reference template argument.
+
+        E.g. hover over 'instance' of the line:
+        'TemplateClass<Foo&&> instance;'
+        """
+        if not self.use_libclang:
+            # Ignore this test for binary completer.
+            return
+        file_name = path.join(path.dirname(__file__),
+                              'test_files',
+                              'test_templates.cpp')
+        self.set_up_view(file_name)
+        completer, settings = self.set_up_completer()
+        # Check the current cursor position is completable.
+        self.assertEqual(self.get_row(13),
+                         "  TemplateClass<Foo&&> instanceRValueRef;")
+        pos = self.view.text_point(13, 24)
+        action_request = ActionRequest(self.view, pos)
+        request, info_popup = completer.info(action_request, settings)
+        self.maxDiff = None
+        fmt = '!!! panel-info "ECC: Info"\n'
+        fmt += '    ## Declaration: ##\n'
+        fmt += '    [TemplateClass]({file}:3:7)&lt;[Foo &amp;&amp;]'
+        fmt += '({file}:1:7)&gt; [instanceRValueRef]({file}:14:24)\n'
+        expected_info_msg = fmt.format(file=file_name)
+        # Make sure we remove trailing spaces on the right to comply with how
+        # sublime text handles this.
+        actual_msg = cleanup_trailing_spaces(info_popup.as_markdown())
+        self.assertEqual(actual_msg, expected_info_msg)
+        # cleanup
+        self.tear_down_completer()
+        self.tear_down()
+
+    def test_template_instance_declaration(self):
+        """Hovering over the template type in a variable declaration.
+
+        E.g. hovering over 'TemplateClass<Foo>' of the line
+        'TemplateClass<Foo> instance;'
+        """
+        if not self.use_libclang:
+            # Ignore this test for binary completer.
+            return
+        file_name = path.join(path.dirname(__file__),
+                              'test_files',
+                              'test_templates.cpp')
+        self.set_up_view(file_name)
+        completer, settings = self.set_up_completer()
+        # Check the current cursor position is completable.
+        self.assertEqual(self.get_row(8),
+                         "  TemplateClass<Foo, int, 123> instanceClassTypeInt;")
+        pos = self.view.text_point(8, 3)
+        action_request = ActionRequest(self.view, pos)
+        request, info_popup = completer.info(action_request, settings)
+        self.maxDiff = None
+        expected_info_msg = """!!! panel-info "ECC: Info"
+    ## Declaration: ##
+    [TemplateClass]({file}:3:7)
+    ### Body: ###
+    ```c++
+    template <class TClass=Foo, typename TType=int, int TInt=12>
+    class TemplateClass
+    {{
+    public:
+      void foo(TemplateClass<TClass, TType, TInt>);
+    }};
+
+    ```
+""".format(file=file_name)
+        # Make sure we remove trailing spaces on the right to comply with how
+        # sublime text handles this.
+        actual_msg = cleanup_trailing_spaces(info_popup.as_markdown())
+        self.assertEqual(actual_msg, expected_info_msg)
+        # cleanup
+        self.tear_down_completer()
+        self.tear_down()
+
+    def test_method_with_template_argument(self):
+        """Hovering over method with argument that is a template type.
+
+        E.g. hovering over 'void foo(TemplateClass<Bar> arg)'
+        """
+        if not self.use_libclang:
+            # Ignore this test for binary completer.
+            return
+        file_name = path.join(path.dirname(__file__),
+                              'test_files',
+                              'test_templates.cpp')
+        self.set_up_view(file_name)
+        completer, settings = self.set_up_completer()
+        # Check the current cursor position is completable.
+        self.assertEqual(self.get_row(14),
+                         "  instanceRValueRef.foo(instanceRValueRef);")
+        pos = self.view.text_point(14, 21)
+        action_request = ActionRequest(self.view, pos)
+        request, info_popup = completer.info(action_request, settings)
+        self.maxDiff = None
+        fmt = '!!! panel-info "ECC: Info"\n'
+        fmt += '    ## Declaration: ##\n'
+        fmt += '    void [foo]({file}:6:8) ([TemplateClass]({file}:3:7)&lt;Foo '
+        fmt += '&amp;&amp;, int, *ECC: unknown*&gt;)\n'
+        expected_info_msg = fmt.format(file=file_name)
         # Make sure we remove trailing spaces on the right to comply with how
         # sublime text handles this.
         actual_msg = cleanup_trailing_spaces(info_popup.as_markdown())

--- a/tests/test_files/testTemplatesManual.cpp
+++ b/tests/test_files/testTemplatesManual.cpp
@@ -1,0 +1,83 @@
+/// File using several C++ libraries with templated types,
+/// useful for manual testing of popup info by hovering over code.
+/// Not added to auto-testing because popups include
+/// libC++ implementation details that can change without warning,
+/// making it difficult to test for correct info in the popups.
+#include <algorithm>
+#include <array>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+class A {
+  int a;
+  void foo(int a);
+public:
+  void foo(double a);
+
+  template<int BarTemplateParameter>
+  int bar() { return BarTemplateParameter;}
+
+  template<class One, class Two, class Three>
+  void barTemp3();
+
+  template<int M>
+  int barM(std::shared_ptr<A> a, const std::shared_ptr<A>& aConst) { return M;}
+
+  std::shared_ptr<A>& barNoTempl(
+    std::shared_ptr<A> sharedPtr,
+    const std::shared_ptr<A>& constRefToSharedPtr,
+    std::shared_ptr<A>&& rValueRefToSharedPtr);
+};
+
+
+template <typename TempArg>
+class Templated {
+};
+
+template <typename TempArg1, typename TempArg2>
+class TemplatedTwo {
+};
+
+int main(int argc, char const *argv[]) {
+  std::shared_ptr<A> pointerToA;
+  pointerToA.reset();
+  pointerToA->bar<5>();
+  pointerToA->barTemp3<A, A, A>();
+  pointerToA->barM<5>(pointerToA, pointerToA);
+  pointerToA.reset(pointerToA.get());
+  std::pair<std::shared_ptr<A>, std::string> myPair;
+  myPair.first = nullptr;
+
+  A justA;
+  A& refA = justA;
+  A* ptrA;
+  A*& ptrRefA = ptrA;
+  A&& rvalueRefA = std::move(justA);
+  Templated<int> templatedInt;
+  Templated<A> templatedA;
+  Templated<A&&> templatedOnARvalueRef;
+  Templated<std::shared_ptr<const A&&>*>* templatedSharedPtrARvalueRef;
+  Templated<A>&& templatedARValueRef = std::move(templatedA);
+  Templated<A*> templatedAPtr;
+  Templated<A*>& templatedAPtrRef = templatedAPtr;
+  Templated<std::shared_ptr<A*>> templatedSharedPtrAPtr;
+  Templated<const std::shared_ptr<A*>> templatedConstSharedPtrAPtr;
+  Templated<const std::shared_ptr<A>*>* templatedConstSharedPtrAPtrPtr;
+  Templated<std::shared_ptr<A>> templatedSharedPtrA;
+  Templated<std::shared_ptr<const A>> templatedSharedPtrConstA;
+  Templated<const std::shared_ptr<const A>> templatedConstSharedPtrConstA;
+
+  TemplatedTwo<A, A> templatedTwoAA;
+  TemplatedTwo<std::shared_ptr<const A>, const std::shared_ptr<A>*> templatedTwoSharedConstA_ConstSharedPtrPointer;
+  A a;
+  a.foo(2.0);
+
+  std::array<A, 5> arraySize5;
+
+  auto lambda = [](std::shared_ptr<A> a) {
+    return a;
+  };
+  lambda(pointerToA);
+  return 0;
+}

--- a/tests/test_files/test_templates.cpp
+++ b/tests/test_files/test_templates.cpp
@@ -1,0 +1,17 @@
+class Foo;
+template <class TClass=Foo, typename TType=int, int TInt=12>
+class TemplateClass
+{
+public:
+  void foo(TemplateClass<TClass, TType, TInt>);
+};
+int main(int argc, char const *argv[]) {
+  TemplateClass<Foo, int, 123> instanceClassTypeInt;
+  TemplateClass<Foo> instanceClassAndDefaults;
+  TemplateClass<TemplateClass<Foo>> instanceNested;
+  TemplateClass<Foo*> instancePointer;
+  TemplateClass<Foo&> instanceRef;
+  TemplateClass<Foo&&> instanceRValueRef;
+  instanceRValueRef.foo(instanceRValueRef);
+  return 0;
+}


### PR DESCRIPTION
Before, hovering over instances of template classes only included a hyperlink to the template class, but not the template parameters. This was especially annoying with smart pointers and containers, where the template class itself is not very interesting, but I do care about following links to the template parameter. For example, only a link to `std::shared_ptr` would be created:
![image](https://user-images.githubusercontent.com/20820660/44612062-dd219c80-a7ca-11e8-9502-a66595c4f80c.png)

After this PR, we also create hyperlinks to each template parameter's type, e.g. we show links to both `std::shared_ptr` and `class A`:
![image](https://user-images.githubusercontent.com/20820660/44612013-81efaa00-a7ca-11e8-8c63-26f697323b0d.png)

This works with nested templates:
![image](https://user-images.githubusercontent.com/20820660/44612043-b5323900-a7ca-11e8-86b8-b77712c0d908.png)

And with pointer/reference types and const qualifiers:
![image](https://user-images.githubusercontent.com/20820660/44612136-87012900-a7cb-11e8-9020-303afeb39b86.png)

Unfortunately, there is one small regression I've discovered with integer literals used as template parameters, because the integer literal's value is not easily and independently available in the libclang API. For now, I've opted to just show an 'unknown' message.
![image](https://user-images.githubusercontent.com/20820660/44612054-c418eb80-a7ca-11e8-96cb-1d838e538cf6.png)
With more effort and a little bit of parsing, we could get this use case to work, but I'm not sure this is a common or useful-enough case to spend the effort on, and am looking for some guidance from @niosus. For reference, here's what the pop-up would have looked like before this PR (we see the '5' in the popup, but there's no link to `class A`.:
![image](https://user-images.githubusercontent.com/20820660/44612070-e6ab0480-a7ca-11e8-9458-b1d2a14a3f36.png)

Also unfortunately, this requires some non-standard modifications to cindex files to expose two functions in libclang's publicly-supported C API. For some reason, these are not yet exposed to python, but I can put together a patch to add these methods to cindex.py in the llvm project.

I have tested this on macOS using cindex40.py.
