### PR TITLE
always show info popup on command

### DIFF
--- a/EasyClangComplete.py
+++ b/EasyClangComplete.py
@@ -236,7 +236,7 @@ class EccShowPopupInfoCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         """Run show popup info command."""
         position = self.view.sel()[0].begin()
-        EasyClangComplete.begin_show_info_job(self.view, position)
+        EasyClangComplete.begin_show_info_job(self.view, position, True)
 
 
 class EasyClangComplete(sublime_plugin.EventListener):
@@ -548,7 +548,7 @@ class EasyClangComplete(sublime_plugin.EventListener):
         EasyClangComplete.begin_show_info_job(view, point)
 
     @staticmethod
-    def begin_show_info_job(view, position):
+    def begin_show_info_job(view, position, force=False):
         """Start thead job to show popup info.
 
         Triggers showing popup with additional information about about
@@ -560,7 +560,7 @@ class EasyClangComplete(sublime_plugin.EventListener):
         settings = EasyClangComplete.settings_manager.settings_for_view(view)
         if not SublBridge.has_valid_syntax(view, settings):
             return
-        if not settings.show_type_info:
+        if not force and not settings.show_type_info:
             return
 
         tooltip_request = ActionRequest(view, position)


### PR DESCRIPTION
The setting show_type_info disables the info popup upon: (1) hovering, (2) show_type_info-command. 
IMHO, this setting should only affect the hovering, and not the show_type_info-command. When a user issues this command, he/she will always want to see the popup, otherwise he/she would not have issued the command.

