### PR TITLE
Prepare v.6.5.1

### DIFF
--- a/messages.json
+++ b/messages.json
@@ -28,5 +28,6 @@
   "6.4.3": "messages/6.4.3.rst",
   "6.4.4": "messages/6.4.4.rst",
   "6.4.5": "messages/6.4.5.rst",
-  "6.5.0": "messages/6.5.0.rst"
+  "6.5.0": "messages/6.5.0.rst",
+  "6.5.1": "messages/6.5.1.rst"
 }

--- a/messages/6.5.1.rst
+++ b/messages/6.5.1.rst
@@ -1,0 +1,25 @@
+Version 6.5.1
+=============
+
+Improvements and bug fixes:
+---------------------------
+- ECC now plays well with other panels being open and won't force
+  close them in case CMake has failed.
+
+Huuuge thanks to my GitHub Sponsors! You're amazing! 🙏
+-------------------------------------------------------
+- @vaporstack
+- @Andreasdahlberg
+
+Join them on GitHub Sponsors and support the development!
+https://github.com/sponsors/niosus
+
+Reach out! 😉
+-------------
+
+Tell me how YOU use the plugin!
+- PM me on reddit: @soinus
+- Tweet at me on twitter: @igor_niosus 🐦
+
+Other means of support here:
+https://github.com/niosus/EasyClangComplete#support-it


### PR DESCRIPTION
Improvements and bug fixes:
---------------------------
- ECC now plays well with other panels being open and won't force
  close them in case CMake has failed.

