### PR TITLE
Prepare v6.4.1

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Please follow the issue template *exactly* when creating a new issue.
 I will be closing issues that do not follow that template. Please understand
 that maintaining this codebase takes time and I expect at least well-formatted
 issue statement to be able to tackle it. It is very demotivating to format 
-the issues instead of the original submitter.
+the issues instead of actually solving them, so I would really like to outsource this task to the original submitter.
 
 Please don't jump into creating a Pull Request straight away and open an issue
 first. This way, we can synchronize our views on the problem, so that everyone
@@ -15,10 +15,10 @@ avoids losing time.
 
 ### Branches ###
 There are two branches:
-- `master`: should be stable and generally following the last release. Used for
-  urgent bug fixing.
-- `dev`: used to develop new features. Merges with master right before a new
-  release.
+- `master`: used for ongoing development. Merges into `release` branchright
+  before a new release.
+- `release`: should be stable and following the last release. Used for urgent
+  bug fixing exclusively on top of the previous release.
 
 ### Code style ###
 - Line width is `80` characters

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
 # Before submitting make sure #
-- Make sure your branch is based on `dev`
+- Make sure your branch is based on `master`
 - Reference an issue that this PR closes if there is one
 - Add your PR descriptions below the line
-- Remove this prefix (everything above the line)
+- Remove this prefix (everything above the line right below)
 
---------------------------------------------------------
+-------------------------------------------------------------------------------
 
 YOUR PR DESCRIPTION GOES HERE
 

--- a/messages.json
+++ b/messages.json
@@ -22,5 +22,6 @@
   "6.2.7": "messages/6.2.7.rst",
   "6.2.8": "messages/6.2.8.rst",
   "6.3.0": "messages/6.3.0.rst",
-  "6.4.0": "messages/6.4.0.rst"
+  "6.4.0": "messages/6.4.0.rst",
+  "6.4.1": "messages/6.4.1.rst"
 }

--- a/messages/6.4.1.rst
+++ b/messages/6.4.1.rst
@@ -1,0 +1,36 @@
+Version 6.4.1
+=============
+
+Improvements and bug fixes:
+---------------------------
+- Fix progress showing a wrong job name.
+- Show console output if CMake generation fails.
+- Fix cmake flags source overwriting CMAKE_PREFIX_PATHS environment variable.
+- Add more suffixes to find libclang, thanks @jeeb.
+- Fix docs generation after updating the theme.
+
+Development announcement:
+-------------------------
+I decided to move away from using the "dev" branch. Now all the development
+will be happening in the "master" branch. The releases will be sourced from
+the "release" branch. See contribution guidelines for details.
+
+
+💜 this plugin? Consider supporting its development! 💰💸💶
+------------------------------------------------------------
+‼️NEW‼️ Head to GitHub Sponsors and support my work if you enjoy the plugin!
+https://github.com/sponsors/niosus
+
+Alternatively, become a backer on Open Collective!
+https://opencollective.com/EasyClangComplete#backers
+
+I you use this plugin in a company, push to become a sponsor!
+https://opencollective.com/EasyClangComplete#sponsor
+
+This plugin took a significant amount of effort. It is available and will always
+be available for free, both as freedom and as beer.
+
+If you appreciate it - support it. How much would you say it is worth to you?
+
+For more info head here:
+https://github.com/niosus/EasyClangComplete#support-it


### PR DESCRIPTION
Improvements and bug fixes:
---------------------------
- Fix progress showing a wrong job name.
- Show console output if CMake generation fails.
- Fix cmake flags source overwriting CMAKE_PREFIX_PATHS environment variable.
- Add more suffixes to find libclang, thanks @jeeb.
- Fix docs generation after updating the theme.

Development announcement:
-------------------------
I decided to move away from using the "dev" branch. Now all the development
will be happening in the "master" branch. The releases will be sourced from
the "release" branch. See contribution guidelines for details.

