### PR TITLE
Make valid syntax configurable

### DIFF
--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -68,9 +68,9 @@
   // your file of interest. The values here are good defaults, but feel free to
   // customize the list to your liking. The languages
   "valid_syntaxes": [
-    {"lang": "C", "syntaxes": ["C", "C Improved", "C99"]},
-    {"lang": "CPP", "syntaxes": ["C++", "C++11"]},
-    {"lang": "OBJECTIVE_C", "syntaxes": ["Objective-C"]},
+    {"lang": "C",             "syntaxes": ["C", "C Improved", "C99"]},
+    {"lang": "CPP",           "syntaxes": ["C++", "C++11"]},
+    {"lang": "OBJECTIVE_C",   "syntaxes": ["Objective-C"]},
     {"lang": "OBJECTIVE_CPP", "syntaxes": ["Objective-CPP"]},
   ],
 

--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -64,16 +64,15 @@
   // Triggers for auto-completion
   "triggers" : [ ".", "->", "::", " ", "	", "(", "[" ],
 
-  // A structure that defines all syntaxes that the plugin will process. Use the
-  // same names as shown in the bottom right corner of Sublime Text when opening
-  // your file of interest. The values here are good defaults, but feel free to
+  // A dictionary that defines a mapping from language to an array of valid
+  // syntaxes for it. The values here are good defaults, but feel free to
   // customize the list to your liking. When modifying this setting make sure
   // that all 4 languages have values.
   "valid_lang_syntaxes": {
     "C":              ["C", "C Improved", "C99"],
     "CPP":            ["C++", "C++11"],
     "OBJECTIVE_C":    ["Objective-C"],
-    "OBJECTIVE_CPP":  ["Objective-CPP"]
+    "OBJECTIVE_CPP":  ["Objective-C++"]
   },
 
   // Use libclang.

--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -22,14 +22,15 @@
     // this is needed to include the correct headers for clang
     "-I/usr/lib/clang/$clang_version/include",
   ],
-  // C specific flags. Prepend common_flags for C files.
-  "c_flags" : [ "-std=c11" ],
-  // C++ specific flags. Prepend common_flags for C++ files.
-  "cpp_flags" : [ "-std=c++11" ],
-  // Objective-C specific flags. Prepend common_flags for Objective-C files.
-  "objective_c_flags" : [ "-std=c11" ],
-  // Objective-C++ specific flags. Prepend common_flags for Objective-C++ files.
-  "objective_cpp_flags" : [ "-std=c++11" ],
+
+  // Language-specific flags. Prepend common_flags for files of given language.
+  // When adapting to your needs, make sure to keep all language keys.
+  "lang_flags": {
+    "C": ["-std=c11"],
+    "CPP": ["-std=c++11"],
+    "OBJECTIVE_C": ["-std=c11"],
+    "OBJECTIVE_CPP": ["-std=c++11"],
+  },
 
   // Define how we search needed flags. Prioritized from top to bottom.
   // Possible entries for "file":
@@ -66,13 +67,14 @@
   // A structure that defines all syntaxes that the plugin will process. Use the
   // same names as shown in the bottom right corner of Sublime Text when opening
   // your file of interest. The values here are good defaults, but feel free to
-  // customize the list to your liking. The languages
-  "valid_syntaxes": [
-    {"lang": "C",             "syntaxes": ["C", "C Improved", "C99"]},
-    {"lang": "CPP",           "syntaxes": ["C++", "C++11"]},
-    {"lang": "OBJECTIVE_C",   "syntaxes": ["Objective-C"]},
-    {"lang": "OBJECTIVE_CPP", "syntaxes": ["Objective-CPP"]},
-  ],
+  // customize the list to your liking. When modifying this setting make sure
+  // that all 4 languages have values.
+  "valid_lang_syntaxes": {
+    "C":              ["C", "C Improved", "C99"],
+    "CPP":            ["C++", "C++11"],
+    "OBJECTIVE_C":    ["Objective-C"],
+    "OBJECTIVE_CPP":  ["Objective-CPP"]
+  },
 
   // Use libclang.
   // If set to false will use clang_binary and parse the output of

--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -60,8 +60,19 @@
   // Possible styles: "color", "mono", "none"
   "gutter_style": "color",
 
-  // triggers for auto-completion
+  // Triggers for auto-completion
   "triggers" : [ ".", "->", "::", " ", "	", "(", "[" ],
+
+  // A structure that defines all syntaxes that the plugin will process. Use the
+  // same names as shown in the bottom right corner of Sublime Text when opening
+  // your file of interest. The values here are good defaults, but feel free to
+  // customize the list to your liking. The languages
+  "valid_syntaxes": [
+    {"lang": "C", "syntaxes": ["C", "C Improved", "C99"]},
+    {"lang": "CPP", "syntaxes": ["C++", "C++11"]},
+    {"lang": "OBJECTIVE_C", "syntaxes": ["Objective-C"]},
+    {"lang": "OBJECTIVE_CPP", "syntaxes": ["Objective-CPP"]},
+  ],
 
   // Use libclang.
   // If set to false will use clang_binary and parse the output of

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -60,36 +60,33 @@ class SettingsStorage:
     # refer to Preferences.sublime-settings for usage explanation
     NAMES_ENUM = [
         "autocomplete_all",
-        "c_flags",
         "clang_binary",
         "cmake_binary",
         "common_flags",
-        "cpp_flags",
         "expand_template_types",
         "flags_sources",
+        "gutter_style",
+        "header_to_source_mapping",
         "hide_default_completions",
         "include_file_folder",
         "include_file_parent_folder",
+        "lang_flags",
         "libclang_path",
-        "gutter_style",
         "max_cache_age",
-        "objective_c_flags",
-        "objective_cpp_flags",
         "progress_style",
-        "show_type_info",
         "show_errors",
         "show_type_body",
-        "triggers",
-        "valid_syntaxes",
-        "use_libclang",
-        "use_libclang_caching",
-        "verbose",
-        "header_to_source_mapping",
-        "use_target_compiler_built_in_flags",
+        "show_type_info",
         "target_c_compiler",
         "target_cpp_compiler",
         "target_objective_c_compiler",
         "target_objective_cpp_compiler",
+        "triggers",
+        "use_libclang",
+        "use_libclang_caching",
+        "use_target_compiler_built_in_flags",
+        "valid_lang_syntaxes",
+        "verbose",
     ]
 
     def __init__(self, settings_handle):
@@ -189,16 +186,15 @@ class SettingsStorage:
                 error_msg = "flag source '{}' is not one of {}".format(
                     source_dict["file"], SettingsStorage.FLAG_SOURCES)
                 return False, error_msg
-        for syntax_dict in self.valid_syntaxes:
-            if Tools.LANG_TAG not in syntax_dict \
-                    or Tools.SYNTAXES_TAG not in syntax_dict:
-                error_msg = "No '{}' or '{}' setting in syntaxes '{}'".format(
-                    Tools.LANG_TAG, Tools.SYNTAXES_TAG, syntax_dict)
+        # Check if all languages are present in language-specific settings.
+        for lang_tag in Tools.LANG_TAGS:
+            if lang_tag not in self.lang_flags.keys():
+                error_msg = "lang '{}' is not in {}".format(
+                    lang_tag, self.lang_flags)
                 return False, error_msg
-            if syntax_dict[Tools.LANG_TAG] not in Tools.LANG_TAGS:
-                error_msg = "lang '{}' is not one of {}".format(
-                    syntax_dict[Tools.LANG_TAG],
-                    Tools.LANG_TAGS)
+            if lang_tag not in self.valid_lang_syntaxes:
+                error_msg = "No '{}' in syntaxes '{}'".format(
+                    lang_tag, self.valid_lang_syntaxes)
                 return False, error_msg
         return True, ""
 

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -80,6 +80,7 @@ class SettingsStorage:
         "show_errors",
         "show_type_body",
         "triggers",
+        "valid_syntaxes",
         "use_libclang",
         "use_libclang_caching",
         "verbose",
@@ -188,11 +189,22 @@ class SettingsStorage:
                 error_msg = "flag source '{}' is not one of {}".format(
                     source_dict["file"], SettingsStorage.FLAG_SOURCES)
                 return False, error_msg
+        for syntax_dict in self.valid_syntaxes:
+            if Tools.LANG_TAG not in syntax_dict \
+                    or Tools.SYNTAXES_TAG not in syntax_dict:
+                error_msg = "No '{}' or '{}' setting in syntaxes '{}'".format(
+                    Tools.LANG_TAG, Tools.SYNTAXES_TAG, syntax_dict)
+                return False, error_msg
+            if syntax_dict[Tools.LANG_TAG] not in Tools.LANG_TAGS:
+                error_msg = "lang '{}' is not one of {}".format(
+                    syntax_dict[Tools.LANG_TAG],
+                    Tools.LANG_TAGS)
+                return False, error_msg
         return True, ""
 
     @property
     def target_compilers(self):
-        """A dictionary with the target compilers to use."""
+        """Create a dictionary with the target compilers to use."""
         result = dict()
         if hasattr(self, "target_c_compiler"):
             result["c"] = self.target_c_compiler

--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -426,21 +426,20 @@ class Tools:
             This guarantees that sublime text will show default completions.
         syntax_regex (regex): regex to parse syntax setting
         valid_extensions (list): list of valid extensions for auto-completion
-        valid_syntax (list): list of valid syntaxes for this plugin
 
     """
 
     syntax_regex = re.compile(r"\/([^\/]+)\.(?:tmLanguage|sublime-syntax)")
 
-    valid_extensions = [".c", ".cc", ".cpp", ".cxx", ".h", ".hpp", ".hxx",
-                        ".m", ".mm"]
+    LANG_TAG = "lang"
+    SYNTAXES_TAG = "syntaxes"
 
-    C_SYNTAX = ["C", "C Improved", "C99"]
-    CPP_SYNTAX = ["C++", "C++11", "C++ (Colorcoded)", "cuda-c++", "deviot"]
-    OBJECTIVE_C_SYNTAX = ["Objective-C"]
-    OBJECTIVE_CPP_SYNTAX = ["Objective-C++"]
-    valid_syntax = C_SYNTAX + CPP_SYNTAX \
-        + OBJECTIVE_C_SYNTAX + OBJECTIVE_CPP_SYNTAX
+    LANG_C_TAG = "C"
+    LANG_CPP_TAG = "CPP"
+    LANG_OBJECTIVE_C_TAG = "OBJECTIVE_C"
+    LANG_OBJECTIVE_CPP_TAG = "OBJECTIVE_CPP"
+    LANG_TAGS = [LANG_C_TAG, LANG_CPP_TAG,
+                 LANG_OBJECTIVE_C_TAG, LANG_OBJECTIVE_CPP_TAG]
 
     SHOW_DEFAULT_COMPLETIONS = None
     HIDE_DEFAULT_COMPLETIONS = ([], sublime.INHIBIT_WORD_COMPLETIONS |
@@ -482,24 +481,21 @@ class Tools:
         return tempdir
 
     @staticmethod
-    def get_view_lang(view):
+    def get_view_lang(view, settings_storage):
         """Get language from view description.
 
         Args:
             view (sublime.View): Current view
+            settings_storage (SettingsStorage): ECC settings for the view
 
         Returns:
-            str: language, "C", "C++", "Objective-C", or "Objective-C++""
+            str: language, one of LANG_TAGS or None if nothing matched
         """
         syntax = Tools.get_view_syntax(view)
-        if syntax in Tools.C_SYNTAX:
-            return "C"
-        if syntax in Tools.CPP_SYNTAX:
-            return "C++"
-        if syntax in Tools.OBJECTIVE_C_SYNTAX:
-            return "Objective-C"
-        if syntax in Tools.OBJECTIVE_CPP_SYNTAX:
-            return "Objective-C++"
+        for syntax_dict in settings_storage.valid_syntaxes:
+            if syntax in syntax_dict[Tools.SYNTAXES_TAG]:
+                return syntax_dict[Tools.LANG_TAG]
+        log.error("Cannot recognize language from syntax: '%s'", syntax)
         return None
 
     @staticmethod
@@ -524,19 +520,22 @@ class Tools:
         return None
 
     @staticmethod
-    def has_valid_syntax(view):
+    def has_valid_syntax(view, settings_storage):
         """Check if syntax is valid for this plugin.
 
         Args:
             view (sublime.View): current view
+            settings_storage (SettingsStorage): ECC settings for this view
 
         Returns:
             bool: True if valid, False otherwise
         """
-        syntax = Tools.get_view_syntax(view)
-        if syntax in Tools.valid_syntax:
-            return True
-        return False
+        lang = Tools.get_view_lang(view, settings_storage)
+        if not lang:
+            # We could not determine the language from syntax. Means the syntax
+            # is not valid for us.
+            return False
+        return True
 
     @staticmethod
     def is_valid_view(view):
@@ -554,10 +553,6 @@ class Tools:
         if not view.file_name():
             log.debug("view file_name is None")
             return False
-        if not Tools.has_valid_syntax(view):
-            log.debug("view has wrong syntax: %s",
-                      Tools.get_view_syntax(view))
-            return False
         if view.is_scratch():
             log.debug("view is scratch view")
             return False
@@ -568,23 +563,6 @@ class Tools:
             log.debug("view file_name does not exist in system")
             return False
         return True
-
-    @staticmethod
-    def has_valid_extension(view):
-        """Test if the current file has a valid extension.
-
-        Args:
-            view (sublime.View): current view
-
-        Returns:
-            bool: extension is valid
-        """
-        if not view or not view.file_name():
-            return False
-        (_, ext) = path.splitext(view.file_name())
-        if ext in Tools.valid_extensions:
-            return True
-        return False
 
     @staticmethod
     def seconds_from_string(time_str):

--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -492,9 +492,9 @@ class Tools:
             str: language, one of LANG_TAGS or None if nothing matched
         """
         syntax = Tools.get_view_syntax(view)
-        for syntax_dict in settings_storage.valid_syntaxes:
-            if syntax in syntax_dict[Tools.SYNTAXES_TAG]:
-                return syntax_dict[Tools.LANG_TAG]
+        for lang, syntaxes in settings_storage.valid_lang_syntaxes.items():
+            if syntax in syntaxes:
+                return lang
         log.error("Cannot recognize language from syntax: '%s'", syntax)
         return None
 

--- a/plugin/view_config.py
+++ b/plugin/view_config.py
@@ -364,16 +364,15 @@ class ViewConfig(object):
         lang_args = list()
         if current_lang == Tools.LANG_OBJECTIVE_C_TAG:
             target_lang = "objective-c"
-            lang_args = settings.objective_c_flags
         elif current_lang == Tools.LANG_OBJECTIVE_CPP_TAG:
             target_lang = "objective-c++"
-            lang_args = settings.objective_cpp_flags
         elif current_lang == Tools.LANG_C_TAG:
             target_lang = "c"
-            lang_args = settings.c_flags
-        else:
+        elif current_lang == Tools.LANG_CPP_TAG:
             target_lang = "c++"
-            lang_args = settings.cpp_flags
+        else:
+            log.error("unrecognized language '%s'!", target_lang)
+        lang_args = settings.lang_flags[current_lang]
         if need_lang_flags:
             lang_flags += ["-x", target_lang]
         lang_flags += lang_args

--- a/plugin/view_config.py
+++ b/plugin/view_config.py
@@ -357,18 +357,18 @@ class ViewConfig(object):
             Flag[]: A list of language-specific flags.
         """
         from .utils.compiler_builtins import CompilerBuiltIns
-        current_lang = Tools.get_view_lang(view)
+        current_lang = Tools.get_view_lang(view, settings)
         lang_flags = []
         target_compilers = settings.target_compilers
         target_lang = None
         lang_args = list()
-        if current_lang == "Objective-C":
+        if current_lang == Tools.LANG_OBJECTIVE_C_TAG:
             target_lang = "objective-c"
             lang_args = settings.objective_c_flags
-        elif current_lang == "Objective-C++":
+        elif current_lang == Tools.LANG_OBJECTIVE_CPP_TAG:
             target_lang = "objective-c++"
             lang_args = settings.objective_cpp_flags
-        elif current_lang == 'C':
+        elif current_lang == Tools.LANG_C_TAG:
             target_lang = "c"
             lang_args = settings.c_flags
         else:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -30,7 +30,7 @@ class test_settings(GuiTestWrapper):
         self.assertIsNotNone(settings.clang_binary)
         self.assertIsNotNone(settings.flags_sources)
         self.assertIsNotNone(settings.show_errors)
-        self.assertIsNotNone(settings.valid_syntaxes)
+        self.assertIsNotNone(settings.valid_lang_syntaxes)
 
     def test_valid(self):
         """Test validity."""

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -30,6 +30,7 @@ class test_settings(GuiTestWrapper):
         self.assertIsNotNone(settings.clang_binary)
         self.assertIsNotNone(settings.flags_sources)
         self.assertIsNotNone(settings.show_errors)
+        self.assertIsNotNone(settings.valid_syntaxes)
 
     def test_valid(self):
         """Test validity."""


### PR DESCRIPTION
Close issue #432. This enables setting custom syntax to enable the plugin for
it. The downside is that now whenever we open a new view we have to load the
user settings which can take some minor time, but in practice, it seems nearly
imperceptible.

This commit removes default syntaxes: "C++ (Colorcoded)", "cuda-c++", "deviot"


