### PR TITLE
Add '-target' to the list of flags, so it won't be ignored

### DIFF
--- a/plugin/utils/flag.py
+++ b/plugin/utils/flag.py
@@ -306,6 +306,7 @@ class Flag:
         "-mthread-model",
         "-o",
         "-serialize-diagnostics",
+        "-target",
         "-T",
         "-Tbss",
         "-Tdata",


### PR DESCRIPTION
This way, I can pass '-target' flag to ECC cmake, and configure cmake to use a custom compiler.

For more information, see #712 