### PR TITLE
fix(plugin/error_vis/popups.py): small fix to parse doxygen special comments properly

### DIFF
--- a/plugin/error_vis/popups.py
+++ b/plugin/error_vis/popups.py
@@ -480,7 +480,7 @@ class Popup:
 
         import string
         lines = raw_comment.split('\n')
-        chars_to_strip = '/' + '*' + string.whitespace
+        chars_to_strip = '/' + '*' + '!' + string.whitespace
         lines = [line.lstrip(chars_to_strip) for line in lines]
         lines = pop_prepending_empty_lines(lines)
         clean_lines = []


### PR DESCRIPTION
This tiny change solves issue #728 , in which doxygen special comments use the '!' char.
Instead of just stripping away leading '/' and '*' chars from the start of each comment line, now '!' chars are also stripped away.