### PR TITLE
Spelling filters

### DIFF
--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -586,7 +586,7 @@ class EasyClangComplete(sublime_plugin.EventListener):
                 name=ThreadJob.COMPLETE_TAG,
                 callback=self.completion_finished,
                 function=config_manager.trigger_completion,
-                args=[view, completion_request])
+                args=[view, completion_request, settings])
             EasyClangComplete.thread_pool.new_job(job)
         elif pos_status == PosStatus.COMPLETE_INCLUDES:
             log.debug("Completing includes")

--- a/dependencies.json
+++ b/dependencies.json
@@ -7,7 +7,8 @@
             "python-jinja2",
             "markupsafe",
             "pymdownx",
-            "pyyaml"
+            "pyyaml",
+            "regex"
         ]
     }
 }

--- a/plugin/completion/base_complete.py
+++ b/plugin/completion/base_complete.py
@@ -47,11 +47,12 @@ class BaseCompleter:
         # Store the latest errors here
         self.latest_errors = None
 
-    def complete(self, completion_request):
+    def complete(self, completion_request, settings):
         """Generate completions. See children for implementation.
 
         Args:
             completion_request (ActionRequest): request object
+            settings: all plugin settings
 
         Raises:
             NotImplementedError: Guarantees we do not call this abstract method

--- a/plugin/completion/bin_complete.py
+++ b/plugin/completion/bin_complete.py
@@ -96,7 +96,7 @@ class Completer(BaseCompleter):
         else:
             self.compiler_variant = ClangCompilerVariant()
 
-    def complete(self, completion_request):
+    def complete(self, completion_request, settings):
         """Create a list of autocompletions. Called asynchronously.
 
         It builds up a clang command that is then executed
@@ -111,7 +111,7 @@ class Completer(BaseCompleter):
         end = time.time()
         log.debug("code complete done in %s seconds", end - start)
 
-        completions = Completer._parse_completions(raw_complete)
+        completions = Completer._parse_completions(raw_complete, settings)
         log.debug('completions: %s' % completions)
         return (completion_request, completions)
 
@@ -206,11 +206,12 @@ class Completer(BaseCompleter):
         return Tools.run_command(complete_cmd)
 
     @staticmethod
-    def _parse_completions(complete_results):
+    def _parse_completions(complete_results, settings):
         """Create snippet-like structures from a list of completions.
 
         Args:
             complete_results (list): raw completions list
+            settings: all plugin settings
 
         Returns:
             list: updated completions
@@ -286,5 +287,8 @@ class Completer(BaseCompleter):
             hint = re.sub(Completer.compl_content_regex,
                           Parser.make_pretty,
                           comp_dict['content'])
+            hint = Tools.filter_spelling(hint, settings.spelling_filters)
+            contents = Tools.filter_spelling(contents,
+                                             settings.spelling_filters)
             completions.append([trigger + "\t" + hint, contents])
         return completions

--- a/plugin/completion/lib_complete.py
+++ b/plugin/completion/lib_complete.py
@@ -12,6 +12,7 @@ import logging
 
 from .base_complete import BaseCompleter
 from .compiler_variant import LibClangCompilerVariant
+from ..utils.tools import Tools
 from ..utils.clang_utils import ClangUtils
 from ..utils.subl_bridge import SublBridge
 from ..error_vis.popups import Popup
@@ -156,7 +157,7 @@ class Completer(BaseCompleter):
             end = time.time()
             log.debug("compilation done in %s seconds", end - start)
 
-    def complete(self, completion_request):
+    def complete(self, completion_request, settings):
         """Create a list of autocompletions. Called asynchronously.
 
         Using the current translation unit it queries libclang for the
@@ -165,6 +166,7 @@ class Completer(BaseCompleter):
         Args:
             completion_request (tools.ActionRequest): completion request
                 holding information about the view and needed location.
+            settings: all plugin settings
 
         Raises:
             ValueError: if file name does not exist - throw exception.
@@ -230,7 +232,8 @@ class Completer(BaseCompleter):
                 excluded = self.bigger_ignore_list
             else:
                 excluded = self.default_ignore_list
-            completions = Completer._parse_completions(complete_obj, excluded)
+            completions = Completer._parse_completions(
+                complete_obj, excluded, settings)
         log.debug('completions: %s' % completions)
         return (completion_request, completions)
 
@@ -395,12 +398,13 @@ class Completer(BaseCompleter):
         return True
 
     @staticmethod
-    def _parse_completions(complete_results, excluded):
+    def _parse_completions(complete_results, excluded, settings):
         """Create snippet-like structures from a list of completions.
 
         Args:
             complete_results (list): raw completions list
             excluded (list): list of excluded classes of completions
+            settings: all plugin settings
 
         Returns:
             list: updated completions
@@ -423,9 +427,13 @@ class Completer(BaseCompleter):
                     continue
                 if not chunk.spelling:
                     continue
-                hint += chunk.spelling
+                spelling = Tools.filter_spelling(
+                    chunk.spelling, settings.spelling_filters)
+                if not spelling:
+                    continue
+                hint += spelling
                 if chunk.isKindTypedText():
-                    trigger += chunk.spelling
+                    trigger += spelling
                 if chunk.isKindResultType():
                     hint += ' '
                     continue
@@ -435,9 +443,9 @@ class Completer(BaseCompleter):
                     continue
                 if chunk.isKindPlaceHolder():
                     contents += ('${' + str(place_holders) + ':' +
-                                 chunk.spelling + '}')
+                                 spelling + '}')
                     place_holders += 1
                 else:
-                    contents += chunk.spelling
+                    contents += spelling
             completions.append([trigger + "\t" + hint, contents])
         return completions

--- a/plugin/error_vis/popups.py
+++ b/plugin/error_vis/popups.py
@@ -6,6 +6,7 @@ import markupsafe
 import logging
 import re
 
+from ..utils.tools import Tools
 from ..utils.macro_parser import MacroParser
 from ..utils.index_location import IndexLocation
 
@@ -126,7 +127,8 @@ class Popup:
             if result_type_not_none and cursor.spelling != cursor.type.spelling:
                 # Don't show duplicates if the user focuses type, not variable
                 declaration_text += Popup._declaration_for_type(result_type,
-                                                                cindex)
+                                                                cindex,
+                                                                settings)
                 declaration_text += " "
         # Link to declaration of item under cursor
         if cursor.location:
@@ -144,7 +146,8 @@ class Popup:
             args = []
             for arg in cursor.get_arguments():
                 arg_type_decl = Popup._declaration_for_type(arg.type,
-                                                            cindex)
+                                                            cindex,
+                                                            settings)
                 if arg.spelling:
                     args.append(arg_type_decl + " " + arg.spelling)
                 else:
@@ -347,6 +350,7 @@ class Popup:
     @staticmethod
     def _declaration_for_type(clang_type,
                               cindex,
+                              settings,
                               default_spelling=None):
         """Get declaration for a cindex.Type.
 
@@ -356,11 +360,13 @@ class Popup:
         """
         if clang_type.kind == cindex.TypeKind.POINTER:
             pointee_type = clang_type.get_pointee()
-            pointee_text = Popup._declaration_for_type(pointee_type, cindex)
+            pointee_text = Popup._declaration_for_type(pointee_type, cindex,
+                                                       settings)
             return pointee_text + ' \\*'
         if clang_type.kind == cindex.TypeKind.LVALUEREFERENCE:
             referee_type = clang_type.get_pointee()
-            referee_text = Popup._declaration_for_type(referee_type, cindex)
+            referee_text = Popup._declaration_for_type(referee_type, cindex,
+                                                       settings)
             return referee_text + ' &'
         if clang_type.spelling is None or clang_type.spelling == "":
             # This happens, for example, when using an integer literal as
@@ -376,9 +382,11 @@ class Popup:
         if num_template_args < 1:
             # Just link to the type
             log.debug('Number of template args is too low.')
+            type_spelling = Tools.filter_spelling(
+                clang_type.spelling, settings.spelling_filters)
             declaration_text += Popup.link_from_location(
                 Popup.location_from_type(clang_type),
-                clang_type.spelling,
+                type_spelling,
                 trailing_space=False)
             return declaration_text
 
@@ -410,12 +418,16 @@ class Popup:
         if not type_name or len(arg_list) != num_template_args:
             log.debug('Wrong number of template args: len(%s) vs %s',
                       arg_list, num_template_args)
+            type_spelling = Tools.filter_spelling(
+                clang_type.spelling, settings.spelling_filters)
             declaration_text += Popup.link_from_location(
                 Popup.location_from_type(clang_type),
-                clang_type.spelling,
+                type_spelling,
                 trailing_space=False)
             return declaration_text
 
+        type_name = Tools.filter_spelling(
+            type_name, settings.spelling_filters)
         declaration_text += Popup.link_from_location(
             Popup.location_from_type(clang_type),
             type_name,
@@ -426,6 +438,7 @@ class Popup:
             declaration_text += Popup._declaration_for_type(
                 templ_type,
                 cindex,
+                settings,
                 default_spelling=arg_list[arg_index].strip())
             if arg_index + 1 < num_template_args:
                 declaration_text += ", "

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -108,6 +108,7 @@ class SettingsStorage:
         "show_index_references",
         "show_type_body",
         "show_type_info",
+        "spelling_filters",
         "target_compilers",
         "triggers",
         "use_default_definitions",

--- a/plugin/utils/tools.py
+++ b/plugin/utils/tools.py
@@ -73,3 +73,21 @@ class Tools:
         """Generate md5 unique sting hash given init_string."""
         import hashlib
         return hashlib.md5(init_string.encode('utf-8')).hexdigest()
+
+    @staticmethod
+    def filter_spelling(string, filters):
+        """Run the string through the user-defined spelling filters."""
+        # use the regex module instead of re if available
+        import re
+        sub = re.sub
+        try:
+            import regex
+            sub = regex.sub
+        except ImportError:
+            pass
+
+        # apply all filters
+        for f in filters:
+            string = sub(f["pattern"], f["replace"], string)
+
+        return string

--- a/plugin/view_config/view_config_manager.py
+++ b/plugin/view_config/view_config_manager.py
@@ -135,7 +135,7 @@ class ViewConfigManager(object):
             return tooltip_request, ""
         return config.completer.info(tooltip_request, settings)
 
-    def trigger_completion(self, view, completion_request):
+    def trigger_completion(self, view, completion_request, settings):
         """Get completions.
 
         This function is needed to ensure that python can get everything
@@ -143,7 +143,7 @@ class ViewConfigManager(object):
         to an async task. This left a reference to a completer forever active.
         """
         view_config = self.get_from_cache(view)
-        return view_config.completer.complete(completion_request)
+        return view_config.completer.complete(completion_request, settings)
 
     def __run_timer(self):
         """We make sure we run a single thread."""

--- a/tests/test_complete.py
+++ b/tests/test_complete.py
@@ -67,7 +67,7 @@ class BaseTestCompleter(object):
         view_config_manager = ViewConfigManager()
         view_config = view_config_manager.load_for_view(self.view, settings)
         completer = view_config.completer
-        return completer
+        return completer, settings
 
     def tear_down_completer(self):
         """Tear down completer for the current view.
@@ -91,7 +91,7 @@ class BaseTestCompleter(object):
                               'test_files',
                               'test.cpp')
         self.set_up_view(file_name)
-        completer = self.set_up_completer()
+        completer, _ = self.set_up_completer()
 
         self.assertIsNotNone(completer.version_str)
         self.tear_down_completer()
@@ -103,7 +103,7 @@ class BaseTestCompleter(object):
                               'test.cpp')
         self.set_up_view(file_name)
 
-        completer = self.set_up_completer()
+        completer, settings = self.set_up_completer()
 
         # Check the current cursor position is completable.
         self.assertEqual(self.get_row(8), "  a.")
@@ -113,7 +113,7 @@ class BaseTestCompleter(object):
 
         # Load the completions.
         request = ActionRequest(self.view, pos)
-        (_, completions) = completer.complete(request)
+        (_, completions) = completer.complete(request, settings)
 
         # Verify that we got the expected completions back.
         self.assertIsNotNone(completions)
@@ -129,7 +129,7 @@ class BaseTestCompleter(object):
                               'test.cpp')
         self.set_up_view(file_name)
 
-        completer = self.set_up_completer()
+        completer, settings = self.set_up_completer()
 
         # Check the current cursor position is completable.
         self.assertEqual(self.get_row(8), "  a.")
@@ -139,7 +139,7 @@ class BaseTestCompleter(object):
 
         # Load the completions.
         request = ActionRequest(self.view, pos)
-        (_, completions) = completer.complete(request)
+        (_, completions) = completer.complete(request, settings)
 
         # Verify that we got the expected completions back.
         self.assertIsNotNone(completions)
@@ -157,7 +157,7 @@ class BaseTestCompleter(object):
                               'test.cpp')
         self.set_up_view(file_name)
 
-        completer = self.set_up_completer()
+        completer, settings = self.set_up_completer()
 
         # Check the current cursor position is completable.
         self.assertEqual(self.get_row(8), "  a.")
@@ -167,7 +167,7 @@ class BaseTestCompleter(object):
 
         # Load the completions.
         request = ActionRequest(self.view, pos)
-        (_, completions) = completer.complete(request)
+        (_, completions) = completer.complete(request, settings)
 
         # Verify that we got the expected completions back.
         self.assertIsNotNone(completions)
@@ -185,7 +185,7 @@ class BaseTestCompleter(object):
                               'test_vector.cpp')
         self.set_up_view(file_name)
 
-        completer = self.set_up_completer()
+        completer, settings = self.set_up_completer()
 
         # Check the current cursor position is completable.
         self.assertEqual(self.get_row(3), "  vec.")
@@ -195,7 +195,7 @@ class BaseTestCompleter(object):
 
         # Load the completions.
         request = ActionRequest(self.view, pos)
-        (_, completions) = completer.complete(request)
+        (_, completions) = completer.complete(request, settings)
 
         # Verify that we got the expected completions back.
         self.assertIsNotNone(completions)
@@ -212,7 +212,7 @@ class BaseTestCompleter(object):
                               'test_property.m')
         self.set_up_view(file_name)
 
-        completer = self.set_up_completer()
+        completer, settings = self.set_up_completer()
 
         # Check the current cursor position is completable.
         self.assertEqual(self.get_row(6), "  foo.")
@@ -222,7 +222,7 @@ class BaseTestCompleter(object):
 
         # Load the completions.
         request = ActionRequest(self.view, pos)
-        (_, completions) = completer.complete(request)
+        (_, completions) = completer.complete(request, settings)
 
         # Verify that we got the expected completions back.
         self.assertIsNotNone(completions)
@@ -239,7 +239,7 @@ class BaseTestCompleter(object):
                               'test_void_method.m')
         self.set_up_view(file_name)
 
-        completer = self.set_up_completer()
+        completer, settings = self.set_up_completer()
 
         # Check the current cursor position is completable.
         self.assertEqual(self.get_row(6), "  [foo ")
@@ -249,7 +249,7 @@ class BaseTestCompleter(object):
 
         # Load the completions.
         request = ActionRequest(self.view, pos)
-        (_, completions) = completer.complete(request)
+        (_, completions) = completer.complete(request, settings)
 
         # Verify that we got the expected completions back.
         self.assertIsNotNone(completions)
@@ -266,7 +266,7 @@ class BaseTestCompleter(object):
                               'test_method_one_parameter.m')
         self.set_up_view(file_name)
 
-        completer = self.set_up_completer()
+        completer, settings = self.set_up_completer()
 
         # Check the current cursor position is completable.
         self.assertEqual(self.get_row(6), "  [foo ")
@@ -276,7 +276,7 @@ class BaseTestCompleter(object):
 
         # Load the completions.
         request = ActionRequest(self.view, pos)
-        (_, completions) = completer.complete(request)
+        (_, completions) = completer.complete(request, settings)
 
         # Verify that we got the expected completions back.
         self.assertIsNotNone(completions)
@@ -294,7 +294,7 @@ class BaseTestCompleter(object):
                               'test_method_two_parameters.m')
         self.set_up_view(file_name)
 
-        completer = self.set_up_completer()
+        completer, settings = self.set_up_completer()
 
         # Check the current cursor position is completable.
         self.assertEqual(self.get_row(6), "  [foo ")
@@ -304,7 +304,7 @@ class BaseTestCompleter(object):
 
         # Load the completions.
         request = ActionRequest(self.view, pos)
-        (_, completions) = completer.complete(request)
+        (_, completions) = completer.complete(request, settings)
 
         # Verify that we got the expected completions back.
         self.assertIsNotNone(completions)
@@ -324,7 +324,7 @@ class BaseTestCompleter(object):
                               'test_objective_cpp.mm')
         self.set_up_view(file_name)
 
-        completer = self.set_up_completer()
+        completer, settings = self.set_up_completer()
 
         # Check the current cursor position is completable.
         self.assertEqual(self.get_row(3), "  str.")
@@ -334,7 +334,7 @@ class BaseTestCompleter(object):
 
         # Load the completions.
         request = ActionRequest(self.view, pos)
-        (_, completions) = completer.complete(request)
+        (_, completions) = completer.complete(request, settings)
 
         # Verify that we got the expected completions back.
         self.assertIsNotNone(completions)
@@ -385,7 +385,7 @@ class BaseTestCompleter(object):
                               'test_location.cpp')
         self.set_up_view(file_name)
 
-        completer = self.set_up_completer()
+        completer, _ = self.set_up_completer()
 
         # Check the current cursor position is completable.
         row = 9


### PR DESCRIPTION
@niosus: Same here (old PR is #613).  If the close was intentional I will drop it for good :smile:.

These filters are applied to all completions and info popups. I have used them for some time now and find them very useful to make completions more readable. For example in my environment I strip the `__cxx11` namespace, rename `basic_string` to `string`, and remove some other stuff I don't care to see.

There still may be some small bugs but if you would like to integrate this, I can add some more documentation and tests.