### PR TITLE
Spelling filters

### DIFF
--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -580,7 +580,7 @@ class EasyClangComplete(sublime_plugin.EventListener):
                 name=ThreadJob.COMPLETE_TAG,
                 callback=self.completion_finished,
                 function=config_manager.trigger_completion,
-                args=[view, completion_request])
+                args=[view, completion_request, settings])
             EasyClangComplete.thread_pool.new_job(job)
         elif pos_status == PosStatus.COMPLETE_INCLUDES:
             log.debug("Completing includes")

--- a/dependencies.json
+++ b/dependencies.json
@@ -7,7 +7,8 @@
             "python-jinja2",
             "markupsafe",
             "pymdownx",
-            "pyyaml"
+            "pyyaml",
+            "regex"
         ]
     }
 }

--- a/plugin/completion/base_complete.py
+++ b/plugin/completion/base_complete.py
@@ -47,11 +47,12 @@ class BaseCompleter:
         # Store the latest errors here
         self.latest_errors = None
 
-    def complete(self, completion_request):
+    def complete(self, completion_request, settings):
         """Generate completions. See children for implementation.
 
         Args:
             completion_request (ActionRequest): request object
+            settings: all plugin settings
 
         Raises:
             NotImplementedError: Guarantees we do not call this abstract method

--- a/plugin/completion/bin_complete.py
+++ b/plugin/completion/bin_complete.py
@@ -95,7 +95,7 @@ class Completer(BaseCompleter):
         else:
             self.compiler_variant = ClangCompilerVariant()
 
-    def complete(self, completion_request):
+    def complete(self, completion_request, settings):
         """Create a list of autocompletions. Called asynchronously.
 
         It builds up a clang command that is then executed
@@ -110,7 +110,7 @@ class Completer(BaseCompleter):
         end = time.time()
         log.debug("code complete done in %s seconds", end - start)
 
-        completions = Completer._parse_completions(raw_complete)
+        completions = Completer._parse_completions(raw_complete, settings)
         log.debug('completions: %s' % completions)
         return (completion_request, completions)
 
@@ -205,11 +205,12 @@ class Completer(BaseCompleter):
         return Tools.run_command(complete_cmd)
 
     @staticmethod
-    def _parse_completions(complete_results):
+    def _parse_completions(complete_results, settings):
         """Create snippet-like structures from a list of completions.
 
         Args:
             complete_results (list): raw completions list
+            settings: all plugin settings
 
         Returns:
             list: updated completions
@@ -285,5 +286,8 @@ class Completer(BaseCompleter):
             hint = re.sub(Completer.compl_content_regex,
                           Parser.make_pretty,
                           comp_dict['content'])
+            hint = Tools.filter_spelling(hint, settings.spelling_filters)
+            contents = Tools.filter_spelling(contents,
+                                             settings.spelling_filters)
             completions.append([trigger + "\t" + hint, contents])
         return completions

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -91,6 +91,7 @@ class SettingsStorage:
         "show_index_references",
         "show_type_body",
         "show_type_info",
+        "spelling_filters",
         "target_compilers",
         "triggers",
         "use_default_includes",

--- a/plugin/tools.py
+++ b/plugin/tools.py
@@ -784,3 +784,21 @@ class Tools:
             if flag.startswith(prefix):
                 return idx
         return None
+
+    @staticmethod
+    def filter_spelling(string, filters):
+        """Run the string through the user-defined spelling filters."""
+        # use the regex module instead of re if available
+        import re
+        sub = re.sub
+        try:
+            import regex
+            sub = regex.sub
+        except ImportError:
+            pass
+
+        # apply all filters
+        for f in filters:
+            string = sub(f["pattern"], f["replace"], string)
+
+        return string

--- a/plugin/view_config.py
+++ b/plugin/view_config.py
@@ -535,7 +535,7 @@ class ViewConfigManager(object):
             return tooltip_request, ""
         return config.completer.info(tooltip_request, settings)
 
-    def trigger_completion(self, view, completion_request):
+    def trigger_completion(self, view, completion_request, settings):
         """Get completions.
 
         This function is needed to ensure that python can get everything
@@ -543,7 +543,7 @@ class ViewConfigManager(object):
         to an async task. This left a reference to a completer forever active.
         """
         view_config = self.get_from_cache(view)
-        return view_config.completer.complete(completion_request)
+        return view_config.completer.complete(completion_request, settings)
 
     def __run_timer(self):
         """We make sure we run a single thread."""

--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -57,7 +57,7 @@ class BaseTestCompleter(object):
         view_config_manager = ViewConfigManager()
         view_config = view_config_manager.load_for_view(self.view, settings)
         completer = view_config.completer
-        return completer
+        return completer, settings
 
     def tear_down_completer(self):
         """Tear down completer for the current view.
@@ -81,7 +81,7 @@ class BaseTestCompleter(object):
                               'test_files',
                               'test.cpp')
         self.set_up_view(file_name)
-        completer = self.set_up_completer()
+        completer, _ = self.set_up_completer()
 
         self.assertIsNotNone(completer.version_str)
         self.tear_down_completer()
@@ -93,7 +93,7 @@ class BaseTestCompleter(object):
                               'test.cpp')
         self.set_up_view(file_name)
 
-        completer = self.set_up_completer()
+        completer, settings = self.set_up_completer()
 
         # Check the current cursor position is completable.
         self.assertEqual(self.get_row(8), "  a.")
@@ -103,7 +103,7 @@ class BaseTestCompleter(object):
 
         # Load the completions.
         request = ActionRequest(self.view, pos)
-        (_, completions) = completer.complete(request)
+        (_, completions) = completer.complete(request, settings)
 
         # Verify that we got the expected completions back.
         self.assertIsNotNone(completions)
@@ -119,7 +119,7 @@ class BaseTestCompleter(object):
                               'test.cpp')
         self.set_up_view(file_name)
 
-        completer = self.set_up_completer()
+        completer, settings = self.set_up_completer()
 
         # Check the current cursor position is completable.
         self.assertEqual(self.get_row(8), "  a.")
@@ -129,7 +129,7 @@ class BaseTestCompleter(object):
 
         # Load the completions.
         request = ActionRequest(self.view, pos)
-        (_, completions) = completer.complete(request)
+        (_, completions) = completer.complete(request, settings)
 
         # Verify that we got the expected completions back.
         self.assertIsNotNone(completions)
@@ -147,7 +147,7 @@ class BaseTestCompleter(object):
                               'test.cpp')
         self.set_up_view(file_name)
 
-        completer = self.set_up_completer()
+        completer, settings = self.set_up_completer()
 
         # Check the current cursor position is completable.
         self.assertEqual(self.get_row(8), "  a.")
@@ -157,7 +157,7 @@ class BaseTestCompleter(object):
 
         # Load the completions.
         request = ActionRequest(self.view, pos)
-        (_, completions) = completer.complete(request)
+        (_, completions) = completer.complete(request, settings)
 
         # Verify that we got the expected completions back.
         self.assertIsNotNone(completions)
@@ -175,7 +175,7 @@ class BaseTestCompleter(object):
                               'test_vector.cpp')
         self.set_up_view(file_name)
 
-        completer = self.set_up_completer()
+        completer, settings = self.set_up_completer()
 
         # Check the current cursor position is completable.
         self.assertEqual(self.get_row(3), "  vec.")
@@ -185,7 +185,7 @@ class BaseTestCompleter(object):
 
         # Load the completions.
         request = ActionRequest(self.view, pos)
-        (_, completions) = completer.complete(request)
+        (_, completions) = completer.complete(request, settings)
 
         # Verify that we got the expected completions back.
         self.assertIsNotNone(completions)
@@ -202,7 +202,7 @@ class BaseTestCompleter(object):
                               'test_property.m')
         self.set_up_view(file_name)
 
-        completer = self.set_up_completer()
+        completer, settings = self.set_up_completer()
 
         # Check the current cursor position is completable.
         self.assertEqual(self.get_row(6), "  foo.")
@@ -212,7 +212,7 @@ class BaseTestCompleter(object):
 
         # Load the completions.
         request = ActionRequest(self.view, pos)
-        (_, completions) = completer.complete(request)
+        (_, completions) = completer.complete(request, settings)
 
         # Verify that we got the expected completions back.
         self.assertIsNotNone(completions)
@@ -229,7 +229,7 @@ class BaseTestCompleter(object):
                               'test_void_method.m')
         self.set_up_view(file_name)
 
-        completer = self.set_up_completer()
+        completer, settings = self.set_up_completer()
 
         # Check the current cursor position is completable.
         self.assertEqual(self.get_row(6), "  [foo ")
@@ -239,7 +239,7 @@ class BaseTestCompleter(object):
 
         # Load the completions.
         request = ActionRequest(self.view, pos)
-        (_, completions) = completer.complete(request)
+        (_, completions) = completer.complete(request, settings)
 
         # Verify that we got the expected completions back.
         self.assertIsNotNone(completions)
@@ -256,7 +256,7 @@ class BaseTestCompleter(object):
                               'test_method_one_parameter.m')
         self.set_up_view(file_name)
 
-        completer = self.set_up_completer()
+        completer, settings = self.set_up_completer()
 
         # Check the current cursor position is completable.
         self.assertEqual(self.get_row(6), "  [foo ")
@@ -266,7 +266,7 @@ class BaseTestCompleter(object):
 
         # Load the completions.
         request = ActionRequest(self.view, pos)
-        (_, completions) = completer.complete(request)
+        (_, completions) = completer.complete(request, settings)
 
         # Verify that we got the expected completions back.
         self.assertIsNotNone(completions)
@@ -284,7 +284,7 @@ class BaseTestCompleter(object):
                               'test_method_two_parameters.m')
         self.set_up_view(file_name)
 
-        completer = self.set_up_completer()
+        completer, settings = self.set_up_completer()
 
         # Check the current cursor position is completable.
         self.assertEqual(self.get_row(6), "  [foo ")
@@ -294,7 +294,7 @@ class BaseTestCompleter(object):
 
         # Load the completions.
         request = ActionRequest(self.view, pos)
-        (_, completions) = completer.complete(request)
+        (_, completions) = completer.complete(request, settings)
 
         # Verify that we got the expected completions back.
         self.assertIsNotNone(completions)
@@ -314,7 +314,7 @@ class BaseTestCompleter(object):
                               'test_objective_cpp.mm')
         self.set_up_view(file_name)
 
-        completer = self.set_up_completer()
+        completer, settings = self.set_up_completer()
 
         # Check the current cursor position is completable.
         self.assertEqual(self.get_row(3), "  str.")
@@ -324,7 +324,7 @@ class BaseTestCompleter(object):
 
         # Load the completions.
         request = ActionRequest(self.view, pos)
-        (_, completions) = completer.complete(request)
+        (_, completions) = completer.complete(request, settings)
 
         # Verify that we got the expected completions back.
         self.assertIsNotNone(completions)
@@ -375,7 +375,7 @@ class BaseTestCompleter(object):
                               'test_location.cpp')
         self.set_up_view(file_name)
 
-        completer = self.set_up_completer()
+        completer, _ = self.set_up_completer()
 
         # Check the current cursor position is completable.
         row = 9


### PR DESCRIPTION
These filters are applied to all completions and info popups. I have used them for some time now and find them very useful to make completions more readable. For example in my environment I strip the `__cxx11` namespace, rename `basic_string` to `string`, and remove some other stuff I don't care to see.

There still may be some small bugs but if you would like to integrate this, I can add some more documentation and tests.