### PR TITLE
Add support for replacement of vscode variables

### DIFF
--- a/plugin/flags_sources/c_cpp_properties.py
+++ b/plugin/flags_sources/c_cpp_properties.py
@@ -97,6 +97,11 @@ class CCppProperties(FlagsSource):
                 include_paths = content["configurations"][0]["includePath"]
             except Exception:
                 include_paths = []
+
+            # VSCode variable for current working directory
+            vsc_ws = '${workspaceFolder}'
+            # Attempt to replace VSCode variables if any
+            includes = [i.replace(vsc_ws, '.') for i in include_paths]
             includes = [path.expandvars(i) for i in include_paths]
             includes = ["-I{}".format(include) for include in includes]
             return includes

--- a/tests/c_cpp_properties_files/vscode_vars/c_cpp_properties.json
+++ b/tests/c_cpp_properties_files/vscode_vars/c_cpp_properties.json
@@ -1,0 +1,17 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "intelliSenseMode": "msvc-x64",
+            "includePath": [ "${workspaceFolder}/source" ],
+            "defines": [ ],
+            "compileCommands": "/path/to/compile_commands.json",
+            "browse": {
+                "path": [ "${workspaceRoot}" ],
+                "limitSymbolsToIncludedHeaders": true,
+                "databaseFilename": ""
+            }
+        }
+    ],
+    "version": 2
+}

--- a/tests/test_c_cpp_properties.py
+++ b/tests/test_c_cpp_properties.py
@@ -50,6 +50,19 @@ class TestCCppProperties(TestCase):
         print(scope)
         self.assertEqual(expected, db.get_flags(search_scope=scope))
 
+    def test_expand_vscode_variables(self):
+        """Test vscode variables are expanded."""
+        include_prefixes = ['-I']
+        db = CCppProperties(include_prefixes)
+
+        expected = [Flag('-I', path.normpath('/source'))]
+        path_to_db = path.join(path.dirname(__file__),
+                               'c_cpp_properties_files',
+                               'vscode_vars')
+        scope = SearchScope(from_folder=path_to_db)
+        print(scope)
+        self.assertEqual(expected, db.get_flags(search_scope=scope))
+
     def test_no_db_in_folder(self):
         """Test if no json is found."""
         include_prefixes = ['-I']


### PR DESCRIPTION
Convert Variables such as ${workspaceFolder} so
they can be understood by LLVM

Close #741 

