### PR TITLE
plugin/clang: add clang 8 SONAME for Linux

### DIFF
--- a/plugin/clang/utils.py
+++ b/plugin/clang/utils.py
@@ -21,7 +21,7 @@ class ClangUtils:
         windows_suffixes (list): suffixes for windows
     """
     windows_suffixes = ['.dll', '.lib']
-    linux_suffixes = ['.so', '.so.1', '.so.7']
+    linux_suffixes = ['.so', '.so.1', '.so.7', '.so.8']
     osx_suffixes = ['.dylib']
 
     suffixes = {


### PR DESCRIPTION
--------------------------------------------------------

Fedora 30 updated their default libclang to version 8, and thus
the SONAME was bumped.

In the future this probably should be replaced by some
"check latest available SONAME for libXXX" kind of check,
but I'm not sure what the best way to handle that would be.
