### PR TITLE
More accurate description of the `libclang_path` setting.

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -391,12 +391,11 @@ symbol under cursor taking them from Sublime Text index.
 
 ### **`libclang_path`**
 
-On some esoteric systems we cannot find `libclang` properly.
-If you know where your `libclang` is - set the full path here. This setting generally should not be needed.
+EasyClangComplete tries to auto-detect where `libclang` is installed. If this fails, you can specify the full path to the binary file.
 
 !!! example "Default value"
     ```json
-    "libclang_path": "<some_path_here>",
+    "libclang_path": "D:\\Program Files\\LLVM\\bin\\libclang.dll",
     ```
 
 ### **`progress_style`**


### PR DESCRIPTION
I had quite a bit of trouble understanding what you meant by `libclang`. I thought you wanted a directory.

What I would have liked even better, though, is an understanding of what you're doing to detect libclang in the first place. Do you expect it to be in the `PATH`?