### PR TITLE
Move flag parsing functionality to flag.py

### DIFF
--- a/docs/configs.md
+++ b/docs/configs.md
@@ -54,12 +54,12 @@ the file which is currently opened by the user.
     [
         {
           "directory": "/main_dir",
-          "command": "/usr/bin/c++    -I/lib_include_dir    -o CMakeFiles/main_obj.o -c /home/user/dummy_main.cpp",
+          "command": "c++    -I/lib_include_dir    -o CMakeFiles/main_obj.o -c /home/user/dummy_main.cpp",
           "file": "/home/user/dummy_main.cpp"
         },
         {
           "directory": "/lib_dir",
-          "command": "/usr/bin/c++   -Dlib_EXPORTS  -fPIC   -o CMakeFiles/lib_obj.o -c /home/user/dummy_lib.cpp",
+          "command": "c++   -Dlib_EXPORTS  -fPIC   -o CMakeFiles/lib_obj.o -c /home/user/dummy_lib.cpp",
           "file": "/home/user/dummy_lib.cpp"
         }
     ]

--- a/plugin/flags_sources/compilation_db.py
+++ b/plugin/flags_sources/compilation_db.py
@@ -136,7 +136,6 @@ class CompilationDb(FlagsSource):
             # TODO(igor): maybe show message to the user instead here
             log.critical("Compilation database has unsupported format")
             return None
-        argument_list = CompilationDb.filter_bad_arguments(argument_list)
         return Flag.tokenize_list(argument_list, base_path)
 
     def _parse_database(self, current_db_path):

--- a/plugin/flags_sources/compilation_db.py
+++ b/plugin/flags_sources/compilation_db.py
@@ -174,46 +174,6 @@ class CompilationDb(FlagsSource):
             parsed_db[CompilationDb.ALL_TAG] = unique_list_of_flags.as_list()
         return parsed_db
 
-    @staticmethod
-    def filter_bad_arguments(argument_list):
-        """Filter out the arguments that we don't care about.
-
-        Args:
-            argument_list (str[]): a list of flags.
-
-        Returns:
-            str[]: Flags without the unneeded ones.
-        """
-        new_args = []
-        skip_next = False
-        for i, argument in enumerate(argument_list):
-            if skip_next:
-                # somebody told us to skip this
-                skip_next = False
-                continue
-            if i == 0:
-                # ignore first element as it is always the program to run,
-                # something like 'c++'
-
-                if argument == 'ccache':
-                    # if it is ccache, we might need to skip the second as well
-                    skip_next = True
-
-                continue
-            if i == len(argument_list) - 1:
-                # ignore the last element as it is a file to compile, something
-                # like 'test.cpp'
-                continue
-            if argument == '-c':
-                # ignore -c too
-                continue
-            if argument == '-o':
-                # ignore the -o flag and whatever comes after it
-                skip_next = True
-                continue
-            new_args.append(argument)
-        return new_args
-
     def _find_related_sources(self, file_path, db):
         if not file_path:
             log.debug("[db]:[header-to-source]: skip retrieving related "

--- a/tests/compilation_db_files/arguments/compile_commands.json
+++ b/tests/compilation_db_files/arguments/compile_commands.json
@@ -1,7 +1,7 @@
 [
 {
   "arguments": [
-    "/usr/bin/c++",
+    "c++",
     "-I/lib_include_dir",
     "-o",
     "CMakeFiles/main_obj.o",
@@ -13,7 +13,7 @@
 },
 {
   "arguments": [
-    "/usr/bin/c++",
+    "c++",
     "-Dlib_EXPORTS",
     "-fPIC",
     "-o",

--- a/tests/compilation_db_files/command/compile_commands.json
+++ b/tests/compilation_db_files/command/compile_commands.json
@@ -1,12 +1,12 @@
 [
 {
   "directory": "/main_dir",
-  "command": "/usr/bin/c++    -I/lib_include_dir    -o CMakeFiles/main_obj.o -c /home/user/dummy_main.cpp",
+  "command": "c++    -I/lib_include_dir    -o CMakeFiles/main_obj.o -c /home/user/dummy_main.cpp",
   "file": "/home/user/dummy_main.cpp"
 },
 {
   "directory": "/lib_dir",
-  "command": "/usr/bin/c++   -Dlib_EXPORTS  -fPIC   -o CMakeFiles/lib_obj.o -c /home/user/dummy_lib.cpp",
+  "command": "c++   -Dlib_EXPORTS  -fPIC   -o CMakeFiles/lib_obj.o -c /home/user/dummy_lib.cpp",
   "file": "/home/user/dummy_lib.cpp"
 }
 ]

--- a/tests/compilation_db_files/directory/compile_commands.json
+++ b/tests/compilation_db_files/directory/compile_commands.json
@@ -1,7 +1,7 @@
 [
 {
   "arguments": [
-    "/usr/bin/c++",
+    "c++",
     "-I./include",
     "-I../../include",
     "-isystem",

--- a/tests/test_compilation_db.py
+++ b/tests/test_compilation_db.py
@@ -46,20 +46,9 @@ class TestCompilationDb(object):
         if self.lazy_parsing:
             self.assertIsNone(db.get_flags(search_scope=scope))
         else:
-            self.assertEqual(expected, db.get_flags(search_scope=scope))
-
-    def test_get_all_flags_arguments(self):
-        """Test argument filtering."""
-        arguments = [
-            "/usr/bin/c++",
-            "-I/lib_include_dir",
-            "-o",
-            "CMakeFiles/main_obj.o",
-            "-c",
-            "/home/user/dummy_main.cpp"]
-        expected = ["-I/lib_include_dir"]
-        result = CompilationDb.filter_bad_arguments(arguments)
-        self.assertEqual(result, expected)
+            self.assertIn(expected[0], db.get_flags(search_scope=scope))
+            self.assertIn(expected[1], db.get_flags(search_scope=scope))
+            self.assertIn(expected[2], db.get_flags(search_scope=scope))
 
     def test_strip_wrong_arguments(self):
         """Test if compilation db is found and flags loaded from arguments."""
@@ -77,18 +66,21 @@ class TestCompilationDb(object):
         if self.lazy_parsing:
             import sublime
             if sublime.platform() != 'windows':
-                expected = [Flag('', '-Dlib_EXPORTS'),
-                            Flag('', '-fPIC')]
                 file_path = path.realpath("/home/user/dummy_lib.cpp")
-                self.assertEqual(expected, db.get_flags(file_path=file_path,
-                                                        search_scope=scope))
+                self.assertIn(Flag('', '-Dlib_EXPORTS'),
+                              db.get_flags(file_path=file_path,
+                                           search_scope=scope))
+                self.assertIn(Flag('', '-fPIC'),
+                              db.get_flags(file_path=file_path,
+                                           search_scope=scope))
             # Check that we don't get the 'all' entry.
             self.assertIsNone(db.get_flags(search_scope=scope))
         else:
             expected = [Flag('-I', path.normpath('/lib_include_dir')),
                         Flag('', '-Dlib_EXPORTS'),
                         Flag('', '-fPIC')]
-            self.assertEqual(expected, db.get_flags(search_scope=scope))
+            for expected_flag in expected:
+                self.assertIn(expected_flag, db.get_flags(search_scope=scope))
 
     def test_get_flags_for_path(self):
         """Test if compilation db is found."""
@@ -99,8 +91,11 @@ class TestCompilationDb(object):
             lazy_flag_parsing=self.lazy_parsing
         )
 
-        expected_lib = [Flag('', '-Dlib_EXPORTS'), Flag('', '-fPIC')]
-        expected_main = [Flag('-I', path.normpath('/lib_include_dir'))]
+        expected_lib = [Flag('', '-Dlib_EXPORTS'),
+                        Flag('', '-fPIC'),
+                        Flag('-o', 'CMakeFiles/lib_obj.o', ' '),
+                        Flag('', '-c')]
+        expected_main = Flag('-I', path.normpath('/lib_include_dir'))
         lib_file_path = path.normpath('/home/user/dummy_lib.cpp')
         main_file_path = path.normpath('/home/user/dummy_main.cpp')
         # also try to test a header
@@ -111,7 +106,7 @@ class TestCompilationDb(object):
         scope = SearchScope(from_folder=path_to_db)
         self.assertEqual(expected_lib, db.get_flags(lib_file_path, scope))
         self.assertEqual(expected_lib, db.get_flags(lib_file_path_h, scope))
-        self.assertEqual(expected_main, db.get_flags(main_file_path, scope))
+        self.assertIn(expected_main, db.get_flags(main_file_path, scope))
         self.assertIn(lib_file_path, db._cache)
         self.assertIn(main_file_path, db._cache)
         path_to_db = path.join(path.dirname(__file__),
@@ -125,7 +120,7 @@ class TestCompilationDb(object):
         if self.lazy_parsing:
             self.assertNotIn(CompilationDb.ALL_TAG, db._cache[path_to_db])
         else:
-            self.assertIn(expected_main[0],
+            self.assertIn(expected_main,
                           db._cache[path_to_db][CompilationDb.ALL_TAG])
             self.assertIn(
                 expected_lib[0], db._cache[path_to_db][CompilationDb.ALL_TAG])
@@ -153,16 +148,18 @@ class TestCompilationDb(object):
             lazy_flag_parsing=self.lazy_parsing
         )
 
-        expected_lib = [Flag('', '-Dlib_EXPORTS'), Flag('', '-fPIC')]
-        expected_main = [Flag('-I', path.normpath('/lib_include_dir'))]
+        expected_main = Flag('-I', path.normpath('/lib_include_dir'))
         lib_file_path = path.normpath('/home/user/dummy_lib.cpp')
         main_file_path = path.normpath('/home/user/dummy_main.cpp')
         path_to_db = path.join(path.dirname(__file__),
                                'compilation_db_files',
                                'command')
         scope = SearchScope(from_folder=path_to_db)
-        self.assertEqual(expected_lib, db.get_flags(lib_file_path, scope))
-        self.assertEqual(expected_main, db.get_flags(main_file_path, scope))
+        self.assertIn(Flag('', '-Dlib_EXPORTS'),
+                      db.get_flags(lib_file_path, scope))
+        self.assertIn(Flag('', '-fPIC'),
+                      db.get_flags(lib_file_path, scope))
+        self.assertIn(expected_main, db.get_flags(main_file_path, scope))
         # check persistence
         self.assertGreater(len(db._cache), 2)
         self.assertEqual(path.join(path_to_db, "compile_commands.json"),
@@ -217,10 +214,6 @@ class TestCompilationDb(object):
                                'command_c')
         scope = SearchScope(from_folder=path_to_db)
         flags = db.get_flags(main_file_path, scope)
-        self.assertNotIn(Flag('-c', ''), flags)
-        self.assertNotIn(Flag('', '-c'), flags)
-        self.assertNotIn(Flag('-o', ''), flags)
-        self.assertNotIn(Flag('', '-o'), flags)
         self.assertIn(Flag('', '-Wno-poison-system-directories'), flags)
         self.assertIn(Flag('', '-march=armv7-a'), flags)
 
@@ -244,16 +237,11 @@ class TestCompilationDb(object):
         self.assertNotIn(Flag('', 'ccache'), flags)
         self.assertNotIn(Flag('cc', ''), flags)
         self.assertNotIn(Flag('', 'cc'), flags)
-        self.assertNotIn(Flag('-c', ''), flags)
-        self.assertNotIn(Flag('', '-c'), flags)
-        self.assertNotIn(Flag('-o', ''), flags)
-        self.assertNotIn(Flag('', '-o'), flags)
         self.assertIn(Flag('', '-Wno-poison-system-directories'), flags)
         self.assertIn(Flag('', '-march=armv7-a'), flags)
 
     def test_get_c_flags_ccache_irrelevant(self):
-        """Test argument filtering when ccache string is present, but not the
-           first argument (e.g. strangely named source file)"""
+        """Test filtering when ccache string is not the first argument."""
         include_prefixes = ['-I']
         db = CompilationDb(
             include_prefixes,
@@ -272,10 +260,6 @@ class TestCompilationDb(object):
         self.assertNotIn(Flag('', 'ccache'), flags)
         self.assertNotIn(Flag('cc', ''), flags)
         self.assertNotIn(Flag('', 'cc'), flags)
-        self.assertNotIn(Flag('-c', ''), flags)
-        self.assertNotIn(Flag('', '-c'), flags)
-        self.assertNotIn(Flag('-o', ''), flags)
-        self.assertNotIn(Flag('', '-o'), flags)
         self.assertIn(Flag('', '-Wno-poison-system-directories'), flags)
         self.assertIn(Flag('', '-march=armv7-a'), flags)
 

--- a/tests/test_compilation_db.py
+++ b/tests/test_compilation_db.py
@@ -92,9 +92,7 @@ class TestCompilationDb(object):
         )
 
         expected_lib = [Flag('', '-Dlib_EXPORTS'),
-                        Flag('', '-fPIC'),
-                        Flag('-o', 'CMakeFiles/lib_obj.o', ' '),
-                        Flag('', '-c')]
+                        Flag('', '-fPIC')]
         expected_main = Flag('-I', path.normpath('/lib_include_dir'))
         lib_file_path = path.normpath('/home/user/dummy_lib.cpp')
         main_file_path = path.normpath('/home/user/dummy_main.cpp')
@@ -104,8 +102,8 @@ class TestCompilationDb(object):
                                'compilation_db_files',
                                'command')
         scope = SearchScope(from_folder=path_to_db)
-        self.assertEqual(expected_lib, db.get_flags(lib_file_path, scope))
-        self.assertEqual(expected_lib, db.get_flags(lib_file_path_h, scope))
+        self.assertIn(expected_lib[0], db.get_flags(lib_file_path, scope))
+        self.assertIn(expected_lib[0], db.get_flags(lib_file_path_h, scope))
         self.assertIn(expected_main, db.get_flags(main_file_path, scope))
         self.assertIn(lib_file_path, db._cache)
         self.assertIn(main_file_path, db._cache)
@@ -196,7 +194,8 @@ class TestCompilationDb(object):
             self.assertIsNone(db.get_flags(search_scope=scope))
         else:
             db.get_flags(search_scope=scope)
-            self.assertEqual(expected, db.get_flags(search_scope=scope))
+            for expected_flag in expected:
+                self.assertIn(expected_flag, db.get_flags(search_scope=scope))
 
     def test_get_c_flags(self):
         """Test argument filtering for c language."""

--- a/tests/test_flag.py
+++ b/tests/test_flag.py
@@ -14,11 +14,11 @@ class TestFlag(TestCase):
 
     def test_init(self):
         """Initialization test."""
-        flag = Flag.Builder().from_unparsed_string("hello").build()
-        self.assertEqual(flag.as_list(), ["hello"])
-        self.assertEqual(flag.prefix, "")
+        flag = Flag.Builder().from_unparsed_string("-Ihello").build()
+        self.assertEqual(flag.as_list(), ["-I", "hello"])
+        self.assertEqual(flag.prefix, "-I")
         self.assertEqual(flag.body, "hello")
-        self.assertEqual(str(flag), "hello")
+        self.assertEqual(str(flag), "-Ihello")
         flag = Flag("hello", "world", " ")
         self.assertEqual(flag.as_list(), ["hello", "world"])
         self.assertEqual(flag.prefix, "hello")
@@ -62,9 +62,12 @@ class TestFlag(TestCase):
         """Test tokenizing a list of all split flags."""
         flag1 = Flag.Builder().with_prefix('hello').with_body('world').build()
         self.assertEqual(Flag("hello", "world"), flag1)
-        flag2 = Flag.Builder().from_unparsed_string('hello world').build()
-        self.assertEqual(Flag("", "hello world"), flag2)
         flag3 = Flag.Builder().from_unparsed_string('-Iworld').build()
         self.assertEqual(Flag("-I", "world"), flag3)
         flag4 = Flag.Builder().from_unparsed_string('-include world').build()
         self.assertEqual(Flag("-include", "world", " "), flag4)
+
+    def test_builder_invalid(self):
+        """Test tokenizing invalid flags."""
+        flag2 = Flag.Builder().from_unparsed_string('hello world').build()
+        self.assertEqual(Flag("", ""), flag2)


### PR DESCRIPTION
Introduce a check for possible flag indicators to detect what is a flag
and what is just a string in the command line. Generally speaking we
only want to get the actual flags and not the strings such as the
compiler, ccache or the file being compiled.

Fix #665 