### PR TITLE
Add support for parsing non-unix paths in compilation database

### DIFF
--- a/plugin/flags_sources/compilation_db.py
+++ b/plugin/flags_sources/compilation_db.py
@@ -131,7 +131,9 @@ class CompilationDb(FlagsSource):
             base_path = path.realpath(entry['directory'])
         if 'command' in entry:
             import shlex
-            argument_list = shlex.split(entry['command'])
+            import os
+            argument_list = shlex.split(entry['command'],
+                                        posix=os.name == 'posix')
         elif 'arguments' in entry:
             argument_list = entry['arguments']
         else:


### PR DESCRIPTION
The parsing mode (posix vs non-posix) is selected automatically by checking if the OS in which ECC is currently running supports posix. Otherwise, `shlex` would not treat windows paths correctly (treating them as posix paths).

<details>
<summary>Here is an example for such a generated compilation database:</summary>
  
```json
[
{
  "directory": "C:/Users/Secret/AppData/Local/Temp/EasyClangComplete/cmake_builds/afeee6ac216a4e3cad7a41f5cf6958c1",
  "command": "C:\\PROGRA~1\\LLVM\\bin\\CLANG_~1.EXE    -target i686-pc-windows-gnu -g   -Wall -Wextra -Wpedantic -Werror -std=c++14 -o CMakeFiles\\space-age.dir\\space_age_test.cpp.obj -c C:\\Users\\Secret\\Exercism\\cpp\\space-age\\space_age_test.cpp",
  "file": "C:/Users/Secret/Exercism/cpp/space-age/space_age_test.cpp"
},
{
  "directory": "C:/Users/Secret/AppData/Local/Temp/EasyClangComplete/cmake_builds/afeee6ac216a4e3cad7a41f5cf6958c1",
  "command": "C:\\PROGRA~1\\LLVM\\bin\\CLANG_~1.EXE    -target i686-pc-windows-gnu -g   -Wall -Wextra -Wpedantic -Werror -std=c++14 -o CMakeFiles\\space-age.dir\\space_age.cpp.obj -c C:\\Users\\Secret\\Exercism\\cpp\\space-age\\space_age.cpp",
  "file": "C:/Users/Secret/Exercism/cpp/space-age/space_age.cpp"
},
{
  "directory": "C:/Users/Secret/AppData/Local/Temp/EasyClangComplete/cmake_builds/afeee6ac216a4e3cad7a41f5cf6958c1",
  "command": "C:\\PROGRA~1\\LLVM\\bin\\CLANG_~1.EXE    -target i686-pc-windows-gnu -g   -Wall -Wextra -Wpedantic -Werror -std=c++14 -o CMakeFiles\\space-age.dir\\test\\tests-main.cpp.obj -c C:\\Users\\Secret\\Exercism\\cpp\\space-age\\test\\tests-main.cpp",
  "file": "C:/Users/Secret/Exercism/cpp/space-age/test/tests-main.cpp"
}
]
```

</details>

By doing this, I assume that non-posix operating systems will generate compilation database that has non-posix paths (this was my case when running ECC on Windows).

Implementation note: I chose `os.name` over `platform.system()` based on [this](https://stackoverflow.com/a/11674977) and [this](https://stackoverflow.com/a/58071295).

Related to #712 