### PR TITLE
Introduce a more thorough clean method

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -18,8 +18,8 @@
         "command": "ecc_show_all_errors"
     },
     {
-        "caption": "ECC: Clean current CMake cache",
-        "command": "clean_cmake"
+        "caption": "ECC: Clean internal cache",
+        "command": "clean_internal_cache"
     },
     {
         "caption": "ECC: Show popup info",

--- a/plugin/flags_sources/cmake_file.py
+++ b/plugin/flags_sources/cmake_file.py
@@ -143,6 +143,15 @@ class CMakeFile(FlagsSource):
         return flags
 
     @staticmethod
+    def get_cache_dir():
+        """Get all builds folder name.
+
+        Returns:
+            str: Path to a temp folder where all cache is stored.
+        """
+        return File.get_temp_dir('cmake_builds')
+
+    @staticmethod
     def unique_folder_name(cmake_path):
         """Get unique build folder name.
 
@@ -152,8 +161,8 @@ class CMakeFile(FlagsSource):
         Returns:
             str: Path to a unique temp folder.
         """
-        return File.get_temp_dir('cmake_builds',
-                                 Tools.get_unique_str(cmake_path))
+        return File.get_temp_dir('cmake_builds', 
+            Tools.get_unique_str(cmake_path))
 
     @staticmethod
     def __prepend_prefix_paths(prefix_paths):

--- a/plugin/utils/tools.py
+++ b/plugin/utils/tools.py
@@ -64,9 +64,9 @@ class Tools:
             output_text = e.output.decode("utf-8")
             _log.debug("Command finished with code: %s", e.returncode)
             _log.debug("Command output: \n%s", output_text)
-        except OSError:
+        except OSError as e:
             _log.debug(
-                "Executable file not found executing: {}".format(command))
+                "Error while executing command: %s", e.strerror)
         return output_text
 
     @staticmethod

--- a/plugin/view_config/view_config_manager.py
+++ b/plugin/view_config/view_config_manager.py
@@ -104,6 +104,14 @@ class ViewConfigManager(object):
             log.error("Traceback: %s", tb)
             return None
 
+    def clear(self):
+        """Clear all cache."""
+        import gc
+        log.debug("Trying to clean all view cache")
+        with self.__rlock:
+            self.__cache.clear()
+            gc.collect()  # Explicitly collect garbage.
+
     def clear_for_view(self, v_id):
         """Clear config for a view id."""
         assert isinstance(v_id, int), "View id should be an int."


### PR DESCRIPTION
Before we would only clean cmake cache and that operation would regularly fail due to a bug in the code. This PR allows to clear all internal cache including the temporary folders generated before.

