### PR TITLE
Add typing to the list of dependencies.

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -7,7 +7,8 @@
             "python-jinja2",
             "markupsafe",
             "pymdownx",
-            "pyyaml"
+            "pyyaml",
+            "typing"
         ]
     }
 }


### PR DESCRIPTION
Hello,

In recent versions of Sublime Text EasyClangComplete shows an error in the console saying it can't find the typing module. This makes Sublime Text unusable as whenever you press " or < to type an include it can't invoke the plugin so it just ignores your input. Adding the typing module to the list of dependencies resolves this issue.

(I'm aware most people have probably moved to Clang-LSP but unfortunately I have to support an old project that predate CMake and that Bear is slow to build a compilation database for so until our CMakeified development branch becomes stable I'm still using EasyClangComplete).