### PR TITLE
added linux suffix used on fedora

### DIFF
--- a/plugin/clang/utils.py
+++ b/plugin/clang/utils.py
@@ -24,7 +24,7 @@ class ClangUtils:
     libclang_name = None
 
     windows_suffixes = ['.dll', '.lib']
-    linux_suffixes = ['.so', '.so.1']
+    linux_suffixes = ['.so', '.so.1', 'so.7']
     osx_suffixes = ['.dylib']
 
     suffixes = {


### PR DESCRIPTION
# Before submitting make sure #
- Make sure your branch is based on `dev`
- Reference an issue that this PR closes if there is one
- Add your PR descriptions below the line
- Remove this prefix (everything above the line)

--------------------------------------------------------

Added the .so7 suffix so libclang is automatically found on fedora
