### PR TITLE
Fix passing view instead of id when clearing

### DIFF
--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -166,7 +166,8 @@ class CleanCmakeCommand(sublime_plugin.TextCommand):
             log.debug("Cleaning file: '%s'", cmake_file_path)
             del cmake_cache[file_path]
             del cmake_cache[cmake_file_path]
-            EasyClangComplete.view_config_manager.clear_for_view(self.view)
+            EasyClangComplete.view_config_manager.clear_for_view(
+                self.view.buffer_id())
             # Better safe than sorry. Cleanup!
             gc.collect()
             temp_proj_dir = CMakeFile.unique_folder_name(cmake_file_path)

--- a/easy_clang_complete.sublime-project
+++ b/easy_clang_complete.sublime-project
@@ -5,7 +5,7 @@
 			"file_regex": "^[ ]*File \"(...*?)\", line ([0-9]*)",
 			"name": "Anaconda Python Builder",
 			"selector": "source.python",
-			"shell_cmd": "\"python\" -u \"$file\""
+			"shell_cmd": "\"python3\" -u \"$file\""
 		}
 	],
 	"folders":

--- a/plugin/view_config/view_config_manager.py
+++ b/plugin/view_config/view_config_manager.py
@@ -106,6 +106,7 @@ class ViewConfigManager(object):
 
     def clear_for_view(self, v_id):
         """Clear config for a view id."""
+        assert isinstance(v_id, int), "View id should be an int."
         import gc
         log.debug("Trying to clear config for view: %s", v_id)
         with self.__rlock:


### PR DESCRIPTION
I was passing a view instead of the view id to the cleanup when manual cleanup command was involved. This is fixed this this PR.

