### PR TITLE
Fix flag misparse due to trailing newlines in .clang_complete

### DIFF
--- a/plugin/utils/flag.py
+++ b/plugin/utils/flag.py
@@ -79,12 +79,13 @@ class Flag:
         skip_next_entry = False
         log.debug("Tokenizing: %s", all_split_line)
         for i, entry in enumerate(all_split_line):
-            if entry.startswith("#"):
+            sentry = entry.strip()
+            if sentry.startswith("#"):
                 continue
             if skip_next_entry:
                 skip_next_entry = False
                 continue
-            if entry in Flag.SEPARABLE_PREFIXES:
+            if sentry in Flag.SEPARABLE_PREFIXES:
                 # add both this and next part to a flag
                 if (i + 1) < len(all_split_line):
                     flags += Flag.Builder()\
@@ -94,7 +95,7 @@ class Flag:
                     skip_next_entry = True
                     continue
             flags += Flag.Builder()\
-                .from_unparsed_string(entry)\
+                .from_unparsed_string(sentry)\
                 .build_with_expansion(current_folder)
         return flags
 


### PR DESCRIPTION
Seems to be the key error with #564 that broke with the latest release.

This fixes
```
-include
/file/file.h
```
but obviously does not fix the one line case, as `in` will not match with the part after space:
```
-include /file/file.h
```

In my opinion, for the latter the whole thing is best to be rewritten with a more solid tokenization done during file parsing, so I decided not to change it in a quick fix.