### PR TITLE
Remove default keybinding for showing all errors

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,4 +1,3 @@
 [
   { "keys": ["shift+f12"], "command": "ecc_goto_declaration"},
-  { "keys": ["ctrl+shift+e"], "command": "ecc_show_all_errors"}
 ]


### PR DESCRIPTION
It seems to clash with some other keybinding on macOS, so I removed it
completely here. Close #434

