### PR TITLE
Fix flag parsing for /U flag

### DIFF
--- a/plugin/utils/flag.py
+++ b/plugin/utils/flag.py
@@ -159,6 +159,9 @@ class Flag:
         def from_unparsed_string(self, chunk):
             """Parse an unknown string into body and prefix."""
             chunk = chunk.strip()
+            if not Flag.indicates_flag(chunk):
+                # This is not a valid flag, so reset all values to default.
+                return Flag.Builder()
             for prefix in Flag.SEPARABLE_PREFIXES:
                 if chunk.startswith(prefix):
                     self.__prefix = prefix
@@ -171,9 +174,6 @@ class Flag:
             # We did not find any separable prefix, so it's all body.
             if not self.__body:
                 self.__body = chunk
-            if not Flag.indicates_flag(self.__body):
-                # This is not a valid flag, so reset all values to default.
-                self.__init__()
             return self
 
         def with_body(self, body):

--- a/tests/test_flag.py
+++ b/tests/test_flag.py
@@ -67,8 +67,10 @@ class TestFlag(TestCase):
         flag4 = Flag.Builder().from_unparsed_string('-include world').build()
         self.assertEqual(Flag("-include", "world", " "), flag4)
         # Check that we don't trigger on /U flag.
-        flag5 = Flag.Builder().from_unparsed_string('/User/blah').build()
-        self.assertEqual(Flag("", "", ""), flag5)
+        import platform
+        if platform.system() != "Windows":
+            flag5 = Flag.Builder().from_unparsed_string('/User/blah').build()
+            self.assertEqual(Flag("", "", ""), flag5)
 
     def test_builder_invalid(self):
         """Test tokenizing invalid flags."""

--- a/tests/test_flag.py
+++ b/tests/test_flag.py
@@ -66,6 +66,9 @@ class TestFlag(TestCase):
         self.assertEqual(Flag("-I", "world"), flag3)
         flag4 = Flag.Builder().from_unparsed_string('-include world').build()
         self.assertEqual(Flag("-include", "world", " "), flag4)
+        # Check that we don't trigger on /U flag.
+        flag5 = Flag.Builder().from_unparsed_string('/User/blah').build()
+        self.assertEqual(Flag("", "", ""), flag5)
 
     def test_builder_invalid(self):
         """Test tokenizing invalid flags."""


### PR DESCRIPTION
This PR fixes a newly introduced issue where if a path starts with `/U` it is considered a flag and the `/U` is separated from it. This causes issues on Macs as paths often start with `/User`.

Fix #677 