### PR TITLE
Exclude subfolder with ignore_folders wildcards

### DIFF
--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -312,8 +312,8 @@ class SettingsStorage:
             expanded_path = path.expandvars(ignore_path)
             expanded_path = sublime.expand_variables(
                 expanded_path, self._wildcard_values)
-            result.append( path.expanduser(expanded_path) )
-        self.ignore_list = result;
+            result.append(path.expanduser(expanded_path))
+        self.ignore_list = result
 
     def __replace_wildcard_if_needed(self, query):
         if isinstance(query, str):

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -302,6 +302,8 @@ class SettingsStorage:
 
     def __update_ignore_list(self):
         """Populate variables inside of the ignore list."""
+        from os import path
+        import sublime
         if not self.ignore_list:
             log.critical(" Cannot update paths of ignore list.")
             return

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -305,7 +305,13 @@ class SettingsStorage:
         if not self.ignore_list:
             log.critical(" Cannot update paths of ignore list.")
             return
-        self.ignore_list = self.__replace_wildcard_if_needed(self.ignore_list)
+        result = []
+        for ignore_path in self.ignore_list:
+            expanded_path = path.expandvars(ignore_path)
+            expanded_path = sublime.expand_variables(
+                expanded_path, self._wildcard_values)
+            result.append( path.expanduser(expanded_path) )
+        self.ignore_list = result;
 
     def __replace_wildcard_if_needed(self, query):
         if isinstance(query, str):


### PR DESCRIPTION
I wanted to use the `ignore_folders` setting to exclude a complete folder system, including multiple subfolders. However currently the `ignore_list` only matches the top most folder.

For example a setup like
```
/include/foo/bar.h
/src/bar.cc
/main.cc
```
with setting
```
ignore_folders=["/*"],
```
would internally expand to the `SettingsStorage.ignore_list=["/include/", "/src/", "/main.cc"]`. Therefore only `/main.cc` would actually be excluded, not `/include/foo/bar.h` and `/src/bar.cc`.

To also exclude the subfolders one would have to do something like
```
ignore_folders=[
  "/*",
  "/*/*",
  "/*/*/*"
],
```
which is a bit ugly, and also leads to a unnecessary long `ignore_list`.

Since `File.is_ignored` already allows patterns, it is unnecessary to fully expand `ignore_list`. Only system or sublime variables (`~`, `$project_path`, etc.) have to be replaced.