### PR TITLE
Fix the expansion of clang binary path

### DIFF
--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -135,8 +135,10 @@
 
   // Pick the clang binary used by the plugin. This is used to determine the
   // version of the plugin and pick correct libclang bindings. Note that this
-  // should either be a full path to the binary or it should be available in
-  // your PATH.
+  // should either be a full (local or global) path to the binary or it should
+  // be available in your PATH. You can use all wildcards apart from
+  // $clang_version as it would not be available before we point to the correct
+  // version of the clang binary.
   "clang_binary" : "clang++",
 
   // Pick the binary used for cmake. Please make sure the binary you provide is

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -355,6 +355,11 @@ Output lots of additional information in the console. Useful for debugging. Off 
 Pick the clang binary used by the plugin. This is used to determine the
 version of the plugin and pick correct libclang bindings or for code completion when the setting [`use_libclang`](#use_libclang) is set to `false`.
 
+Note that this should either be a full (local or global) path to the binary or
+it should be available in your PATH. You can use all wildcards apart from
+`$clang_version` as it would not be available before we point to the correct
+version of the clang binary.
+
 !!! example "Default value"
     ```json
     "clang_binary" : "clang++",

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -340,8 +340,7 @@ class SettingsStorage:
 
         # We need to expand clang binary path *before* we set all wildcards.
         self.clang_binary = self.__replace_wildcard_if_needed(
-            input_path=self.clang_binary,
-            wildcard_values=self._wildcard_values,
+            query=self.clang_binary,
             expand_globbing=False)[0]
         # get clang version string
         version_str = ClangUtils.get_clang_version_str(self.clang_binary)

--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -338,6 +338,11 @@ class SettingsStorage:
         self._wildcard_values[Wildcards.PROJECT_NAME] = \
             variables.get("project_base_name", "")
 
+        # We need to expand clang binary path *before* we set all wildcards.
+        self.clang_binary = self.__replace_wildcard_if_needed(
+            input_path=self.clang_binary,
+            wildcard_values=self._wildcard_values,
+            expand_globbing=False)[0]
         # get clang version string
         version_str = ClangUtils.get_clang_version_str(self.clang_binary)
         self._wildcard_values[Wildcards.CLANG_VERSION] = version_str


### PR DESCRIPTION
This PR intends to fix #664 as the `clang_binary` settings was not expanding properly. The reason for this was that we needed `clang_binary` already expanded when we updated the values for the wildcards, while we needed the wildcards to expand `clang_binary`. It is now expanded while we update the wildcards values.