### PR TITLE
 Added a setting for popup maximum dimensions in pixels

### DIFF
--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -61,6 +61,10 @@
   // Possible styles: "color", "mono", "dot", "none"
   "gutter_style": "color",
 
+  // Maximum width and height for popups eg. declaration info.
+  "popup_maximum_width": 1800,
+  "popup_maximum_height": 800,
+
   // Triggers for auto-completion
   "triggers" : [ ".", "->", "::", " ", "	", "(", "[" ],
 

--- a/plugin/error_vis/popup_error_vis.py
+++ b/plugin/error_vis/popup_error_vis.py
@@ -27,12 +27,15 @@ class PopupErrorVis:
     _ERROR_FLAGS = sublime.DRAW_EMPTY | sublime.DRAW_NO_FILL
     _ERROR_SCOPE = "invalid.illegal"
 
-    def __init__(self, gutter_style=None):
+    def __init__(self, settings):
         """Initialize error visualization.
 
         Args:
             mark_gutter (bool): add a mark to the gutter for error regions
         """
+        gutter_style = settings.gutter_style
+        self.settings = settings
+
         self.err_regions = {}
         if gutter_style == SettingsStorage.GUTTER_COLOR_STYLE:
             self.gutter_mark = PATH_TO_ICON.format(icon="error_color.png")
@@ -141,9 +144,9 @@ class PopupErrorVis:
             max_severity, error_list = PopupErrorVis._as_msg_list(errors_dict)
             text_to_show = Tools.to_md(error_list)
             if max_severity > 2:
-                popup = Popup.error(text_to_show)
+                popup = Popup.error(text_to_show, self.settings)
             else:
-                popup = Popup.warning(text_to_show)
+                popup = Popup.warning(text_to_show, self.settings)
             popup.show(view)
         else:
             log.debug("no error regions for row: %s", row)

--- a/plugin/popups/popups.py
+++ b/plugin/popups/popups.py
@@ -11,7 +11,11 @@ POPUP_CSS_FILE = "Packages/EasyClangComplete/plugin/popups/popup.css"
 
 log = logging.getLogger("ECC")
 
-MD_TEMPLATE = """!!! {type}
+MD_TEMPLATE = """\
+---
+allow_code_wrap: true
+---
+!!! {type}
     {contents}
 """
 

--- a/plugin/popups/popups.py
+++ b/plugin/popups/popups.py
@@ -133,7 +133,9 @@ class Popup:
     @staticmethod
     def error(text, settings):
         """Initialize a new error popup."""
-        popup = Popup((settings.popup_maximum_width, settings.popup_maximum_height))
+        popup = Popup((
+            settings.popup_maximum_width, settings.popup_maximum_height
+        ))
         popup.__popup_type = 'panel-error "ECC: Error"'
         popup.__text = markupsafe.escape(text)
         return popup
@@ -141,7 +143,9 @@ class Popup:
     @staticmethod
     def warning(text, settings):
         """Initialize a new warning popup."""
-        popup = Popup((settings.popup_maximum_width, settings.popup_maximum_height))
+        popup = Popup((
+            settings.popup_maximum_width, settings.popup_maximum_height
+        ))
         popup.__popup_type = 'panel-warning "ECC: Warning"'
         popup.__text = markupsafe.escape(text)
         return popup
@@ -212,7 +216,9 @@ class Popup:
     @staticmethod
     def info(cursor, cindex, settings):
         """Initialize a new warning popup."""
-        popup = Popup((settings.popup_maximum_width, settings.popup_maximum_height))
+        popup = Popup((
+            settings.popup_maximum_width, settings.popup_maximum_height
+        ))
         popup.__popup_type = 'panel-info "ECC: Info"'
         is_type_decl = cursor.kind in [
             cindex.CursorKind.STRUCT_DECL,
@@ -451,7 +457,9 @@ class Popup:
 
     def info_objc(cursor, cindex, settings):
         """Provide information about Objective C cursors."""
-        popup = Popup((settings.popup_maximum_width, settings.popup_maximum_height))
+        popup = Popup((
+            settings.popup_maximum_width, settings.popup_maximum_height
+        ))
         popup.__popup_type = 'panel-info "ECC: Info"'
         is_message = cursor.kind in [
             cindex.CursorKind.OBJC_MESSAGE_EXPR,

--- a/plugin/popups/popups.py
+++ b/plugin/popups/popups.py
@@ -124,9 +124,10 @@ class Popup:
     WRAPPER_CLASS = "ECC"
 
     def __init__(self, max_dimensions):
-        """ Initialize basic needs. 'max_dimensions' is a tuple of
-        (maximum_width, maximum_height) in pixels.
-        """
+        """Initialize basic needs.
+
+        'max_dimensions' is a tuple of (maximum_width, maximum_height) in
+        pixels."""
         self.CSS = sublime.load_resource(POPUP_CSS_FILE)
         self.max_width, self.max_height = max_dimensions
 

--- a/plugin/popups/popups.py
+++ b/plugin/popups/popups.py
@@ -118,25 +118,26 @@ class Popup:
     """Incapsulate popup creation."""
 
     WRAPPER_CLASS = "ECC"
-    MAX_POPUP_WIDTH = 1800
-    MAX_POPUP_HEIGHT = 800
 
-    def __init__(self):
-        """Initialize basic needs."""
+    def __init__(self, max_dimensions):
+        """ Initialize basic needs. 'max_dimensions' is a tuple of
+        (maximum_width, maximum_height) in pixels.
+        """
         self.CSS = sublime.load_resource(POPUP_CSS_FILE)
+        self.max_width, self.max_height = max_dimensions
 
     @staticmethod
-    def error(text):
+    def error(text, settings):
         """Initialize a new error popup."""
-        popup = Popup()
+        popup = Popup((settings.popup_maximum_width, settings.popup_maximum_height))
         popup.__popup_type = 'panel-error "ECC: Error"'
         popup.__text = markupsafe.escape(text)
         return popup
 
     @staticmethod
-    def warning(text):
+    def warning(text, settings):
         """Initialize a new warning popup."""
-        popup = Popup()
+        popup = Popup((settings.popup_maximum_width, settings.popup_maximum_height))
         popup.__popup_type = 'panel-warning "ECC: Warning"'
         popup.__text = markupsafe.escape(text)
         return popup
@@ -207,7 +208,7 @@ class Popup:
     @staticmethod
     def info(cursor, cindex, settings):
         """Initialize a new warning popup."""
-        popup = Popup()
+        popup = Popup((settings.popup_maximum_width, settings.popup_maximum_height))
         popup.__popup_type = 'panel-info "ECC: Info"'
         is_type_decl = cursor.kind in [
             cindex.CursorKind.STRUCT_DECL,
@@ -331,8 +332,8 @@ class Popup:
     def show(self, view, location=-1, on_navigate=None):
         """Show this popup."""
         mdpopups.show_popup(view, self.as_markdown(),
-                            max_width=Popup.MAX_POPUP_WIDTH,
-                            max_height=Popup.MAX_POPUP_HEIGHT,
+                            max_width=self.max_width,
+                            max_height=self.max_height,
                             wrapper_class=Popup.WRAPPER_CLASS,
                             css=self.CSS,
                             flags=sublime.HIDE_ON_MOUSE_MOVE_AWAY,
@@ -446,7 +447,7 @@ class Popup:
 
     def info_objc(cursor, cindex, settings):
         """Provide information about Objective C cursors."""
-        popup = Popup()
+        popup = Popup((settings.popup_maximum_width, settings.popup_maximum_height))
         popup.__popup_type = 'panel-info "ECC: Info"'
         is_message = cursor.kind in [
             cindex.CursorKind.OBJC_MESSAGE_EXPR,

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -72,6 +72,8 @@ class SettingsStorage:
         "expand_template_types",
         "flags_sources",
         "gutter_style",
+        "popup_maximum_width",
+        "popup_maximum_height",
         "header_to_source_mapping",
         "hide_default_completions",
         "include_file_folder",

--- a/plugin/view_config.py
+++ b/plugin/view_config.py
@@ -329,7 +329,7 @@ class ViewConfig(object):
         Returns:
             Completer: A completer. Can be lib completer or bin completer.
         """
-        error_vis = PopupErrorVis(settings.gutter_style)
+        error_vis = PopupErrorVis(settings)
 
         completer = None
         if settings.use_libclang:

--- a/tests/test_error_vis.py
+++ b/tests/test_error_vis.py
@@ -430,7 +430,8 @@ allow_code_wrap: true
 !!! panel-info "ECC: Info"
     ## Declaration: ##
     -(void)[interfaceMethodVoidTwoParametersSecondUnnamed]\
-({file}:24:10):(int)int1 :(int)int2"""
+({file}:24:10):(int)int1 :(int)int2
+"""
         expected_info_msg = fmt.format(file=file_name)
 
         # Make sure we remove trailing spaces on the right to comply with how
@@ -468,7 +469,8 @@ allow_code_wrap: true
 !!! panel-info "ECC: Info"
     ## Declaration: ##
     +([Foo *]({file}:6:8))[interfaceClassMethodFooTwoFooParameters]\
-({file}:26:10):([Foo *]({file}:6:8))f1 fooParam2:([Foo *]({file}:6:8))f2"""
+({file}:26:10):([Foo *]({file}:6:8))f1 fooParam2:([Foo *]({file}:6:8))f2
+"""
         expected_info_msg = fmt.format(file=file_name)
         # Make sure we remove trailing spaces on the right to comply with how
         # sublime text handles this.

--- a/tests/test_error_vis.py
+++ b/tests/test_error_vis.py
@@ -429,7 +429,8 @@ allow_code_wrap: true
 ---
 !!! panel-info "ECC: Info"
     ## Declaration: ##
-    -(void)[interfaceMethodVoidTwoParametersSecondUnnamed]({file}:24:10):(int)int1 :(int)int2"""
+    -(void)[interfaceMethodVoidTwoParametersSecondUnnamed]\
+({file}:24:10):(int)int1 :(int)int2"""
         expected_info_msg = fmt.format(file=file_name)
 
         # Make sure we remove trailing spaces on the right to comply with how
@@ -466,7 +467,8 @@ allow_code_wrap: true
 ---
 !!! panel-info "ECC: Info"
     ## Declaration: ##
-    +([Foo *]({file}:6:8))[interfaceClassMethodFooTwoFooParameters]({file}:26:10):([Foo *]({file}:6:8))f1 fooParam2:([Foo *]({file}:6:8))f2"""
+    +([Foo *]({file}:6:8))[interfaceClassMethodFooTwoFooParameters]\
+({file}:26:10):([Foo *]({file}:6:8))f1 fooParam2:([Foo *]({file}:6:8))f2"""
         expected_info_msg = fmt.format(file=file_name)
         # Make sure we remove trailing spaces on the right to comply with how
         # sublime text handles this.
@@ -854,7 +856,8 @@ allow_code_wrap: true
 ---
 !!! panel-info "ECC: Info"
     ## Declaration: ##
-    [TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7), int, *ECC: unknown*&gt; [instanceClassTypeInt]({file}:9:32)
+    [TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7), int, \
+*ECC: unknown*&gt; [instanceClassTypeInt]({file}:9:32)
 """
         expected_info_msg = fmt.format(file=file_name)
 
@@ -892,7 +895,8 @@ allow_code_wrap: true
 ---
 !!! panel-info "ECC: Info"
     ## Declaration: ##
-    [TemplateClass&lt;Foo, int, 123&gt;]({file}:3:7) [instanceClassTypeInt]({file}:9:32)
+    [TemplateClass&lt;Foo, int, 123&gt;]({file}:3:7) \
+[instanceClassTypeInt]({file}:9:32)
 """
         expected_info_msg = fmt.format(file=file_name)
 
@@ -930,7 +934,8 @@ allow_code_wrap: true
 ---
 !!! panel-info "ECC: Info"
     ## Declaration: ##
-    [TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7)&gt; [instanceClassAndDefaults]({file}:10:22)
+    [TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7)&gt; \
+[instanceClassAndDefaults]({file}:10:22)
 """
         expected_info_msg = fmt.format(file=file_name)
 
@@ -968,7 +973,8 @@ allow_code_wrap: true
 ---
 !!! panel-info "ECC: Info"
     ## Declaration: ##
-    [TemplateClass]({file}:3:7)&lt;[TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7)&gt;&gt; [instanceNested]({file}:11:37)
+    [TemplateClass]({file}:3:7)&lt;[TemplateClass]({file}:3:7)&lt;\
+[Foo]({file}:1:7)&gt;&gt; [instanceNested]({file}:11:37)
 """
         expected_info_msg = fmt.format(file=file_name)
         # Make sure we remove trailing spaces on the right to comply with how
@@ -1005,7 +1011,8 @@ allow_code_wrap: true
 ---
 !!! panel-info "ECC: Info"
     ## Declaration: ##
-    [TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7) \\*&gt; [instancePointer]({file}:12:23)
+    [TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7) \\*&gt; \
+[instancePointer]({file}:12:23)
 """
         expected_info_msg = fmt.format(file=file_name)
         # Make sure we remove trailing spaces on the right to comply with how
@@ -1041,7 +1048,8 @@ allow_code_wrap: true
 ---
 !!! panel-info "ECC: Info"
     ## Declaration: ##
-    [TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7) &amp;&gt; [instanceRef]({file}:13:23)
+    [TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7) &amp;&gt; \
+[instanceRef]({file}:13:23)
 """
         expected_info_msg = fmt.format(file=file_name)
         # Make sure we remove trailing spaces on the right to comply with how
@@ -1078,7 +1086,8 @@ allow_code_wrap: true
 ---
 !!! panel-info "ECC: Info"
     ## Declaration: ##
-    [TemplateClass]({file}:3:7)&lt;[Foo &amp;&amp;]({file}:1:7)&gt; [instanceRValueRef]({file}:14:24)
+    [TemplateClass]({file}:3:7)&lt;[Foo &amp;&amp;]({file}:1:7)&gt; \
+[instanceRValueRef]({file}:14:24)
 """
         expected_info_msg = fmt.format(file=file_name)
         # Make sure we remove trailing spaces on the right to comply with how
@@ -1160,7 +1169,8 @@ allow_code_wrap: true
 ---
 !!! panel-info "ECC: Info"
     ## Declaration: ##
-    void [foo]({file}:6:8) ([TemplateClass]({file}:3:7)&lt;Foo &amp;&amp;, int, *ECC: unknown*&gt;)
+    void [foo]({file}:6:8) \
+([TemplateClass]({file}:3:7)&lt;Foo &amp;&amp;, int, *ECC: unknown*&gt;)
 """
         expected_info_msg = fmt.format(file=file_name)
         # Make sure we remove trailing spaces on the right to comply with how

--- a/tests/test_error_vis.py
+++ b/tests/test_error_vis.py
@@ -162,7 +162,11 @@ class TestErrorVis:
 
     def test_error(self):
         """Test getting text from multiline extent."""
-        error_popup = Popup.error("error_text")
+        manager = SettingsManager()
+        settings = manager.settings_for_view(self.view)
+        settings.popup_maximum_width = 1800
+        settings.popup_maximum_height = 800
+        error_popup = Popup.error("error_text", settings)
         md_text = error_popup.as_markdown()
         expected_error = """!!! panel-error "ECC: Error"
     error_text
@@ -171,7 +175,11 @@ class TestErrorVis:
 
     def test_warning(self):
         """Test generating a simple warning."""
-        error_popup = Popup.warning("warning_text")
+        manager = SettingsManager()
+        settings = manager.settings_for_view(self.view)
+        settings.popup_maximum_width = 1800
+        settings.popup_maximum_height = 800
+        error_popup = Popup.warning("warning_text", settings)
         md_text = error_popup.as_markdown()
         expected_error = """!!! panel-warning "ECC: Warning"
     warning_text

--- a/tests/test_error_vis.py
+++ b/tests/test_error_vis.py
@@ -896,7 +896,7 @@ allow_code_wrap: true
 ---
 !!! panel-info "ECC: Info"
     ## Declaration: ##
-    [TemplateClass]({file}:3:7) \
+    [TemplateClass]({file}:3:7)\
 &lt;[Foo]({file}:1:7), int, 123&gt; \
 [instanceClassTypeInt]({file}:9:32)
 """

--- a/tests/test_error_vis.py
+++ b/tests/test_error_vis.py
@@ -162,26 +162,40 @@ class TestErrorVis:
 
     def test_error(self):
         """Test getting text from multiline extent."""
-        manager = SettingsManager()
-        settings = manager.settings_for_view(self.view)
+        file_name = path.join(path.dirname(__file__),
+                              'test_files',
+                              'test.cpp')
+        self.set_up_view(file_name)
+        _, settings = self.set_up_completer()
         settings.popup_maximum_width = 1800
         settings.popup_maximum_height = 800
         error_popup = Popup.error("error_text", settings)
         md_text = error_popup.as_markdown()
-        expected_error = """!!! panel-error "ECC: Error"
+        expected_error = """\
+---
+allow_code_wrap: true
+---
+!!! panel-error "ECC: Error"
     error_text
 """
         self.assertEqual(md_text, expected_error)
 
     def test_warning(self):
         """Test generating a simple warning."""
-        manager = SettingsManager()
-        settings = manager.settings_for_view(self.view)
+        file_name = path.join(path.dirname(__file__),
+                              'test_files',
+                              'test.cpp')
+        self.set_up_view(file_name)
+        _, settings = self.set_up_completer()
         settings.popup_maximum_width = 1800
         settings.popup_maximum_height = 800
         error_popup = Popup.warning("warning_text", settings)
         md_text = error_popup.as_markdown()
-        expected_error = """!!! panel-warning "ECC: Warning"
+        expected_error = """\
+---
+allow_code_wrap: true
+---
+!!! panel-warning "ECC: Warning"
     warning_text
 """
         self.assertEqual(md_text, expected_error)
@@ -214,7 +228,11 @@ class TestErrorVis:
         pos = self.view.text_point(6, 7)
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
-        expected_info_msg = """!!! panel-info "ECC: Info"
+        expected_info_msg = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
     ## Declaration: ##
     int [main]({file}:7:5) (int argc, const char *[] argv)
 """.format(file=file_name)
@@ -238,7 +256,11 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        expected_info_msg = """!!! panel-info "ECC: Info"
+        expected_info_msg = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
     ## Declaration: ##
     [MyCoolClass]({file}:4:7)
     ### Brief documentation: ###
@@ -285,7 +307,11 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        expected_info_msg = """!!! panel-info "ECC: Info"
+        expected_info_msg = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
     ## Declaration: ##
     void [foo]({file}:14:8) (int a, int b)
     ### Brief documentation: ###
@@ -323,7 +349,11 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        expected_info_msg = """!!! panel-info "ECC: Info"
+        expected_info_msg = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
     ## Declaration: ##
     void [foo]({file}:5:8) ([Foo]({file}:1:7) a, [Foo]({file}:1:7) \\* b)
 """.format(file=file_name)
@@ -353,7 +383,11 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        expected_info_msg = """!!! panel-info "ECC: Info"
+        expected_info_msg = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
     ## Declaration: ##
     -(void)[interfaceMethodVoidNoParameters]({file}:19:10)
     ### Brief documentation: ###
@@ -389,10 +423,13 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        fmt = '!!! panel-info "ECC: Info"\n'
-        fmt += '    ## Declaration: ##\n'
-        fmt += '    -(void)[interfaceMethodVoidTwoParametersSecondUnnamed]'
-        fmt += '({file}:24:10):(int)int1 :(int)int2\n'
+        fmt = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
+    ## Declaration: ##
+    -(void)[interfaceMethodVoidTwoParametersSecondUnnamed]({file}:24:10):(int)int1 :(int)int2"""
         expected_info_msg = fmt.format(file=file_name)
 
         # Make sure we remove trailing spaces on the right to comply with how
@@ -423,11 +460,13 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        fmt = '!!! panel-info "ECC: Info"\n'
-        fmt += '    ## Declaration: ##\n'
-        fmt += '    +([Foo *]({file}:6:8))[interfaceClassMethodFooTwoFoo'
-        fmt += 'Parameters]({file}:26:10):([Foo *]({file}:6:8))f1 '
-        fmt += 'fooParam2:([Foo *]({file}:6:8))f2\n'
+        fmt = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
+    ## Declaration: ##
+    +([Foo *]({file}:6:8))[interfaceClassMethodFooTwoFooParameters]({file}:26:10):([Foo *]({file}:6:8))f1 fooParam2:([Foo *]({file}:6:8))f2"""
         expected_info_msg = fmt.format(file=file_name)
         # Make sure we remove trailing spaces on the right to comply with how
         # sublime text handles this.
@@ -455,7 +494,11 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        expected_info_msg = """!!! panel-info "ECC: Info"
+        expected_info_msg = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
     ## Declaration: ##
     -(void)[protocolMethodVoidNoParameters]({file}:9:10)
     ### Brief documentation: ###
@@ -489,7 +532,11 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        expected_info_msg = """!!! panel-info "ECC: Info"
+        expected_info_msg = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
     ## Declaration: ##
     +(void)[protocolClassMethod]({file}:14:10)
 """.format(file=file_name)
@@ -519,7 +566,11 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        expected_info_msg = """!!! panel-info "ECC: Info"
+        expected_info_msg = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
     ## Declaration: ##
     -(void)[categoryMethodVoidNoParameters]({file}:54:10)
 """.format(file=file_name)
@@ -550,7 +601,11 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        expected_info_msg = """!!! panel-info "ECC: Info"
+        expected_info_msg = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
     ## Declaration: ##
     -(void)[interfaceMethodVoidNoParameters]({file}:34:10)
     ### Brief documentation: ###
@@ -584,7 +639,11 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        expected_info_msg = """!!! panel-info "ECC: Info"
+        expected_info_msg = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
     ## Declaration: ##
     +(void)[protocolClassMethod]({file}:14:10)
 """.format(file=file_name)
@@ -614,7 +673,11 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        expected_info_msg = """!!! panel-info "ECC: Info"
+        expected_info_msg = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
     ## Declaration: ##
     [Protocol]({file}:8:11)
     ### Body: ###
@@ -657,7 +720,11 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        expected_info_msg = """!!! panel-info "ECC: Info"
+        expected_info_msg = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
     ## Declaration: ##
     [Category]({file}:53:12)
     ### Body: ###
@@ -694,7 +761,11 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        expected_info_msg = """!!! panel-info "ECC: Info"
+        expected_info_msg = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
     ## Declaration: ##
     [Interface]({file}:18:12)
     ### Body: ###
@@ -741,7 +812,11 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        expected_info_msg = """!!! panel-info "ECC: Info"
+        expected_info_msg = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
     ## Declaration: ##
     -([MyCovariant&lt;Foo *&gt; *]({file}:3:12))[covariantMethod]({file}:4:22)
 """.format(file=file_name)
@@ -773,10 +848,14 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        fmt = '!!! panel-info "ECC: Info"\n'
-        fmt += '    ## Declaration: ##\n'
-        fmt += '    [TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7), int, '
-        fmt += '*ECC: unknown*&gt; [instanceClassTypeInt]({file}:9:32)\n'
+        fmt = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
+    ## Declaration: ##
+    [TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7), int, *ECC: unknown*&gt; [instanceClassTypeInt]({file}:9:32)
+"""
         expected_info_msg = fmt.format(file=file_name)
 
         # Make sure we remove trailing spaces on the right to comply with how
@@ -807,10 +886,14 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        fmt = '!!! panel-info "ECC: Info"\n'
-        fmt += '    ## Declaration: ##\n'
-        fmt += '    [TemplateClass&lt;Foo, int, 123&gt;]({file}:3:7) '
-        fmt += '[instanceClassTypeInt]({file}:9:32)\n'
+        fmt = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
+    ## Declaration: ##
+    [TemplateClass&lt;Foo, int, 123&gt;]({file}:3:7) [instanceClassTypeInt]({file}:9:32)
+"""
         expected_info_msg = fmt.format(file=file_name)
 
         # Make sure we remove trailing spaces on the right to comply with how
@@ -841,10 +924,14 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        fmt = '!!! panel-info "ECC: Info"\n'
-        fmt += '    ## Declaration: ##\n'
-        fmt += '    [TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7)&gt; '
-        fmt += '[instanceClassAndDefaults]({file}:10:22)\n'
+        fmt = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
+    ## Declaration: ##
+    [TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7)&gt; [instanceClassAndDefaults]({file}:10:22)
+"""
         expected_info_msg = fmt.format(file=file_name)
 
         # Make sure we remove trailing spaces on the right to comply with how
@@ -875,10 +962,14 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        fmt = '!!! panel-info "ECC: Info"\n'
-        fmt += '    ## Declaration: ##\n'
-        fmt += '    [TemplateClass]({file}:3:7)&lt;[TemplateClass]({file}:3:7)'
-        fmt += '&lt;[Foo]({file}:1:7)&gt;&gt; [instanceNested]({file}:11:37)\n'
+        fmt = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
+    ## Declaration: ##
+    [TemplateClass]({file}:3:7)&lt;[TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7)&gt;&gt; [instanceNested]({file}:11:37)
+"""
         expected_info_msg = fmt.format(file=file_name)
         # Make sure we remove trailing spaces on the right to comply with how
         # sublime text handles this.
@@ -908,10 +999,14 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        fmt = '!!! panel-info "ECC: Info"\n'
-        fmt += '    ## Declaration: ##\n'
-        fmt += '    [TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7) \\*&gt; '
-        fmt += '[instancePointer]({file}:12:23)\n'
+        fmt = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
+    ## Declaration: ##
+    [TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7) \\*&gt; [instancePointer]({file}:12:23)
+"""
         expected_info_msg = fmt.format(file=file_name)
         # Make sure we remove trailing spaces on the right to comply with how
         # sublime text handles this.
@@ -940,10 +1035,14 @@ class TestErrorVis:
         pos = self.view.text_point(12, 23)
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
-        fmt = '!!! panel-info "ECC: Info"\n'
-        fmt += '    ## Declaration: ##\n'
-        fmt += '    [TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7) &amp;&gt; '
-        fmt += '[instanceRef]({file}:13:23)\n'
+        fmt = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
+    ## Declaration: ##
+    [TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7) &amp;&gt; [instanceRef]({file}:13:23)
+"""
         expected_info_msg = fmt.format(file=file_name)
         # Make sure we remove trailing spaces on the right to comply with how
         # sublime text handles this.
@@ -973,10 +1072,14 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        fmt = '!!! panel-info "ECC: Info"\n'
-        fmt += '    ## Declaration: ##\n'
-        fmt += '    [TemplateClass]({file}:3:7)&lt;[Foo &amp;&amp;]'
-        fmt += '({file}:1:7)&gt; [instanceRValueRef]({file}:14:24)\n'
+        fmt = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
+    ## Declaration: ##
+    [TemplateClass]({file}:3:7)&lt;[Foo &amp;&amp;]({file}:1:7)&gt; [instanceRValueRef]({file}:14:24)
+"""
         expected_info_msg = fmt.format(file=file_name)
         # Make sure we remove trailing spaces on the right to comply with how
         # sublime text handles this.
@@ -1006,7 +1109,11 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        expected_info_msg = """!!! panel-info "ECC: Info"
+        expected_info_msg = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
     ## Declaration: ##
     [TemplateClass]({file}:3:7)
     ### Body: ###
@@ -1047,10 +1154,14 @@ class TestErrorVis:
         action_request = ActionRequest(self.view, pos)
         request, info_popup = completer.info(action_request, settings)
         self.maxDiff = None
-        fmt = '!!! panel-info "ECC: Info"\n'
-        fmt += '    ## Declaration: ##\n'
-        fmt += '    void [foo]({file}:6:8) ([TemplateClass]({file}:3:7)&lt;Foo '
-        fmt += '&amp;&amp;, int, *ECC: unknown*&gt;)\n'
+        fmt = """\
+---
+allow_code_wrap: true
+---
+!!! panel-info "ECC: Info"
+    ## Declaration: ##
+    void [foo]({file}:6:8) ([TemplateClass]({file}:3:7)&lt;Foo &amp;&amp;, int, *ECC: unknown*&gt;)
+"""
         expected_info_msg = fmt.format(file=file_name)
         # Make sure we remove trailing spaces on the right to comply with how
         # sublime text handles this.


### PR DESCRIPTION
See PR #452 .  I initially made this proportional to view size, but there were problems with that. This approach exposes a user setting for maximum dimensions or uses the current hard-coded values as defaults.

It also changes the behaviour to use code wrapping in the popup.

I'm not 100% happy with this approach, since it means users have to pick a lowest-common-dimension amongst any set of screens they might be using. But there's no reliable way to get screen dimensions via Sublime's API, so this is it.

Also note I couldn't figure out how to run the tests. I updated them, but I haven't been able to run them.