### PR TITLE
Allow avoiding globbing for better ignore list

### DIFF
--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -303,7 +303,7 @@ class SettingsStorage:
     def __update_ignore_list(self):
         """Populate variables inside of the ignore list."""
         if not self.ignore_list:
-            log.critical(" Cannot update paths of ignore list.")
+            log.critical("Cannot update paths of ignore list.")
             return
         self.ignore_list = self.__replace_wildcard_if_needed(self.ignore_list)
 
@@ -314,7 +314,9 @@ class SettingsStorage:
             log.critical("We can only update wildcards in a list!")
         result = []
         for query_path in query:
-            result += File.expand_all(query_path, self._wildcard_values)
+            result += File.expand_all(input_path=query_path,
+                                      wildcard_values=self._wildcard_values,
+                                      expand_globbing=False)
         return result
 
     def __update_wildcard_values(self, view):

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -305,9 +305,11 @@ class SettingsStorage:
         if not self.ignore_list:
             log.critical("Cannot update paths of ignore list.")
             return
-        self.ignore_list = self.__replace_wildcard_if_needed(self.ignore_list)
+        self.ignore_list = self.__replace_wildcard_if_needed(
+            query=self.ignore_list,
+            expand_globbing=False)
 
-    def __replace_wildcard_if_needed(self, query):
+    def __replace_wildcard_if_needed(self, query, expand_globbing=True):
         if isinstance(query, str):
             return self.__replace_wildcard_if_needed([query])
         if not isinstance(query, list):
@@ -316,7 +318,7 @@ class SettingsStorage:
         for query_path in query:
             result += File.expand_all(input_path=query_path,
                                       wildcard_values=self._wildcard_values,
-                                      expand_globbing=False)
+                                      expand_globbing=expand_globbing)
         return result
 
     def __update_wildcard_values(self, view):

--- a/plugin/utils/file.py
+++ b/plugin/utils/file.py
@@ -143,7 +143,10 @@ class File:
         return normpath
 
     @staticmethod
-    def expand_all(input_path, wildcard_values={}, current_folder=''):
+    def expand_all(input_path,
+                   wildcard_values={},
+                   current_folder='',
+                   expand_globbing=True):
         """Expand everything in this path.
 
         This returns a list of canonical paths.
@@ -154,8 +157,11 @@ class File:
         expanded_path = File.canonical_path(expanded_path, current_folder)
         if not expanded_path:
             return []
-        from glob import glob
-        all_paths = glob(expanded_path)
+        if expand_globbing:
+            from glob import glob
+            all_paths = glob(expanded_path)
+        else:
+            all_paths = [expanded_path]
         if len(all_paths) > 0 and all_paths[0] != input_path:
             log.debug("Populated '%s' to '%s'", input_path, all_paths)
             return all_paths

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -112,4 +112,22 @@ class test_file(TestCase):
         self.assertTrue(File.is_ignored('/tmp/hello', ['/tmp*']))
         self.assertTrue(File.is_ignored('/tmp/hello', ['', '/tmp*']))
         self.assertTrue(File.is_ignored('/tmp/hello', ['', '/tmp/hell*']))
+        self.assertTrue(File.is_ignored('/tmp/hello/world', ['/tmp/*']))
+
         self.assertFalse(File.is_ignored('/tmp/hello', ['/tmp/c*']))
+
+    def test_expand_all(self):
+        """Test the globbing and wildcard expansion."""
+        current_dir_glob = path.join(path.dirname(__file__), '*')
+        result = File.expand_all(current_dir_glob)
+        self.assertIn(__file__, result)
+
+        result = File.expand_all(current_dir_glob, expand_globbing=False)
+        self.assertEquals(len(result), 1)
+        self.assertIn(current_dir_glob, result)
+
+        path_with_wildcard = "hello$world"
+        wildcards = {"world": "BLAH"}
+        result = File.expand_all(path_with_wildcard, wildcard_values=wildcards)
+        self.assertEquals(len(result), 1)
+        self.assertIn("helloBLAH", result)


### PR DESCRIPTION
As we have always expanded glob before, the ignore list was stripped from its power, as there was no stars in it left. With this PR the ignore list will ignore all subfiles and subfolders under a a particular folder if it ends with a star.

This solves an issue mentioned in #647  