### PR TITLE
clang-cl + libclang fix

### DIFF
--- a/plugin/completion/lib_complete.py
+++ b/plugin/completion/lib_complete.py
@@ -12,6 +12,7 @@ import logging
 
 from .base_complete import BaseCompleter
 from .compiler_variant import LibClangCompilerVariant
+from .compiler_variant import LibClangClCompilerVariant
 from ..utils.clang_utils import ClangUtils
 from ..utils.subl.subl_bridge import SublBridge
 from ..utils.subl.row_col import ZeroIndexedRowCol
@@ -58,7 +59,11 @@ class Completer(BaseCompleter):
         super().__init__(settings, error_vis)
 
         # Create compiler options of specific variant of the compiler.
-        self.compiler_variant = LibClangCompilerVariant()
+        filename = path.splitext(path.basename(self.clang_binary))[0]
+        if filename.startswith('clang-cl'):
+            self.compiler_variant = LibClangClCompilerVariant()
+        else:
+            self.compiler_variant = LibClangCompilerVariant()
 
         # init tu related variables
         with Completer.rlock:


### PR DESCRIPTION
Compiler: clang-cl 10.0.0
Sublime: 3.2.2
Os: windows

I have encountered a bug with clang-cl toolset on windows.
ECC complains about an unknown flag `-x c` when trying to use clang-cl (libclang option is on)
I'm not sure if there is actually a way to fix this without modifying the code, or this is the best way to fix it, but I could fix it by adding a new compiler variant `LibClangClCompilerVariant`.

Please check out the PR