### PR TITLE
Avoid closing wrong panels

### DIFF
--- a/plugin/utils/output_panel_handler.py
+++ b/plugin/utils/output_panel_handler.py
@@ -1,26 +1,28 @@
 """Handle everything related to the output panel."""
+import time
 import sublime
 
 
 class OutputPanelHandler():
     """Handle the output panel."""
-    _PANEL_TAG = "ECC"
+    PANEL_TAG = "ECC"
+    PANEL_NAME = "output." + PANEL_TAG
 
     @staticmethod
     def hide_panel():
         """Hide the output panel."""
         window = sublime.active_window()
-        window.run_command(
-            "hide_panel", {"panel": "output." + OutputPanelHandler._PANEL_TAG})
+        if window.active_panel() == OutputPanelHandler.PANEL_NAME:
+            window.run_command(
+                "hide_panel", {"panel": OutputPanelHandler.PANEL_NAME})
 
     @staticmethod
     def show(text):
         """Show the panel with text."""
-        import time
         window = sublime.active_window()
-        window.destroy_output_panel(OutputPanelHandler._PANEL_TAG)
+        window.destroy_output_panel(OutputPanelHandler.PANEL_TAG)
         panel_view = window.create_output_panel(
-            OutputPanelHandler._PANEL_TAG)
+            OutputPanelHandler.PANEL_TAG)
         while panel_view.is_loading():
             time.sleep(0.1)
         panel_view.run_command("select_all")
@@ -34,5 +36,5 @@ class OutputPanelHandler():
         panel_view.show(panel_view.size())
 
         window.run_command(
-            "show_panel", {"panel": "output." + OutputPanelHandler._PANEL_TAG})
+            "show_panel", {"panel": OutputPanelHandler.PANEL_NAME})
         panel_view.set_read_only(True)

--- a/tests/test_bazel.py
+++ b/tests/test_bazel.py
@@ -98,7 +98,7 @@ class TestBazelDbGeneration(object):
         future = MockFuture(output)
         Bazel.compdb_generated(future)
         window = sublime.active_window()
-        panel_view = window.find_output_panel(OutputPanelHandler._PANEL_TAG)
+        panel_view = window.find_output_panel(OutputPanelHandler.PANEL_TAG)
         panel_content = panel_view.substr(sublime.Region(0, panel_view.size()))
         split_output = output.split('\n')
         split_panel_content = panel_content.split('\n')


### PR DESCRIPTION
We now will check the name of the active panel before closing it.

This should close #722 