### PR TITLE
Remove settings

### DIFF
--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -100,12 +100,6 @@
   // make plugin verbose
   "verbose" : false,
 
-  // add folder with current file with `-I` flag
-  "include_file_folder" : true,
-
-  // add parent folder of the current file's one with `-I` flag
-  "include_file_parent_folder" : true,
-
   // Pick the clang binary used by the plugin. This is used to determine the
   // version of the plugin and pick correct libclang bindings. Note that this
   // should either be a full path to the binary or it should be available in
@@ -193,14 +187,14 @@
     // "{stamp}.mycustomext
   ],
 
-// Controls if we try to retrieve built-in flags from a target compiler. This
-// option is used when we use a `compile_commands.json` file either directly or
-// indirectly e.g. via CMake. If a compiler is not `null`, we try to ask it for
-// the defines and include paths it sets implicitly and pass them to the clang
-// compiler which is used to generate the code completion. If your completions
-// require the knowledge about the toolchain, this option should improve the
-// quality of the completions, however, in some corner cases it might cause
-// completions to fail entirely.
+  // Controls if we try to retrieve built-in flags from a target compiler. This
+  // option is used when we use a `compile_commands.json` file either directly or
+  // indirectly e.g. via CMake. If a compiler is not `null`, we try to ask it for
+  // the defines and include paths it sets implicitly and pass them to the clang
+  // compiler which is used to generate the code completion. If your completions
+  // require the knowledge about the toolchain, this option should improve the
+  // quality of the completions, however, in some corner cases it might cause
+  // completions to fail entirely.
   "target_compilers": {
     "C":              null,
     "CPP":            null,

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -292,24 +292,6 @@ Output lots of additional information in the console. Useful for debugging. Off 
     "verbose" : false,
     ```
 
-### **`include_file_folder`**
-
-Add the folder with current file with `-I` flag.
-
-!!! example "Default value"
-    ```json
-    "include_file_folder" : true,
-    ```
-
-### **`include_file_parent_folder`**
-
-Add the parent folder of the current file's one with `-I` flag
-
-!!! example "Default value"
-    ```json
-    "include_file_parent_folder" : true,
-    ```
-
 ### **`clang_binary`**
 
 

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -73,8 +73,6 @@ class SettingsStorage:
         "header_to_source_mapping",
         "hide_default_completions",
         "ignore_list",
-        "include_file_folder",
-        "include_file_parent_folder",
         "lang_flags",
         "libclang_path",
         "max_cache_age",
@@ -127,7 +125,7 @@ class SettingsStorage:
             # Initialize wildcard values with view.
             self.__update_wildcard_values(view)
             # Replace wildcards in various paths.
-            self.__populate_common_flags(view.file_name())
+            self.__populate_common_flags()
             self.__populate_flags_source_paths()
             self.__update_ignore_list()
             self.libclang_path = self.__replace_wildcard_if_needed(
@@ -263,23 +261,11 @@ class SettingsStorage:
                         self.flags_sources[idx][option][i] =\
                             self.__replace_wildcard_if_needed(entry)
 
-    def __populate_common_flags(self, current_file_name):
-        """Populate the variables inside common_flags with real values.
-
-        Args:
-            current_file_name (str): current view file name
-        """
-        # populate variables to real values
+    def __populate_common_flags(self):
+        """Populate the variables inside common_flags with real values."""
         log.debug("populating common_flags with current variables.")
         for idx, flag in enumerate(self.common_flags):
             self.common_flags[idx] = self.__replace_wildcard_if_needed(flag)
-
-        file_current_folder = path.dirname(current_file_name)
-        if self.include_file_folder:
-            self.common_flags.append("-I" + file_current_folder)
-        file_parent_folder = path.dirname(file_current_folder)
-        if self.include_file_parent_folder:
-            self.common_flags.append("-I" + file_parent_folder)
 
     def __update_ignore_list(self):
         """Populate variables inside flags sources."""

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -22,8 +22,6 @@ class test_settings(GuiTestWrapper):
         manager = SettingsManager()
         settings = manager.user_settings()
         self.assertIsNotNone(settings.verbose)
-        self.assertIsNotNone(settings.include_file_folder)
-        self.assertIsNotNone(settings.include_file_parent_folder)
         self.assertIsNotNone(settings.triggers)
         self.assertIsNotNone(settings.common_flags)
         self.assertIsNotNone(settings.clang_binary)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,10 +1,16 @@
 """Tests for settings."""
 import sublime
+import imp
 
 from os import path
 
-from EasyClangComplete.plugin.settings.settings_manager import SettingsManager
 from EasyClangComplete.tests.gui_test_wrapper import GuiTestWrapper
+
+from EasyClangComplete.plugin.settings import settings_manager
+
+imp.reload(settings_manager)
+
+SettingsManager = settings_manager.SettingsManager
 
 
 class test_settings(GuiTestWrapper):
@@ -64,10 +70,6 @@ class test_settings(GuiTestWrapper):
         settings = manager.settings_for_view(self.view)
         dirs = settings.common_flags
 
-        current_folder = path.dirname(self.view.file_name())
-        parent_folder = path.dirname(current_folder)
         self.assertTrue(len(initial_common_flags) <= len(dirs))
         self.assertTrue(initial_common_flags[0] in dirs)
         self.assertFalse(initial_common_flags[1] in dirs)
-        self.assertTrue(("-I" + current_folder) in dirs)
-        self.assertTrue(("-I" + parent_folder) in dirs)

--- a/tests/test_view_config.py
+++ b/tests/test_view_config.py
@@ -80,7 +80,7 @@ class TestViewConfig(GuiTestWrapper):
         expected = path.join(path.dirname(
             path.dirname(__file__)), 'local_folder')
         # test include folders
-        self.assertEqual(len(view_config.include_folders), 8)
+        self.assertEqual(len(view_config.include_folders), 6)
         self.assertTrue(expected in view_config.include_folders)
 
         # test include flag

--- a/tests/test_view_config.py
+++ b/tests/test_view_config.py
@@ -69,7 +69,7 @@ class TestViewConfig(GuiTestWrapper):
                 return
         completer = view_config.completer
         print(completer.clang_flags)
-        self.assertEqual(len(completer.clang_flags), 14)
+        self.assertEqual(len(completer.clang_flags), 12)
         # test from the start
         self.assertEqual(completer.clang_flags[0], '-c')
         self.assertEqual(completer.clang_flags[1], '-fsyntax-only')

--- a/tests/test_view_config.py
+++ b/tests/test_view_config.py
@@ -84,7 +84,7 @@ class TestViewConfig(GuiTestWrapper):
         self.assertTrue(expected in view_config.include_folders)
 
         # test include flag
-        self.assertEqual(completer.clang_flags[11], '-I' + expected)
+        self.assertEqual(completer.clang_flags[9], '-I' + expected)
 
     def test_unsaved_views(self):
         """Test that we gracefully handle unsaved views."""


### PR DESCRIPTION
- "include_file_folder"
- "include_file_parent_folder"

These settings were introduced in the first days of the plugin before we could work with various flags sources. These flags are redundant now and sometimes are even harmful. Merging this will fix #282 
