### PR TITLE
Fix issue #533

### DIFF
--- a/plugin/flags_sources/cmake_file.py
+++ b/plugin/flags_sources/cmake_file.py
@@ -79,7 +79,7 @@ class CMakeFile(FlagsSource):
         current_cmake_file = File.search(
             file_name=self._FILE_NAME,
             search_scope=search_scope,
-            search_content='project(')
+            search_content=['project(', 'project ('])
         if not current_cmake_file:
             log.debug("No CMakeLists.txt file with 'project' in it found.")
             return None

--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -298,7 +298,7 @@ class File:
         Args:
             file_name (str): Search for the file with this name
             search_scope (SearchScope): scope where to search for file
-            search_content (str, optional): String that the file must contain
+            search_content (str, list, optional): the file must contain these
 
         Returns:
             File: found file

--- a/tests/cmake_tests/CMakeLists.txt
+++ b/tests/cmake_tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 
-project(test_cmake_project)
+project (test_cmake_project)
 
 add_subdirectory(lib)
 include_directories(lib)


### PR DESCRIPTION
This PR allows to search for `project (` along with of `project(` when searching for a valid `CMakeLists.txt` file.