### PR TITLE
Readd environment variable expansion for flags

### DIFF
--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -305,7 +305,8 @@ class SettingsStorage:
         Returns:
             str: line with replaced wildcards
         """
-        res = sublime.expand_variables(line, self._wildcard_values)
+        res = path.expandvars(line)
+        res = sublime.expand_variables(res, self._wildcard_values)
         if Wildcards.HOME_PATH in res:
             # replace '~' by full home path. Leave everything else intact.
             prefix_idx = res.index(Wildcards.HOME_PATH)


### PR DESCRIPTION
# System info: #
- Sublime Text version: Version 3.1.1, Build 3176
- Which system are you on: Windows 10
- Clang version: 6.0.1

# What happens:  #

I have set an environment variable on Windows that points to the directory of the Visual Studio C++ tool set (`C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Tools\MSVC\14.15.26726`). I want to use this environment variable in my include paths, but it doesn't get expanded. This issue was previously discussed in #128 and resolved in commit 712881d. However in the current release, this feature has been removed. Originally, it was implemented in `settings_storage.py` in the method `__replace_wildcard_if_needed`. The implementation now looks much different and the necessary line `res = path.expandvars(line)` is gone so I readded this line and it seems to work again.


<details>
<summary>Log that illustrates the issue: </summary>
  
```
[ECC:DEBUG]:[settings_storage.py]:[__replace_wildcard_if_needed]:[Dummy-5]: populated '-cxx-isystem${VS_MSVC_PATH}\atlmfc\include' to '-cxx-isystem\atlmfc\include'
```

</details>


