### PR TITLE
Better info template arg expansion.

### DIFF
--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -208,11 +208,4 @@
   "target_cpp_compiler": null,
   "target_objective_c_compiler": null,
   "target_objective_cpp_compiler": null,
-
-  // Expand template types and add more hyperlinks when showing info on hover.
-  // For example, "std::shared_ptr<Foo> foo" will expand to show hyperlinks
-  // to both std::shared_ptr and the template type, Foo. This may cause
-  // some types and typedefs to be verbose. For example, "std::string foo"
-  // expands to "std::string<char, char_traits<char>, allocator<char>> foo".
-  "expand_template_types": true,
 }

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -471,17 +471,4 @@ CMake if you use it as source.
     "target_objective_cpp_compiler": null,
     ```
 
-### **`expand_template_types`**
-
-Expand template types and add more hyperlinks when showing info on hover. For
-example, `std::shared_ptr<Foo> foo` will expand to show hyperlinks to both
-`std::shared_ptr` and the template type, `Foo`. This may cause some types and
-typedefs to be verbose. For example, `std::string foo` expands to
-`std::string<char, char_traits<char>, allocator<char>> foo`.
-  
-!!! example "Default value"
-    ```json
-    "expand_template_types": true,
-    ```
-
 [subl-proj]: https://www.sublimetext.com/docs/3/projects.html

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -68,7 +68,6 @@ class SettingsStorage:
         "clang_binary",
         "cmake_binary",
         "common_flags",
-        "expand_template_types",
         "flags_sources",
         "gutter_style",
         "header_to_source_mapping",

--- a/tests/test_error_vis.py
+++ b/tests/test_error_vis.py
@@ -768,7 +768,7 @@ class TestErrorVis:
         fmt = '!!! panel-info "ECC: Info"\n'
         fmt += '    ## Declaration: ##\n'
         fmt += '    [TemplateClass]({file}:3:7)&lt;[Foo]({file}:1:7), int, '
-        fmt += '*ECC: unknown*&gt; [instanceClassTypeInt]({file}:9:32)\n'
+        fmt += '123&gt; [instanceClassTypeInt]({file}:9:32)\n'
         expected_info_msg = fmt.format(file=file_name)
 
         # Make sure we remove trailing spaces on the right to comply with how
@@ -778,8 +778,8 @@ class TestErrorVis:
         # cleanup
         self.tear_down_completer()
 
-    def test_template_instance_expand_templates_disabled(self):
-        """Test that changing "expand_template_types" setting to false works.
+    def test_template_instance_expand_templates(self):
+        """Test simple types in expansion.
 
         E.g. hover over 'instance' of 'TemplateClass<Foo, int, 123> instance;'
         """
@@ -791,7 +791,6 @@ class TestErrorVis:
                               'test_templates.cpp')
         self.set_up_view(file_name)
         completer, settings = self.set_up_completer()
-        settings.expand_template_types = False
         # Check the current cursor position is completable.
         self.assertEqual(self.get_row(8),
                          "  TemplateClass<Foo, int, 123> instanceClassTypeInt;")
@@ -801,7 +800,8 @@ class TestErrorVis:
         self.maxDiff = None
         fmt = '!!! panel-info "ECC: Info"\n'
         fmt += '    ## Declaration: ##\n'
-        fmt += '    [TemplateClass&lt;Foo, int, 123&gt;]({file}:3:7) '
+        fmt += '    [TemplateClass]({file}:3:7)'
+        fmt += '&lt;[Foo]({file}:1:7), int, 123&gt; '
         fmt += '[instanceClassTypeInt]({file}:9:32)\n'
         expected_info_msg = fmt.format(file=file_name)
 
@@ -813,7 +813,7 @@ class TestErrorVis:
         self.tear_down_completer()
 
     def test_template_instance_default_template_params(self):
-        """Test template instance with some template args left empty (default)
+        """Test template instance with some template args left empty.
 
         E.g. hover over 'instance' of 'TemplateClass<Foo, int> instance;'
         where TemplateClass has an option 3rd template argument.
@@ -847,7 +847,7 @@ class TestErrorVis:
         self.tear_down_completer()
 
     def test_template_instance_nested_template_parameters(self):
-        """Test instance with template arguments that are themselves templates
+        """Test instance with template arguments that are themselves templates.
 
         E.g. hover over 'instance' of the line:
         'std::shared_ptr<std::vector<Foo>>> instance;'
@@ -1042,7 +1042,7 @@ class TestErrorVis:
         fmt = '!!! panel-info "ECC: Info"\n'
         fmt += '    ## Declaration: ##\n'
         fmt += '    void [foo]({file}:6:8) ([TemplateClass]({file}:3:7)&lt;Foo '
-        fmt += '&amp;&amp;, int, *ECC: unknown*&gt;)\n'
+        fmt += '&amp;&amp;, int, 12&gt;)\n'
         expected_info_msg = fmt.format(file=file_name)
         # Make sure we remove trailing spaces on the right to comply with how
         # sublime text handles this.


### PR DESCRIPTION
We now parse the spelling of the type to make sure we don't ignore templates
like A<int>. This allows to remove the unneeded setting `expand_template_types`.