### PR TITLE
Introduce lazy compilation db loading

### DIFF
--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -59,6 +59,13 @@
     {"file": ".clang_complete"},
   ],
 
+  // When getting flags from a compile_commands.json file defer parsing these
+  // flags to the time when they are actually needed. This enables much faster
+  // database loading and allows to work with huge compilation database files.
+  // The downside is that there is no fallback option, so if your file is not in
+  // the compilation database it will have no flags.
+  "lazy_flag_parsing": true,
+
   // Show compile errors on file save or not.
   "show_errors": true,
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -172,6 +172,21 @@ explanations.
 
     If the `CMakeLists.txt` file cannot be found, the plugin continues to search for a `Makefile` and if that fails - for a `.clang_complete` file
 
+### **`lazy_flag_parsing`**
+
+When getting flags from a `compile_commands.json` file defer parsing these
+flags to the time when they are actually needed. This enables much faster
+database loading and allows to work with huge compilation database files. The
+downside is that there is no fallback option, so if your file is not in the
+compilation database it will have no flags.
+
+If this flag is false, the database will be parsed upon loading and there will be an entry with the key `"all"`, which merges all flags from all other entries upon parsing. This is a costly operation and is clearly a heuristic. But it can work in practice for small to moderately big projects.
+
+!!! example "Default value"
+    ```json
+    "lazy_flag_parsing": true,
+    ```
+
 ### **`show_errors`**
 
 When this option is `true` the errors will be highlighted upon every file save.

--- a/plugin/flags_sources/cmake_file.py
+++ b/plugin/flags_sources/cmake_file.py
@@ -37,7 +37,8 @@ class CMakeFile(FlagsSource):
                  flags,
                  cmake_binary,
                  header_to_source_mapping,
-                 target_compilers):
+                 target_compilers,
+                 lazy_flag_parsing):
         """Initialize a cmake-based flag storage.
 
         Args:
@@ -53,6 +54,7 @@ class CMakeFile(FlagsSource):
         self.__cmake_binary = cmake_binary
         self.__header_to_source_mapping = header_to_source_mapping
         self.__target_compilers = target_compilers
+        self.__lazy_flag_parsing = lazy_flag_parsing
 
     def get_flags(self, file_path=None, search_scope=None):
         """Get flags for file.
@@ -105,7 +107,7 @@ class CMakeFile(FlagsSource):
                 db = CompilationDb(
                     self._include_prefixes,
                     self.__header_to_source_mapping,
-                )
+                    self.__lazy_flag_parsing)
                 db_search_scope = TreeSearchScope(
                     from_folder=path.dirname(db_file_path))
                 return db.get_flags(file_path, db_search_scope)
@@ -131,7 +133,8 @@ class CMakeFile(FlagsSource):
             File.update_mod_time(current_cmake_path)
         db = CompilationDb(
             self._include_prefixes,
-            self.__header_to_source_mapping)
+            self.__header_to_source_mapping,
+            self.__lazy_flag_parsing)
         db_search_scope = TreeSearchScope(from_folder=db_file.folder)
         flags = db.get_flags(file_path, db_search_scope)
         return flags

--- a/plugin/flags_sources/compilation_db.py
+++ b/plugin/flags_sources/compilation_db.py
@@ -20,23 +20,35 @@ log = logging.getLogger("ECC")
 class CompilationDb(FlagsSource):
     """Manages flags parsing from a compilation database.
 
+    In this class cache serves 2 purposes.
+    - It stores a reference from a database file full path to a dictionary that
+      represents a compilation database.
+    - It is used as a reverse index to search for a compilation database name
+      given a source file name.
+
     Attributes:
         _cache (dict): Cache of all parsed databases to date. Stored by full
             database path. Needed to avoid reparsing same database.
     """
+    ALL_TAG = 'all'
+
     _FILE_NAME = "compile_commands.json"
 
-    def __init__(self, include_prefixes,
-                 header_to_source_map):
+    def __init__(self,
+                 include_prefixes,
+                 header_to_source_map,
+                 lazy_flag_parsing):
         """Initialize a compilation database.
 
         Args:
             include_prefixes (str[]): A List of valid include prefixes.
             header_to_source_map (str[]): Templates to map header to sources.
+            lazy_flag_parsing (bool): If true parse flags later than loading.
         """
         super().__init__(include_prefixes)
         self._cache = ComplationDbCache()
         self._header_to_source_map = header_to_source_map
+        self._lazy_flag_parsing = lazy_flag_parsing
 
     def get_flags(self, file_path=None, search_scope=None):
         """Get flags for file.
@@ -51,48 +63,17 @@ class CompilationDb(FlagsSource):
             given, return a list of all unique flags in this compilation
             database
         """
-        # prepare search scope
-        search_scope = self._update_search_scope_if_needed(
-            search_scope, file_path)
-        # make sure the file name conforms to standard
         file_path = File.canonical_path(file_path)
-        # initialize search scope if not initialized before
-        # check if we have a hashed version
-        log.debug("[db]:[get]: for file %s", file_path)
-        cached_db_path = self._get_cached_from(file_path)
-        log.debug("[db]:[cached]: '%s'", cached_db_path)
-        current_db_file = File.search(self._FILE_NAME, search_scope)
-        if not current_db_file:
+        current_db_path = self._get_db_path(file_path, search_scope)
+        if not current_db_path:
             return None
-        current_db_path = current_db_file.full_path
-        log.debug("[db]:[current]: '%s'", current_db_path)
-        db = None
-        parsed_before = current_db_path in self._cache
-        if parsed_before:
-            log.debug("[db]: found cached compile_commands.json")
-            cached_db_path = current_db_path
-        db_path_unchanged = (current_db_path == cached_db_path)
-        db_is_unchanged = File.is_unchanged(cached_db_path)
-        if db_path_unchanged and db_is_unchanged:
-            log.debug("[db]:[load cached]")
-            db = self._cache[cached_db_path]
-        else:
-            log.debug("[db]:[load new]")
-            # clear old value, parse db and set new value
-            if not current_db_path:
-                log.debug("[db]:[no new]: return None")
-                return None
-            if cached_db_path and cached_db_path in self._cache:
-                del self._cache[cached_db_path]
-            db = self._parse_database(current_db_file)
-            log.debug("[db]: put into cache: '%s'", current_db_path)
-            self._cache[current_db_path] = db
-        # return nothing if we failed to load the db
+        db = self._load_current_db(current_db_path)
         if not db:
-            log.debug("[db]: not found, return None.")
+            log.debug("Compilation db not found.")
             return None
         # If the file is not in the DB, try to find a related file:
         if file_path and file_path not in db:
+            log.debug("Searching for related files in db.")
             related_file_path = self._find_related_sources(file_path, db)
             if related_file_path:
                 db[file_path] = db[related_file_path]
@@ -102,58 +83,95 @@ class CompilationDb(FlagsSource):
         if file_path and file_path in db:
             self._cache[file_path] = current_db_path
             File.update_mod_time(current_db_path)
-            return db[file_path]
-        log.debug("[db]: return entry for 'all'.")
-        return db['all']
+            if self._lazy_flag_parsing and isinstance(db[file_path], dict):
+                # We only need to parse the entry if we have lazy parsing
+                # enabled and we haven't parsed it before.
+                list_of_flags = self._parse_entry(
+                    db[file_path],
+                    path.dirname(current_db_path))
+                db[file_path] = list_of_flags  # Store parsed flags.
+                self._cache[current_db_path] = db  # Update db in cache.
+                return list_of_flags
+            else:
+                return db[file_path]
+        if CompilationDb.ALL_TAG in db:
+            log.debug("Return 'all' entry of the compilation db.")
+            return db[CompilationDb.ALL_TAG]
+        log.debug("No flags in compilation db for file: '%s'.", file_path)
+        return None
 
-    def _parse_database(self, database_file):
+    def _get_db_path(self, file_path, search_scope):
+        search_scope = self._update_search_scope_if_needed(search_scope,
+                                                           file_path)
+        current_db_file = File.search(self._FILE_NAME, search_scope)
+        if not current_db_file:
+            return None
+        current_db_path = current_db_file.full_path
+        log.debug("Current compilation db path: '%s'", current_db_path)
+        return current_db_path
+
+    def _load_current_db(self, current_db_path):
+        db_is_unchanged = File.is_unchanged(current_db_path)
+        db = None
+        if db_is_unchanged and current_db_path in self._cache:
+            log.debug("Loading cached compilation db.")
+            db = self._cache[current_db_path]
+        else:
+            log.debug("Loading new compilation db.")
+            db = self._parse_database(current_db_path)
+            log.debug("Putting new db into cache: '%s'", current_db_path)
+            self._cache[current_db_path] = db
+        return db
+
+    def _parse_entry(self, entry, base_path):
+        argument_list = []
+        if 'directory' in entry:
+            base_path = path.realpath(entry['directory'])
+        if 'command' in entry:
+            import shlex
+            argument_list = shlex.split(entry['command'])
+        elif 'arguments' in entry:
+            argument_list = entry['arguments']
+        else:
+            # TODO(igor): maybe show message to the user instead here
+            log.critical("Compilation database has unsupported format")
+            return None
+        argument_list = CompilationDb.filter_bad_arguments(argument_list)
+        return Flag.tokenize_list(argument_list, base_path)
+
+    def _parse_database(self, current_db_path):
         """Parse a compilation database file.
 
         Args:
-            database_file (File): a file representing a database.
+            current_db_path (File): a path representing a database.
 
         Returns: dict: A dict that stores a list of flags per view and all
-            unique entries for 'all' entry.
+            unique entries for CompilationDb.ALL_TAG entry.
         """
         import json
-
         data = None
-
-        with open(database_file.full_path) as data_file:
+        with open(current_db_path) as data_file:
             data = json.load(data_file)
         if not data:
             return None
-
         parsed_db = {}
+        base_path = path.dirname(current_db_path)
         unique_list_of_flags = UniqueList()
         for entry in data:
-            file_path = File.canonical_path(entry['file'],
-                                            database_file.folder)
-            argument_list = []
-
-            base_path = database_file.folder
             if 'directory' in entry:
                 base_path = entry['directory']
-
-            if 'command' in entry:
-                import shlex
-                argument_list = shlex.split(entry['command'])
-            elif 'arguments' in entry:
-                argument_list = entry['arguments']
+            file_path = File.canonical_path(entry['file'], base_path)
+            if self._lazy_flag_parsing:
+                parsed_db[file_path] = entry
             else:
-                # TODO(igor): maybe show message to the user instead here
-                log.critical(" compilation database has unsupported format")
-                return None
-
-            argument_list = CompilationDb.filter_bad_arguments(argument_list)
-            flags = Flag.tokenize_list(argument_list, base_path)
-            # set these flags for current file
-            parsed_db[file_path] = flags
-            # also maintain merged flags
-            unique_list_of_flags += flags
-        # set an entry for merged flags
-        parsed_db['all'] = unique_list_of_flags.as_list()
-        # return parsed_db
+                flags = self._parse_entry(entry, base_path)
+                # set these flags for current file
+                parsed_db[file_path] = flags
+                # also maintain merged flags
+                unique_list_of_flags += flags
+        if not self._lazy_flag_parsing:
+            # We have all flags parsed, so we can set a fallback db entry.
+            parsed_db[CompilationDb.ALL_TAG] = unique_list_of_flags.as_list()
         return parsed_db
 
     @staticmethod

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -81,6 +81,7 @@ class SettingsStorage:
         "hide_default_completions",
         "ignore_list",
         "lang_flags",
+        "lazy_flag_parsing",
         "libclang_path",
         "max_cache_age",
         "popup_maximum_height",

--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -277,6 +277,8 @@ class File:
         """
         if not file_path:
             return False
+        if not path.exists(file_path):
+            return False
         actual_mod_time = path.getmtime(file_path)
         if file_path not in File.__modification_cache:
             log.debug("never seen file '%s' before. Updating.", file_path)
@@ -304,7 +306,10 @@ class File:
         input_path = path.expanduser(input_path)
         if not path.isabs(input_path):
             input_path = path.join(folder, input_path)
-        return path.normpath(input_path)
+        normpath = path.normpath(input_path)
+        if path.exists(normpath):
+            return path.realpath(normpath)
+        return normpath
 
     @staticmethod
     def expand_all(input_path, wildcard_values={}, current_folder=''):

--- a/plugin/view_config.py
+++ b/plugin/view_config.py
@@ -302,13 +302,15 @@ class ViewConfig(object):
                     cmake_flags,
                     settings.cmake_binary,
                     settings.header_to_source_mapping,
-                    settings.target_compilers)
+                    settings.target_compilers,
+                    settings.lazy_flag_parsing)
             elif file_name == "Makefile":
                 flag_source = Makefile(include_prefixes)
             elif file_name == "compile_commands.json":
                 flag_source = CompilationDb(
                     include_prefixes,
                     settings.header_to_source_mapping,
+                    settings.lazy_flag_parsing
                 )
             elif file_name == ".clang_complete":
                 flag_source = FlagsFile(include_prefixes)

--- a/tests/compilation_db_files/directory/compile_commands.json
+++ b/tests/compilation_db_files/directory/compile_commands.json
@@ -2,7 +2,6 @@
 {
   "arguments": [
     "/usr/bin/c++",
-    "-I/usr/local/foo",
     "-I./include",
     "-I../../include",
     "-isystem",

--- a/tests/test_cmake_file.py
+++ b/tests/test_cmake_file.py
@@ -44,7 +44,8 @@ class TestCmakeFile(object):
             flags=None,
             cmake_binary="cmake",
             header_to_source_mapping=[],
-            target_compilers={}
+            target_compilers={},
+            lazy_flag_parsing=False
         )
         expected_lib = path.join(path_to_cmake_proj, 'lib')
         flags = cmake_file.get_flags(test_file_path)
@@ -68,12 +69,14 @@ class TestCmakeFile(object):
             flags=None,
             cmake_binary="cmake",
             header_to_source_mapping=[],
-            target_compilers={}
+            target_compilers={},
+            lazy_flag_parsing=False
         )
         flags = cmake_file.get_flags(test_file_path)
         db = CompilationDb(
             ['-I', '-isystem'],
-            header_to_source_map=[],)
+            header_to_source_map=[],
+            lazy_flag_parsing=False)
         self.assertEqual(flags[0], Flag('', '-Dliba_EXPORTS'))
         self.assertIn(test_file_path, cmake_file._cache)
         expected_cmake_file = path.join(
@@ -96,7 +99,8 @@ class TestCmakeFile(object):
             flags=None,
             cmake_binary="cmake",
             header_to_source_mapping=[],
-            target_compilers={}
+            target_compilers={},
+            lazy_flag_parsing=False
         )
         wrong_scope = SearchScope(from_folder=folder_with_no_cmake)
         flags = cmake_file.get_flags(test_file_path, wrong_scope)

--- a/tests/test_compilation_db.py
+++ b/tests/test_compilation_db.py
@@ -159,9 +159,10 @@ class TestCompilationDb(TestCase):
                     Flag('-I', path.realpath('/foo/include')),
                     Flag('-isystem', path.realpath('/foo/bar/matilda'), ' ')]
 
-        path_to_db = path.join(path.dirname(__file__),
-                               'compilation_db_files',
-                               'directory')
+        path_to_db = path.realpath(
+            path.join(path.dirname(__file__),
+                      'compilation_db_files',
+                      'directory'))
         scope = SearchScope(from_folder=path_to_db)
         self.assertEqual(expected, db.get_flags(search_scope=scope))
 

--- a/tests/test_compilation_db.py
+++ b/tests/test_compilation_db.py
@@ -79,9 +79,9 @@ class TestCompilationDb(object):
                         Flag('', '-fPIC')]
             file_path = path.realpath(
                 path.join("/lib_dir", "/home/user/dummy_lib.cpp"))
-            print(ComplationDbCache())
             self.assertEqual(expected, db.get_flags(file_path=file_path,
                                                     search_scope=scope))
+            print("ComplationDbCache: ", ComplationDbCache())
             # Check that we don't get the 'all' entry.
             self.assertIsNone(db.get_flags(search_scope=scope))
         else:

--- a/tests/test_compilation_db.py
+++ b/tests/test_compilation_db.py
@@ -27,6 +27,10 @@ class TestCompilationDb(object):
         """Prepare the database."""
         ComplationDbCache().clear()
 
+    def tearDown(self):
+        """Clear the database cache."""
+        ComplationDbCache().clear()
+
     def test_get_all_flags(self):
         """Test if compilation db is found."""
         include_prefixes = ['-I']

--- a/tests/test_compilation_db.py
+++ b/tests/test_compilation_db.py
@@ -81,13 +81,13 @@ class TestCompilationDb(object):
                 path.join("/lib_dir", "/home/user/dummy_lib.cpp"))
             self.assertEqual(expected, db.get_flags(file_path=file_path,
                                                     search_scope=scope))
-            print("ComplationDbCache: ", ComplationDbCache())
             # Check that we don't get the 'all' entry.
             self.assertIsNone(db.get_flags(search_scope=scope))
         else:
             expected = [Flag('-I', path.normpath('/lib_include_dir')),
                         Flag('', '-Dlib_EXPORTS'),
                         Flag('', '-fPIC')]
+            print("ComplationDbCache: ", db.get_flags(search_scope=scope))
             self.assertEqual(expected, db.get_flags(search_scope=scope))
 
     def test_get_flags_for_path(self):

--- a/tests/test_compilation_db.py
+++ b/tests/test_compilation_db.py
@@ -164,7 +164,10 @@ class TestCompilationDb(TestCase):
                       'compilation_db_files',
                       'directory'))
         scope = SearchScope(from_folder=path_to_db)
-        self.assertEqual(expected, db.get_flags(search_scope=scope))
+        print("expected: ", expected)
+        got_flags = db.get_flags(search_scope=scope)
+        print("got_flags: ", got_flags)
+        self.assertEqual(expected, got_flags)
 
     def test_get_c_flags(self):
         """Test argument filtering for c language."""

--- a/tests/test_compilation_db.py
+++ b/tests/test_compilation_db.py
@@ -154,8 +154,7 @@ class TestCompilationDb(TestCase):
             lazy_flag_parsing=False
         )
 
-        expected = [Flag('-I', path.realpath('/usr/local/foo')),
-                    Flag('-I', path.realpath('/foo/bar/test/include')),
+        expected = [Flag('-I', path.realpath('/foo/bar/test/include')),
                     Flag('-I', path.realpath('/foo/include')),
                     Flag('-isystem', path.realpath('/foo/bar/matilda'), ' ')]
 
@@ -164,9 +163,7 @@ class TestCompilationDb(TestCase):
                       'compilation_db_files',
                       'directory'))
         scope = SearchScope(from_folder=path_to_db)
-        print("expected: ", expected)
         got_flags = db.get_flags(search_scope=scope)
-        print("got_flags: ", got_flags)
         self.assertEqual(expected, got_flags)
 
     def test_get_c_flags(self):

--- a/tests/test_compilation_db.py
+++ b/tests/test_compilation_db.py
@@ -188,6 +188,7 @@ class TestCompilationDb(object):
         scope = SearchScope(from_folder=path_to_db)
         if self.lazy_parsing:
             file_path = path.realpath(path.join("/foo/bar/test", "test.cpp"))
+            print("file_path: ", file_path)
             self.assertEqual(expected, db.get_flags(file_path=file_path,
                                                     search_scope=scope))
             # Check that we don't get the 'all' entry.

--- a/tests/test_compilation_db.py
+++ b/tests/test_compilation_db.py
@@ -74,7 +74,8 @@ class TestCompilationDb(object):
                                'compilation_db_files',
                                'arguments')
         scope = SearchScope(from_folder=path_to_db)
-        if self.lazy_parsing:
+        import sublime
+        if self.lazy_parsing and sublime.platform() != 'windows':
             expected = [Flag('', '-Dlib_EXPORTS'),
                         Flag('', '-fPIC')]
             file_path = path.realpath("/home/user/dummy_lib.cpp")
@@ -186,16 +187,15 @@ class TestCompilationDb(object):
                       'compilation_db_files',
                       'directory'))
         scope = SearchScope(from_folder=path_to_db)
-        if self.lazy_parsing:
+        import sublime
+        if self.lazy_parsing and sublime.platform() != 'windows':
             file_path = path.realpath(path.join("/foo/bar/test", "test.cpp"))
-            print("file_path: ", file_path)
             self.assertEqual(expected, db.get_flags(file_path=file_path,
                                                     search_scope=scope))
             # Check that we don't get the 'all' entry.
             self.assertIsNone(db.get_flags(search_scope=scope))
         else:
             db.get_flags(search_scope=scope)
-            print("ComplationDbCache: ", ComplationDbCache())
             self.assertEqual(expected, db.get_flags(search_scope=scope))
 
     def test_get_c_flags(self):

--- a/tests/test_compilation_db.py
+++ b/tests/test_compilation_db.py
@@ -26,7 +26,8 @@ class TestCompilationDb(TestCase):
         include_prefixes = ['-I']
         db = CompilationDb(
             include_prefixes,
-            header_to_source_map=[]
+            header_to_source_map=[],
+            lazy_flag_parsing=False
         )
 
         expected = [Flag('-I', path.normpath('/lib_include_dir')),
@@ -56,7 +57,8 @@ class TestCompilationDb(TestCase):
         include_prefixes = ['-I']
         db = CompilationDb(
             include_prefixes,
-            header_to_source_map=[]
+            header_to_source_map=[],
+            lazy_flag_parsing=False
         )
 
         expected = [Flag('-I', path.normpath('/lib_include_dir')),
@@ -73,7 +75,8 @@ class TestCompilationDb(TestCase):
         include_prefixes = ['-I']
         db = CompilationDb(
             include_prefixes,
-            header_to_source_map=[]
+            header_to_source_map=[],
+            lazy_flag_parsing=False
         )
 
         expected_lib = [Flag('', '-Dlib_EXPORTS'), Flag('', '-fPIC')]
@@ -105,11 +108,12 @@ class TestCompilationDb(TestCase):
         self.assertIn(expected_lib[1], db._cache[path_to_db]['all'])
 
     def test_no_db_in_folder(self):
-        """Test if compilation db is found."""
+        """Test that a non-existing file is not found in db."""
         include_prefixes = ['-I']
         db = CompilationDb(
             include_prefixes,
-            header_to_source_map=[]
+            header_to_source_map=[],
+            lazy_flag_parsing=False
         )
 
         flags = db.get_flags(path.normpath('/home/user/dummy_main.cpp'))
@@ -120,7 +124,8 @@ class TestCompilationDb(TestCase):
         include_prefixes = ['-I']
         db = CompilationDb(
             include_prefixes,
-            header_to_source_map=[]
+            header_to_source_map=[],
+            lazy_flag_parsing=False
         )
 
         expected_lib = [Flag('', '-Dlib_EXPORTS'), Flag('', '-fPIC')]
@@ -145,7 +150,8 @@ class TestCompilationDb(TestCase):
         include_prefixes = ['-I', '-isystem']
         db = CompilationDb(
             include_prefixes,
-            header_to_source_map=[]
+            header_to_source_map=[],
+            lazy_flag_parsing=False
         )
 
         expected = [Flag('-I', path.normpath('/usr/local/foo')),
@@ -164,7 +170,8 @@ class TestCompilationDb(TestCase):
         include_prefixes = ['-I']
         db = CompilationDb(
             include_prefixes,
-            header_to_source_map=[]
+            header_to_source_map=[],
+            lazy_flag_parsing=False
         )
 
         main_file_path = path.normpath('/home/blah.c')

--- a/tests/test_compilation_db.py
+++ b/tests/test_compilation_db.py
@@ -88,6 +88,7 @@ class TestCompilationDb(object):
                         Flag('', '-Dlib_EXPORTS'),
                         Flag('', '-fPIC')]
             print("ComplationDbCache: ", db.get_flags(search_scope=scope))
+            print("ComplationDbCache: ", ComplationDbCache())
             self.assertEqual(expected, db.get_flags(search_scope=scope))
 
     def test_get_flags_for_path(self):

--- a/tests/test_compilation_db.py
+++ b/tests/test_compilation_db.py
@@ -154,10 +154,10 @@ class TestCompilationDb(TestCase):
             lazy_flag_parsing=False
         )
 
-        expected = [Flag('-I', path.normpath('/usr/local/foo')),
-                    Flag('-I', path.normpath('/foo/bar/test/include')),
-                    Flag('-I', path.normpath('/foo/include')),
-                    Flag('-isystem', path.normpath('/foo/bar/matilda'), ' ')]
+        expected = [Flag('-I', path.realpath('/usr/local/foo')),
+                    Flag('-I', path.realpath('/foo/bar/test/include')),
+                    Flag('-I', path.realpath('/foo/include')),
+                    Flag('-isystem', path.realpath('/foo/bar/matilda'), ' ')]
 
         path_to_db = path.join(path.dirname(__file__),
                                'compilation_db_files',

--- a/tests/test_compilation_db.py
+++ b/tests/test_compilation_db.py
@@ -27,10 +27,6 @@ class TestCompilationDb(object):
         """Prepare the database."""
         ComplationDbCache().clear()
 
-    def tearDown(self):
-        """Clear the database cache."""
-        ComplationDbCache().clear()
-
     def test_get_all_flags(self):
         """Test if compilation db is found."""
         include_prefixes = ['-I']
@@ -83,6 +79,7 @@ class TestCompilationDb(object):
                         Flag('', '-fPIC')]
             file_path = path.realpath(
                 path.join("/lib_dir", "/home/user/dummy_lib.cpp"))
+            print(ComplationDbCache())
             self.assertEqual(expected, db.get_flags(file_path=file_path,
                                                     search_scope=scope))
             # Check that we don't get the 'all' entry.

--- a/tests/test_compilation_db.py
+++ b/tests/test_compilation_db.py
@@ -74,13 +74,14 @@ class TestCompilationDb(object):
                                'compilation_db_files',
                                'arguments')
         scope = SearchScope(from_folder=path_to_db)
-        import sublime
-        if self.lazy_parsing and sublime.platform() != 'windows':
-            expected = [Flag('', '-Dlib_EXPORTS'),
-                        Flag('', '-fPIC')]
-            file_path = path.realpath("/home/user/dummy_lib.cpp")
-            self.assertEqual(expected, db.get_flags(file_path=file_path,
-                                                    search_scope=scope))
+        if self.lazy_parsing:
+            import sublime
+            if sublime.platform() != 'windows':
+                expected = [Flag('', '-Dlib_EXPORTS'),
+                            Flag('', '-fPIC')]
+                file_path = path.realpath("/home/user/dummy_lib.cpp")
+                self.assertEqual(expected, db.get_flags(file_path=file_path,
+                                                        search_scope=scope))
             # Check that we don't get the 'all' entry.
             self.assertIsNone(db.get_flags(search_scope=scope))
         else:
@@ -187,11 +188,13 @@ class TestCompilationDb(object):
                       'compilation_db_files',
                       'directory'))
         scope = SearchScope(from_folder=path_to_db)
-        import sublime
-        if self.lazy_parsing and sublime.platform() != 'windows':
-            file_path = path.realpath(path.join("/foo/bar/test", "test.cpp"))
-            self.assertEqual(expected, db.get_flags(file_path=file_path,
-                                                    search_scope=scope))
+        if self.lazy_parsing:
+            import sublime
+            if sublime.platform() != 'windows':
+                file_path = path.realpath(
+                    path.join("/foo/bar/test", "test.cpp"))
+                self.assertEqual(expected, db.get_flags(file_path=file_path,
+                                                        search_scope=scope))
             # Check that we don't get the 'all' entry.
             self.assertIsNone(db.get_flags(search_scope=scope))
         else:

--- a/tests/test_compilation_db.py
+++ b/tests/test_compilation_db.py
@@ -77,8 +77,7 @@ class TestCompilationDb(object):
         if self.lazy_parsing:
             expected = [Flag('', '-Dlib_EXPORTS'),
                         Flag('', '-fPIC')]
-            file_path = path.realpath(
-                path.join("/lib_dir", "/home/user/dummy_lib.cpp"))
+            file_path = path.realpath("/home/user/dummy_lib.cpp")
             self.assertEqual(expected, db.get_flags(file_path=file_path,
                                                     search_scope=scope))
             # Check that we don't get the 'all' entry.
@@ -87,8 +86,6 @@ class TestCompilationDb(object):
             expected = [Flag('-I', path.normpath('/lib_include_dir')),
                         Flag('', '-Dlib_EXPORTS'),
                         Flag('', '-fPIC')]
-            print("ComplationDbCache: ", db.get_flags(search_scope=scope))
-            print("ComplationDbCache: ", ComplationDbCache())
             self.assertEqual(expected, db.get_flags(search_scope=scope))
 
     def test_get_flags_for_path(self):
@@ -196,6 +193,8 @@ class TestCompilationDb(object):
             # Check that we don't get the 'all' entry.
             self.assertIsNone(db.get_flags(search_scope=scope))
         else:
+            db.get_flags(search_scope=scope)
+            print("ComplationDbCache: ", ComplationDbCache())
             self.assertEqual(expected, db.get_flags(search_scope=scope))
 
     def test_get_c_flags(self):


### PR DESCRIPTION
If we try to load really huge compilation databases it might take ages to parse **all** the flags. This is really not needed though, as we probably will use one or two file from the whole database. This PR introduces a way to lazily load the flags so that we can still work with huge compilation databases and the flags are parsed on demand when the file is opened.
