### PR TITLE
Clarify sublime project variables in documentation

### DIFF
--- a/EasyClangComplete.sublime-settings
+++ b/EasyClangComplete.sublime-settings
@@ -3,8 +3,12 @@
 
   // Every path variable in settings can contain wildcards (without the "").
   // Most commonly used:
-  //  - "$project_path"       <-- replaced by the full path to the project to
-  //                              which the currently opened view belongs.
+  //  - "$project_path"       <-- replaced by the full path to the project
+  //                              (NOT including the project folder itself)
+  //                               to which the currently opened view belongs.
+  //  - "$project_base_path"  <-- replaced by the full path to the project
+  //                              including the project folder. This is more
+  //                              commonly used than "$project_path" above.
   //  - "$project_name"       <-- replaced by the name of the current project.
   //  - "$clang_version"      <-- replaced by the numeric version of used clang.
   //  - "~"                   <-- replaced by the path to user home directory.
@@ -21,7 +25,7 @@
   "common_flags" : [
     // some example includes
     "-I/usr/include",
-    "-I$project_path/src",
+    "-I$project_base_path/src",
     // this is needed to include the correct headers for clang
     "-I/usr/lib/clang/$clang_version/include",
     // For simple projects, you can add a folder where your current file is
@@ -106,7 +110,7 @@
   "ignore_list": [
     "~/some_folder/*",
     "/some/absolute/file.ext",
-    "$project_path/some/project/path/*",
+    "$project_base_path/some/project/path/*",
   ],
 
   // Ignore all flags that match any of the following glob-style patterns. You

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -17,8 +17,8 @@
 Every path variable in settings can contain wildcards:
 
 - Any of [Sublime Text variables](https://www.sublimetext.com/docs/3/build_systems.html#variables). Most common ones:
-    + `$project_path` is replaced by the full path to the folder of the project
-      to which the currently opened view belongs.
+    + `$project_base_path` is replaced by the full path to the folder of the project
+      to which the currently opened view belongs, including the project folder name.
     + `$project_name` is replaced by the name of the current project.
 - `$clang_version` is replaced by the numeric version of used clang.
 - `~` is replaced by the path to user home directory.


### PR DESCRIPTION
Indirectly fixes issues seen by users that might find their way to https://github.com/niosus/EasyClangComplete/issues/290 through google.


Clarify in documentation that most users should be using `$project_base_path`, which points to the project directory, instead of , `$project_path`, which points to the directory HOLDING the project's directory
