### PR TITLE
plugin/clang_utils: add clang 9/10 SONAMEs for Linux

### DIFF
--- a/plugin/utils/clang_utils.py
+++ b/plugin/utils/clang_utils.py
@@ -27,7 +27,7 @@ class ClangUtils:
         WINDOWS_SUFFIXES (list): suffixes for windows
     """
     WINDOWS_SUFFIXES = ['.dll', '.lib']
-    LINUX_SUFFIXES = ['.so', '.so.1', '.so.7', '.so.8', '.so.9']
+    LINUX_SUFFIXES = ['.so', '.so.1', '.so.7', '.so.8', '.so.9', '.so.10']
     OSX_SUFFIXES = ['.dylib']
 
     SUFFIXES = {

--- a/plugin/utils/clang_utils.py
+++ b/plugin/utils/clang_utils.py
@@ -27,7 +27,7 @@ class ClangUtils:
         WINDOWS_SUFFIXES (list): suffixes for windows
     """
     WINDOWS_SUFFIXES = ['.dll', '.lib']
-    LINUX_SUFFIXES = ['.so', '.so.1', '.so.7', '.so.8', '.so.9', '.so.10']
+    LINUX_SUFFIXES = ['.so', '.so.10', '.so.9', '.so.8', '.so.7', '.so.1']
     OSX_SUFFIXES = ['.dylib']
 
     SUFFIXES = {

--- a/plugin/utils/clang_utils.py
+++ b/plugin/utils/clang_utils.py
@@ -27,7 +27,7 @@ class ClangUtils:
         WINDOWS_SUFFIXES (list): suffixes for windows
     """
     WINDOWS_SUFFIXES = ['.dll', '.lib']
-    LINUX_SUFFIXES = ['.so', '.so.1', '.so.7', '.so.8']
+    LINUX_SUFFIXES = ['.so', '.so.1', '.so.7', '.so.8', '.so.9']
     OSX_SUFFIXES = ['.dylib']
 
     SUFFIXES = {


### PR DESCRIPTION
--------------------------------------------------------

The usual thing happening every time a new Clang is released.

As my distro adds Clang 10, I shall test that as well and add that to the list if it works.

In the future, I think we might want to prioritize newer supported versions to older ones, so having `.so` first and then having the rest of the SONAMEs in descending order.

P.S.
Sorry for only pushing this out now, I had silently been patching it in locally while thinking how to handle these SONAME issues better in Python. The burst of recent releases of course breaking that for me and thus making me move on with this without the "better solution" :) .

