### PR TITLE
Fix handling of ccache-prefixed entries in compilation database

### DIFF
--- a/plugin/flags_sources/compilation_db.py
+++ b/plugin/flags_sources/compilation_db.py
@@ -194,6 +194,11 @@ class CompilationDb(FlagsSource):
             if i == 0:
                 # ignore first element as it is always the program to run,
                 # something like 'c++'
+
+                if argument == 'ccache':
+                    # if it is ccache, we might need to skip the second as well
+                    skip_next = True
+
                 continue
             if i == len(argument_list) - 1:
                 # ignore the last element as it is a file to compile, something

--- a/tests/compilation_db_files/command_c_ccache/compile_commands.json
+++ b/tests/compilation_db_files/command_c_ccache/compile_commands.json
@@ -1,0 +1,7 @@
+[
+  {
+    "command": "ccache cc -c -I/home/blah/clients -I/home/blah -I/home/blah/core/h -I/home/blah/network/h -I/home/blah/update/h -I/home/blah/h -I/home/blah/h -I/usr/include -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/libsoup-2.4 -I/usr/include/libxml2 -I/usr/include -I/platform/include/fd655 -I/platform/include/ct1628 -I/home/blah/h -I/home/blah/fs/h -I/home/blah/network/h -I/home/blah/update/h -I/home/blah/update/h -Wall -Wno-unused-function -D_REENTRANT -DWITH_THREADS=1 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -fgnu89-inline -fPIC -D_ALI_BUILD_ -D_GNU_SOURCE -shared-libgcc -std=gnu99 -march=armv7-a -mtune=cortex-a9 -DARMV7SP -ggdb -O2 -Werror -DDEVELOP -o -mfpu=vfp3 -mfloat-abi=softfp -mtune=cortex-a9 -march=armv7-a -Wno-poison-system-directories /home/blah/c/blah.c",
+    "directory": "/home/blah",
+    "file": "/home/blah.c"
+  }
+]

--- a/tests/compilation_db_files/command_c_ccache_irrelevant/compile_commands.json
+++ b/tests/compilation_db_files/command_c_ccache_irrelevant/compile_commands.json
@@ -1,0 +1,7 @@
+[
+  {
+    "command": "cc -c -I/home/blah/clients -I/home/blah -I/home/blah/core/h -I/home/blah/network/h -I/home/blah/update/h -I/home/blah/h -I/home/blah/h -I/usr/include -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/libsoup-2.4 -I/usr/include/libxml2 -I/usr/include -I/platform/include/fd655 -I/platform/include/ct1628 -I/home/blah/h -I/home/blah/fs/h -I/home/blah/network/h -I/home/blah/update/h -I/home/blah/update/h -Wall -Wno-unused-function -D_REENTRANT -DWITH_THREADS=1 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -fgnu89-inline -fPIC -D_ALI_BUILD_ -D_GNU_SOURCE -shared-libgcc -std=gnu99 -march=armv7-a -mtune=cortex-a9 -DARMV7SP -ggdb -O2 -Werror -DDEVELOP -o -mfpu=vfp3 -mfloat-abi=softfp -mtune=cortex-a9 -march=armv7-a -Wno-poison-system-directories ccache",
+    "directory": "/home/blah",
+    "file": "/home/blah.c"
+  }
+]

--- a/tests/test_compilation_db.py
+++ b/tests/test_compilation_db.py
@@ -224,6 +224,61 @@ class TestCompilationDb(object):
         self.assertIn(Flag('', '-Wno-poison-system-directories'), flags)
         self.assertIn(Flag('', '-march=armv7-a'), flags)
 
+    def test_get_c_flags_ccache(self):
+        """Test argument filtering when ccache is used."""
+        include_prefixes = ['-I']
+        db = CompilationDb(
+            include_prefixes,
+            header_to_source_map=[],
+            lazy_flag_parsing=self.lazy_parsing
+        )
+
+        main_file_path = path.normpath('/home/blah.c')
+        # also try to test a header
+        path_to_db = path.join(path.dirname(__file__),
+                               'compilation_db_files',
+                               'command_c_ccache')
+        scope = SearchScope(from_folder=path_to_db)
+        flags = db.get_flags(main_file_path, scope)
+        self.assertNotIn(Flag('ccache', ''), flags)
+        self.assertNotIn(Flag('', 'ccache'), flags)
+        self.assertNotIn(Flag('cc', ''), flags)
+        self.assertNotIn(Flag('', 'cc'), flags)
+        self.assertNotIn(Flag('-c', ''), flags)
+        self.assertNotIn(Flag('', '-c'), flags)
+        self.assertNotIn(Flag('-o', ''), flags)
+        self.assertNotIn(Flag('', '-o'), flags)
+        self.assertIn(Flag('', '-Wno-poison-system-directories'), flags)
+        self.assertIn(Flag('', '-march=armv7-a'), flags)
+
+    def test_get_c_flags_ccache_irrelevant(self):
+        """Test argument filtering when ccache string is present, but not the
+           first argument (e.g. strangely named source file)"""
+        include_prefixes = ['-I']
+        db = CompilationDb(
+            include_prefixes,
+            header_to_source_map=[],
+            lazy_flag_parsing=self.lazy_parsing
+        )
+
+        main_file_path = path.normpath('ccache')
+        # also try to test a header
+        path_to_db = path.join(path.dirname(__file__),
+                               'compilation_db_files',
+                               'command_c_ccache_irrelevant')
+        scope = SearchScope(from_folder=path_to_db)
+        flags = db.get_flags(main_file_path, scope)
+        self.assertNotIn(Flag('ccache', ''), flags)
+        self.assertNotIn(Flag('', 'ccache'), flags)
+        self.assertNotIn(Flag('cc', ''), flags)
+        self.assertNotIn(Flag('', 'cc'), flags)
+        self.assertNotIn(Flag('-c', ''), flags)
+        self.assertNotIn(Flag('', '-c'), flags)
+        self.assertNotIn(Flag('-o', ''), flags)
+        self.assertNotIn(Flag('', '-o'), flags)
+        self.assertIn(Flag('', '-Wno-poison-system-directories'), flags)
+        self.assertIn(Flag('', '-march=armv7-a'), flags)
+
 
 class LazyParsing(TestCompilationDb, TestCase):
     """Test that we can parse DB with lazy parsing."""


### PR DESCRIPTION
Some build systems (Meson in my case) generate compilation database with ccache-prefixed entries. This confuses ECC in sense that it considers 'ccache' a compiler, and 'cc' a parameter.
Fix that by ignoring 'ccache' in the first argument.