### PR TITLE
Skip to next iteration after flag without '=' is parsed

### DIFF
--- a/plugin/settings/settings_storage.py
+++ b/plugin/settings/settings_storage.py
@@ -303,6 +303,7 @@ class SettingsStorage:
             for flag in flags:
                 if '=' not in flag:
                     new_flags.append(flag)
+                    continue
                 split_flag = flag.split('=')
                 prefix = split_flag[0].strip()
                 value = split_flag[1].strip()


### PR DESCRIPTION
This PR fixes a bug where a flag within a flag (a nested flag) that doesn't contain a '=' character triggers an excpetion.

For example, see this `flag_sources` setting:

```json
    "flags_sources": [
      {
        "file": "CMakeLists.txt",
        "flags":
        [
            "-DCMAKE_CXX_COMPILER=clang++",
            "-DCMAKE_CXX_FLAGS=-target i686-pc-windows-gnu",
            "-G",
            "MinGW Makefiles"
        ]
      }
    ],
```

My PR fixes an exception triggered by ` "-DCMAKE_CXX_FLAGS=-target i686-pc-windows-gnu"`. I can verify that for this current example, along with eliminating the exception, the flags are also parsed correctly.

Related #712 