### PR TITLE
Update error message of unrecognized syntax

### DIFF
--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -495,7 +495,7 @@ class Tools:
         for lang, syntaxes in settings_storage.valid_lang_syntaxes.items():
             if syntax in syntaxes:
                 return lang
-        log.error("Cannot recognize language from syntax: '%s'", syntax)
+        log.debug("ECC does nothing for language syntax: '%s'", syntax)
         return None
 
     @staticmethod


### PR DESCRIPTION
This PR just changes one single message from annoying error message to a debug message if we detected a syntax that we should not process. 

As discussed in #501 with @kgizdov I have looked a bit into the feasability of adding some cache for valid syntax but have decided against it, so this PR also will close #501 

My reasoning for not implementing cache:
- current pipeline is actually fast enough to be imperceptible to the user:
  + we get current `settings_storage` object for the active view. This object must be generated upon opening the view for the first time. Whenever we click or modify this view we still do the same, but get the valid object from the settings cache now.
  + getting `settings_storage` object from cache and checking the view validity takes approx. 0.0007 seconds on my 3-yeal old i5 ultrabook. I think this is fast enough to be honest.
- the cache that was proposed in #501 makes only partial sense:
  + we still need to load settings whenever we open a view as we don't know which project it is in, so the settings can be different from the previous view.
  + the only cache we can implement is the one that populates syntax upon loading the view. The issue here is that this is another point that is completely not encapsulated and I (and whoever will maintain this in the future) will have to remember about it. This new cache needs to be additionally invalidated upon settings reload and has to be stored on a per-view basis. I'd rather stick with settings encapsulated into a `settings_storage` object and have a single cache for settings as it is implemented now. Especially considering that the current solution is plenty fast.
