### PR TITLE
Command to show info popup for select symbol

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -21,4 +21,8 @@
         "caption": "EasyClangComplete: Clean current CMake cache",
         "command": "clean_cmake"
     },
+    {
+        "caption": "EasyClangComplete: Show popup info",
+        "command": "ecc_show_popup_info"
+    },
 ]

--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -167,6 +167,15 @@ class CleanCmakeCommand(sublime_plugin.TextCommand):
             log.debug("Nothing to clean")
 
 
+class EccShowPopupInfoCommand(sublime_plugin.TextCommand):
+    """Command that shows popup info on current cursor location."""
+
+    def run(self, edit):
+        """Run show popup info command."""
+        position = self.view.sel()[0].begin()
+        EasyClangComplete.begin_show_info_job(self.view, position)
+
+
 class EasyClangComplete(sublime_plugin.EventListener):
     """Base class for this plugin.
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ pallet. Open it by pressing:
 All the commands of this plugin start with `EasyClangComplete:` and should be
 self explanatory. Open an issue if they are not.
 
+### Key Bindings ###
+EasyClangComplete provides several default key bindings listed
+[here](Default.sublime-keymap). Modify or create your own bindings by editing
+your Sublime Key Binding preferences to run a command listed
+in [this file](Default.sublime-commands). For example, to show a popup with info
+about the currently selected symbol, add this to your key bindings:
+
+`{ "keys": ["ctrl+i"], "command": "ecc_show_popup_info" },`
+
 ## Settings ##
 
 Please see the default settings [file](EasyClangComplete.sublime-settings)


### PR DESCRIPTION
Add command to show popup info for selected symbol

Closes #326. Adds "EasyClangComplete: Show popup info" to the command menu.

By default, does not set any key bindings. Users may edit their key binding preferences to use the new command named "ecc_show_popup_info", for example:
` { "keys": ["ctrl+i"], "command": "ecc_show_popup_info" },`

The implementation refactors the EasyClangComplete class to use only class variables and staticmethod's to show popup info, then adds the new command class that invokes the class methods.