### PR TITLE
Add flags to expandable arguments, fix #537

### DIFF
--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -42,7 +42,7 @@ class SettingsStorage:
                     "CppProperties.json",
                     "c_cpp_properties.json",
                     ".clang_complete"]
-    FLAG_SOURCES_ENTRIES_WITH_PATHS = ["search_in", "prefix_paths"]
+    FLAG_SOURCES_ENTRIES_WITH_PATHS = ["search_in", "prefix_paths", "flags"]
 
     PREFIXES = ["ecc_", "easy_clang_complete_"]
 


### PR DESCRIPTION
Now `flags` part in the `flags_sources` setting will also get proper expansion of variables.
