### PR TITLE
Add "ignore_flags" setting

### DIFF
--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -109,6 +109,14 @@
     "$project_path/some/project/path/*",
   ],
 
+  // Ignore all flags that match any of the following glob-style patterns. You
+  // can use shell-style wildcard expansion as well as sublime variables and ~
+  // for home director.
+  "ignore_flags": [
+    "some_flag_pattern*",
+    "-W_other_pattern_$project_path*",
+  ],
+
   // Use libclang.
   // If set to false will use clang_binary and parse the output of
   // `clang_binary -Xclang -code-complete-at...` instead.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -290,6 +290,17 @@ Do not run the plugin for any files that match these paths. Use
     ],
     ```
 
+### **`ignore_flags`**
+Ignore all flags that match any of the following glob-style patterns. You can use `glob/fnmatch` shell-style wildcard expansion as well as sublime variables and `~` for home director.
+
+!!! example "Default value"
+    ```json
+    "ignore_flags": [
+        "some_flag_pattern*",
+        "-W_other_pattern_$project_path*",
+    ],
+    ```
+
 ### **`use_libclang`**
 
 If set to `true` will use `libclang` through python bindings. This offers much better performance generally, but can be buggy on some systems. When set to `false` will use clang_binary and parse the output of `clang -Xclang -code-complete-at <some_file>` instead.

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -155,11 +155,11 @@ class SettingsStorage:
             self.__populate_common_flags()
             self.__populate_flags_source_paths()
             if not self.__expand_setting(self.ignore_list):
-                log.critical("Cannot expand ignore list")
+                log.critical("Cannot expand ignore_list")
             if not self.__expand_setting(self.ignore_flags):
-                log.critical("Cannot expand ignore flags")
+                log.critical("Cannot expand ignore_flags")
             if not self.__expand_setting(self.header_to_source_mapping):
-                log.critical("Cannot expand header to source mapping")
+                log.critical("Cannot expand header_to_source_mapping")
             self.libclang_path = self.__replace_wildcard_if_needed(
                 self.libclang_path)[0]
             self.clang_binary = self.__replace_wildcard_if_needed(

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -95,6 +95,7 @@ class SettingsStorage:
         "gutter_style",
         "header_to_source_mapping",
         "hide_default_completions",
+        "ignore_flags",
         "ignore_list",
         "lang_flags",
         "lazy_flag_parsing",
@@ -153,8 +154,12 @@ class SettingsStorage:
             # Replace wildcards in various paths.
             self.__populate_common_flags()
             self.__populate_flags_source_paths()
-            self.__update_ignore_list()
-            self.__update_header_to_source_mapping()
+            if not self.__expand_setting(self.ignore_list):
+                log.critical("Cannot expand ignore list")
+            if not self.__expand_setting(self.ignore_flags):
+                log.critical("Cannot expand ignore flags")
+            if not self.__expand_setting(self.header_to_source_mapping):
+                log.critical("Cannot expand header to source mapping")
             self.libclang_path = self.__replace_wildcard_if_needed(
                 self.libclang_path)[0]
             self.clang_binary = self.__replace_wildcard_if_needed(
@@ -301,23 +306,14 @@ class SettingsStorage:
                     current_folder=self.project_folder)
         self.common_flags = new_common_flags
 
-    def __update_ignore_list(self):
+    def __expand_setting(self, setting):
         """Populate variables inside of the ignore list."""
-        if not self.ignore_list:
-            log.critical("Cannot update paths of ignore list.")
-            return
+        if not setting:
+            return False
         self.ignore_list = self.__replace_wildcard_if_needed(
             query=self.ignore_list,
             expand_globbing=False)
-
-    def __update_header_to_source_mapping(self):
-        """Populate variables inside of the header_to_source_mapping list."""
-        if not self.header_to_source_mapping:
-            log.critical("Cannot update paths of header_to_source_mapping.")
-            return
-        self.header_to_source_mapping = self.__replace_wildcard_if_needed(
-            query=self.header_to_source_mapping,
-            expand_globbing=False)
+        return True
 
     def __replace_wildcard_if_needed(self, query, expand_globbing=True):
         if isinstance(query, str):

--- a/plugin/view_config/view_config.py
+++ b/plugin/view_config/view_config.py
@@ -189,10 +189,13 @@ class ViewConfig(object):
             init_flags, lang_flags, common_flags, source_flags)
 
         flags_as_str_list = []
+        log.debug("Appending and filtering flags with ignore patterns: %s",
+                  settings.ignore_flags)
         for flag in flags:
             ignore_this_flag = False
             for pattern in settings.ignore_flags:
                 if fnmatch.fnmatch(flag.body, pattern):
+                    log.debug("Ignoring flag: %s", flag)
                     ignore_this_flag = True
                     break
             if ignore_this_flag:

--- a/plugin/view_config/view_config.py
+++ b/plugin/view_config/view_config.py
@@ -170,6 +170,7 @@ class ViewConfig(object):
         Returns:
             (Completer, str[]): A completer bundled with flags as str list.
         """
+        import fnmatch
         if not SublBridge.is_valid_view(view):
             log.warning(" no flags for an invalid view %s.", view)
             return (None, [])
@@ -189,6 +190,13 @@ class ViewConfig(object):
 
         flags_as_str_list = []
         for flag in flags:
+            ignore_this_flag = False
+            for pattern in settings.ignore_flags:
+                if fnmatch.fnmatch(flag.body, pattern):
+                    ignore_this_flag = True
+                    break
+            if ignore_this_flag:
+                continue
             flags_as_str_list += flag.as_list()
 
         include_folders = ViewConfig.__get_include_folders(prefixes, flags)


### PR DESCRIPTION
This PR adds an "ignore_flags" setting that can be used to filter out flags that we don't want to be passed to clang.