### PR TITLE
Better libclang handling and documentation updates

### DIFF
--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -106,12 +106,15 @@
   // add parent folder of the current file's one with `-I` flag
   "include_file_parent_folder" : true,
 
-  // pick the clang binary used by the plugin. This is used to determine the
-  // version of the plugin and pick correct libclang bindings.
+  // Pick the clang binary used by the plugin. This is used to determine the
+  // version of the plugin and pick correct libclang bindings. Note that this
+  // should either be a full path to the binary or it should be available in
+  // your PATH.
   "clang_binary" : "clang++",
 
   // pick the binary used for cmake. Please make sure the binary you provide is
-  // accessible from the command line on your system.
+  // accessible from the command line on your system. Note that this should
+  // either be a full path to the binary or it should be available in your PATH.
   "cmake_binary" : "cmake",
 
   // ignore triggers and try to complete after each character
@@ -137,8 +140,11 @@
   // the symbol under cursor taking them from Sublime Text index.
   "show_index_references": true,
 
-  // On some esoteric systems we cannot find libclang properly.
-  // If you know where your libclang is - set the full path here.
+  // If the libclang library cannot be found in standard places, the user can
+  // provide a path to `libclang`. This path can either be a full path to the
+  // libclang library, e.g. `/usr/lib/libclang.so` or a folder that contains
+  // libclang library, e.g. `/usr/lib/`. This setting generally should not be
+  // needed.
   "libclang_path": "<some_path_here>",
 
   // Pick the progress style. There are currently these styles available:

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -60,13 +60,24 @@ Specify common flags that are passed to clang for **every** compilation. These
 usually include common include paths that are needed for finding STL etc. Below
 are typical defaults for Linux.
 
-??? example "Good defaults for Linux & MacOS <small>(click to expand)</small>"
+??? example "Good defaults for Linux <small>(click to expand)</small>"
     ```json  
     "common_flags" : [
-      "-I/usr/include",
-      "-I$project_base_path/src",
-      // this is needed to include the correct headers for clang
-      "-I/usr/lib/clang/$clang_version/include",
+        "-I/usr/include",
+        "-I$project_base_path/src",
+        // this is needed to include the correct headers for clang
+        "-I/usr/lib/clang/$clang_version/include",
+    ],
+    ```
+
+??? example "Good defaults MacOS <small>(click to expand)</small>"
+    ```json  
+    "common_flags" : [
+        // some example includes
+        "-I/usr/include/",
+        "-I/usr/local/include",
+        "-I/Library/Developer/CommandLineTools/usr/lib/clang/$clang_version",
+        "-I/Library/Developer/CommandLineTools/usr/include/c++/v1",       
     ],
     ```
 
@@ -391,8 +402,11 @@ symbol under cursor taking them from Sublime Text index.
 
 ### **`libclang_path`**
 
-On some esoteric systems we cannot find `libclang` properly.
-If you know where your `libclang` is - set the full path here. This setting generally should not be needed.
+If the libclang library cannot be found in standard places, the user can
+provide a path to `libclang`. This path can either be a full path to the
+libclang library, e.g. `/usr/lib/libclang.so` or a folder that contains
+libclang library, e.g. `/usr/lib/`. This setting generally should not be
+needed.
 
 !!! example "Default value"
     ```json

--- a/plugin/clang/cindex32.py
+++ b/plugin/clang/cindex32.py
@@ -3120,14 +3120,20 @@ class Config:
         if Config.library_file:
             return Config.library_file
 
-        from .utils import ClangUtils
-        from os import path
-        filename = ClangUtils.libclang_name
+        import platform
+        name = platform.system()
+
+        if name == 'Darwin':
+            file = 'libclang.dylib'
+        elif name == 'Windows':
+            file = 'libclang.dll'
+        else:
+            file = 'libclang.so'
 
         if Config.library_path:
-            filename = path.join(Config.library_path, filename)
+            file = Config.library_path + '/' + file
 
-        return filename
+        return file
 
     def get_cindex_library(self):
         try:

--- a/plugin/clang/cindex33.py
+++ b/plugin/clang/cindex33.py
@@ -3220,14 +3220,20 @@ class Config:
         if Config.library_file:
             return Config.library_file
 
-        from .utils import ClangUtils
-        from os import path
-        filename = ClangUtils.libclang_name
+        import platform
+        name = platform.system()
+
+        if name == 'Darwin':
+            file = 'libclang.dylib'
+        elif name == 'Windows':
+            file = 'libclang.dll'
+        else:
+            file = 'libclang.so'
 
         if Config.library_path:
-            filename = path.join(Config.library_path, filename)
+            file = Config.library_path + '/' + file
 
-        return filename
+        return file
 
     def get_cindex_library(self):
         try:

--- a/plugin/clang/cindex34.py
+++ b/plugin/clang/cindex34.py
@@ -3381,14 +3381,20 @@ class Config:
         if Config.library_file:
             return Config.library_file
 
-        from .utils import ClangUtils
-        from os import path
-        filename = ClangUtils.libclang_name
+        import platform
+        name = platform.system()
+
+        if name == 'Darwin':
+            file = 'libclang.dylib'
+        elif name == 'Windows':
+            file = 'libclang.dll'
+        else:
+            file = 'libclang.so'
 
         if Config.library_path:
-            filename = path.join(Config.library_path, filename)
+            file = Config.library_path + '/' + file
 
-        return filename
+        return file
 
     def get_cindex_library(self):
         try:

--- a/plugin/clang/cindex35.py
+++ b/plugin/clang/cindex35.py
@@ -3466,14 +3466,20 @@ class Config:
         if Config.library_file:
             return Config.library_file
 
-        from .utils import ClangUtils
-        from os import path
-        filename = ClangUtils.libclang_name
+        import platform
+        name = platform.system()
+
+        if name == 'Darwin':
+            file = 'libclang.dylib'
+        elif name == 'Windows':
+            file = 'libclang.dll'
+        else:
+            file = 'libclang.so'
 
         if Config.library_path:
-            filename = path.join(Config.library_path, filename)
+            file = Config.library_path + '/' + file
 
-        return filename
+        return file
 
     def get_cindex_library(self):
         try:

--- a/plugin/clang/cindex37.py
+++ b/plugin/clang/cindex37.py
@@ -3564,14 +3564,20 @@ class Config:
         if Config.library_file:
             return Config.library_file
 
-        from .utils import ClangUtils
-        from os import path
-        filename = ClangUtils.libclang_name
+        import platform
+        name = platform.system()
+
+        if name == 'Darwin':
+            file = 'libclang.dylib'
+        elif name == 'Windows':
+            file = 'libclang.dll'
+        else:
+            file = 'libclang.so'
 
         if Config.library_path:
-            filename = path.join(Config.library_path, filename)
+            file = Config.library_path + '/' + file
 
-        return filename
+        return file
 
     def get_cindex_library(self):
         try:

--- a/plugin/clang/cindex38.py
+++ b/plugin/clang/cindex38.py
@@ -3619,14 +3619,20 @@ class Config:
         if Config.library_file:
             return Config.library_file
 
-        from .utils import ClangUtils
-        from os import path
-        filename = ClangUtils.libclang_name
+        import platform
+        name = platform.system()
+
+        if name == 'Darwin':
+            file = 'libclang.dylib'
+        elif name == 'Windows':
+            file = 'libclang.dll'
+        else:
+            file = 'libclang.so'
 
         if Config.library_path:
-            filename = path.join(Config.library_path, filename)
+            file = Config.library_path + '/' + file
 
-        return filename
+        return file
 
     def get_cindex_library(self):
         try:

--- a/plugin/clang/cindex39.py
+++ b/plugin/clang/cindex39.py
@@ -3964,14 +3964,20 @@ class Config:
         if Config.library_file:
             return Config.library_file
 
-        from .utils import ClangUtils
-        from os import path
-        filename = ClangUtils.libclang_name
+        import platform
+        name = platform.system()
+
+        if name == 'Darwin':
+            file = 'libclang.dylib'
+        elif name == 'Windows':
+            file = 'libclang.dll'
+        else:
+            file = 'libclang.so'
 
         if Config.library_path:
-            filename = path.join(Config.library_path, filename)
+            file = Config.library_path + '/' + file
 
-        return filename
+        return file
 
     def get_cindex_library(self):
         try:

--- a/plugin/clang/cindex40.py
+++ b/plugin/clang/cindex40.py
@@ -3885,14 +3885,20 @@ class Config:
         if Config.library_file:
             return Config.library_file
 
-        from .utils import ClangUtils
-        from os import path
-        filename = ClangUtils.libclang_name
+        import platform
+        name = platform.system()
+
+        if name == 'Darwin':
+            file = 'libclang.dylib'
+        elif name == 'Windows':
+            file = 'libclang.dll'
+        else:
+            file = 'libclang.so'
 
         if Config.library_path:
-            filename = path.join(Config.library_path, filename)
+            file = Config.library_path + '/' + file
 
-        return filename
+        return file
 
     def get_cindex_library(self):
         try:

--- a/plugin/clang/cindex50.py
+++ b/plugin/clang/cindex50.py
@@ -4035,14 +4035,20 @@ class Config:
         if Config.library_file:
             return Config.library_file
 
-        from .utils import ClangUtils
-        from os import path
-        filename = ClangUtils.libclang_name
+        import platform
+        name = platform.system()
+
+        if name == 'Darwin':
+            file = 'libclang.dylib'
+        elif name == 'Windows':
+            file = 'libclang.dll'
+        else:
+            file = 'libclang.so'
 
         if Config.library_path:
-            filename = path.join(Config.library_path, filename)
+            file = Config.library_path + '/' + file
 
-        return filename
+        return file
 
     def get_cindex_library(self):
         try:

--- a/plugin/clang/utils.py
+++ b/plugin/clang/utils.py
@@ -66,7 +66,7 @@ class ClangUtils:
         return None
 
     @staticmethod
-    def try_load_from_user_hint(libclang_path):
+    def get_folder_and_name(libclang_path):
         """Load library hinted by the user.
 
         Args:
@@ -75,12 +75,61 @@ class ClangUtils:
         Returns:
             str: folder of the libclang library or None if not found.
         """
-        if path.exists(libclang_path):
-            return path.dirname(libclang_path)
+        if not path.exists(libclang_path):
+            log.debug("User provided wrong libclang path: '%s'", libclang_path)
+            return None, None
+        if path.isdir(libclang_path):
+            log.debug("User provided folder for libclang: '%s'", libclang_path)
+            return libclang_path, None
+        # The user has provided a file. We will anyway search for the proper
+        # file in the folder that contains this file.
+        log.debug("User provided full libclang path: '%s'", libclang_path)
+        return path.dirname(libclang_path), path.basename(libclang_path)
 
     @staticmethod
-    def find_libclang_dir(clang_binary, libclang_path, version_str):
+    def prepare_search_libclang_cmd(clang_binary, lib_file_name):
+        """Prepare a command that we use to search for libclang paths."""
+        stdin = None
+        stdout = None
+        stderr = None
+        startupinfo = None
+        # let's find the library
+        if platform.system() == "Darwin":
+            # [HACK]: wtf??? why does it not find libclang.dylib?
+            get_library_path_cmd = [clang_binary, "-print-file-name="]
+        elif platform.system() == "Windows":
+            get_library_path_cmd = [clang_binary,
+                                    "-print-prog-name=clang"]
+            # Don't let console window pop-up briefly.
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+            startupinfo.wShowWindow = subprocess.SW_HIDE
+            stdin = subprocess.PIPE
+            stderr = subprocess.PIPE
+        elif platform.system() == "Linux":
+            get_library_path_cmd = [
+                clang_binary, "-print-file-name={}".format(lib_file_name)]
+        return get_library_path_cmd, stdin, stdout, stderr, startupinfo
+
+    @staticmethod
+    def get_all_possible_filenames(version_str):
+        """Get a list of all filename on this system."""
+        current_system = platform.system()
+        possible_filenames = []
+        for suffix in ClangUtils.suffixes[current_system]:
+            for name in ClangUtils.possible_filenames[current_system]:
+                if platform.system() == "Linux":
+                    name = name.replace("$version", version_str)
+                possible_filenames.append(
+                    "{name}{suffix}".format(name=name, suffix=suffix))
+        return possible_filenames
+
+    @staticmethod
+    def find_libclang(clang_binary, libclang_path, version_str):
         """Find directory with libclang.
+
+        We only need the directory here as the filename is set to
+        ClangUtils.libclang_name and is read from cindex files.
 
         Args:
             clang_binary (str): clang binary to call
@@ -89,68 +138,63 @@ class ClangUtils:
             version_str(str): version of libclang to be used in format 3.8.0
         Returns:
             str: folder with libclang
+            str: full path to libclang library
         """
-        stdin = None
-        stderr = None
-        log.debug("platform: %s", platform.architecture())
-        log.debug("python version: %s", platform.python_version())
+        log.debug("Platform: %s, %s", platform.system(),
+                  platform.architecture())
+        log.debug("Python version: %s", platform.python_version())
+        log.debug("User provided libclang_path: '%s'", libclang_path)
+
         current_system = platform.system()
-        log.debug("we are on '%s'", platform.system())
-        log.debug("user provided libclang_path: %s", libclang_path)
-        # Get version string for help finding the proper libclang library on
-        # Linux
+        if current_system == "Linux":
+            # We only care about first two digits on Linux.
+            version_str = version_str[0:3]
+
         if libclang_path:
             # User thinks he knows better. Let him try his luck.
-            libclang_dir = ClangUtils.try_load_from_user_hint(libclang_path)
-            if libclang_dir:
+            user_libclang_dir, libclang_file = ClangUtils.get_folder_and_name(
+                libclang_path)
+            if user_libclang_dir and libclang_file:
                 # It was found! No need to search any further!
-                ClangUtils.libclang_name = path.basename(libclang_path)
-                log.info("using user-provided libclang: '%s'", libclang_path)
-                return libclang_dir
+                log.info("Using user-provided libclang: '%s'", libclang_path)
+                return user_libclang_dir, path.join(
+                    user_libclang_dir, libclang_file)
+
         # If the user hint did not work, we look for it normally
-        if current_system == "Linux":
-            # we only care about first two digits
-            version_str = version_str[0:3]
-        for suffix in ClangUtils.suffixes[current_system]:
-            # pick a name for a file
-            for name in ClangUtils.possible_filenames[current_system]:
-                file = "{name}{suffix}".format(name=name, suffix=suffix)
-                log.debug("searching for: '%s'", file)
-                startupinfo = None
-                # let's find the library
-                if platform.system() == "Darwin":
-                    # [HACK]: wtf??? why does it not find libclang.dylib?
-                    get_library_path_cmd = [clang_binary, "-print-file-name="]
-                elif platform.system() == "Windows":
-                    get_library_path_cmd = [clang_binary,
-                                            "-print-prog-name=clang"]
-                    # Don't let console window pop-up briefly.
-                    startupinfo = subprocess.STARTUPINFO()
-                    startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-                    startupinfo.wShowWindow = subprocess.SW_HIDE
-                    stdin = subprocess.PIPE
-                    stderr = subprocess.PIPE
-                elif platform.system() == "Linux":
-                    file = file.replace("$version", version_str)
-                    get_library_path_cmd = [
-                        clang_binary, "-print-file-name={}".format(file)]
-                output = subprocess.check_output(
-                    get_library_path_cmd,
-                    stdin=stdin,
-                    stderr=stderr,
-                    startupinfo=startupinfo).decode('utf8').strip()
-                log.debug("libclang search output = '%s'", output)
-                if output:
-                    libclang_dir = ClangUtils.dir_from_output(output)
-                    if path.isdir(libclang_dir):
-                        full_libclang_path = path.join(libclang_dir, file)
-                        log.debug("Checking path: %s", full_libclang_path)
-                        if path.exists(full_libclang_path):
-                            log.info("found libclang library file: '%s'",
-                                     full_libclang_path)
-                            ClangUtils.libclang_name = file
-                            return libclang_dir
-                log.warning("Clang could not find '%s'", file)
+        possible_filenames = ClangUtils.get_all_possible_filenames(version_str)
+        for libclang_filename in possible_filenames:
+            log.debug("Searching for: '%s'", libclang_filename)
+            if user_libclang_dir:
+                log.debug("Searching in user provided folder: '%s'",
+                          user_libclang_dir)
+                # User has provided a folder. First search in it.
+                user_hinted_file = path.join(
+                    user_libclang_dir, libclang_filename)
+                if path.exists(user_hinted_file):
+                    # Found valid file in the folder that the user provided.
+                    return user_libclang_dir, user_hinted_file
+
+            log.debug("Generating search folder")
+            get_library_path_cmd, stdin, stdout, stderr, startupinfo = \
+                ClangUtils.prepare_search_libclang_cmd(
+                    clang_binary, libclang_filename)
+            output = subprocess.check_output(
+                get_library_path_cmd,
+                stdin=stdin,
+                stderr=stderr,
+                startupinfo=startupinfo).decode('utf8').strip()
+            log.debug("Libclang search output = '%s'", output)
+            if output:
+                libclang_dir = ClangUtils.dir_from_output(output)
+                if path.isdir(libclang_dir):
+                    full_libclang_path = path.join(
+                        libclang_dir, libclang_filename)
+                    log.debug("Checking path: %s", full_libclang_path)
+                    if path.exists(full_libclang_path):
+                        log.info("Found libclang library file: '%s'",
+                                 full_libclang_path)
+                        return libclang_dir, full_libclang_path
+                log.debug("Clang could not find '%s'", full_libclang_path)
         # if we haven't found anything there is nothing to return
-        log.error("no libclang found at all")
-        return None
+        log.error("No libclang found!")
+        return None, None

--- a/plugin/clang/utils.py
+++ b/plugin/clang/utils.py
@@ -16,13 +16,10 @@ class ClangUtils:
     """Utils to help handling libclang, e.g. searching for it.
 
     Attributes:
-        libclang_name (str): name of the libclang library file
         linux_suffixes (list): suffixes for linux
         osx_suffixes (list): suffixes for osx
         windows_suffixes (list): suffixes for windows
     """
-    libclang_name = None
-
     windows_suffixes = ['.dll', '.lib']
     linux_suffixes = ['.so', '.so.1', '.so.7']
     osx_suffixes = ['.dylib']
@@ -126,10 +123,11 @@ class ClangUtils:
 
     @staticmethod
     def find_libclang(clang_binary, libclang_path, version_str):
-        """Find directory with libclang.
+        """Find libclang.
 
-        We only need the directory here as the filename is set to
-        ClangUtils.libclang_name and is read from cindex files.
+        We either use a user-provided directory/file for libclang or search for
+        one by calling clang_binary with specific parameters. We return both the
+        folder and full path to the found library.
 
         Args:
             clang_binary (str): clang binary to call
@@ -167,7 +165,6 @@ class ClangUtils:
             if user_libclang_dir:
                 log.debug("Searching in user provided folder: '%s'",
                           user_libclang_dir)
-                # User has provided a folder. First search in it.
                 user_hinted_file = path.join(
                     user_libclang_dir, libclang_filename)
                 if path.exists(user_hinted_file):

--- a/plugin/completion/lib_complete.py
+++ b/plugin/completion/lib_complete.py
@@ -107,11 +107,12 @@ class Completer(BaseCompleter):
             # to figure out the path libclang.
             if not self.cindex.Config.loaded:
                 # This will return something like /.../lib/clang/3.x.0
-                libclang_dir = ClangUtils.find_libclang_dir(
+                libclang_dir, libclang_file = ClangUtils.find_libclang(
                     settings.clang_binary,
                     settings.libclang_path,
                     settings.clang_version)
                 if libclang_dir:
+                    self.cindex.Config.set_library_file(libclang_file)
                     self.cindex.Config.set_library_path(libclang_dir)
 
             # check if we can build an index. If not, set valid to false


### PR DESCRIPTION
Before we were handling libclang in a strange way. This PR fixes it.
We now make use of the function `set_library_file` already available in the standard `cindex` modules provided by LLVM. Therefore the `get_filename` function has been reverted to the original code and our function that searches for libclang now returns the full path to the found libclang library.
